### PR TITLE
web: extend build with data needed by explain command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ test: ## Run the build system unit tests.
 	cd build && bun test
 
 .PHONY: build
-build: ## Build the schema catalog (FORCE_BUILD=1 forces, BUILD_SUMMARY=<path> writes a summary, RUN_TO_COMPLETION=1 reports source failures instead of aborting).
-	cd build && bun src/main.ts build $(if $(FORCE_BUILD),--force) $(if $(BUILD_SUMMARY),--summary $(BUILD_SUMMARY)) $(if $(RUN_TO_COMPLETION),--run-to-completion)
+build: ## Build the schema catalog (FORCE_BUILD=1 forces, BUILD_SUMMARY=<path> writes a summary, RUN_TO_COMPLETION=1 reports failures, CONCURRENT=<n> sets parallelism).
+	cd build && bun src/main.ts build $(if $(FORCE_BUILD),--force) $(if $(BUILD_SUMMARY),--summary $(BUILD_SUMMARY)) $(if $(RUN_TO_COMPLETION),--run-to-completion) $(if $(CONCURRENT),--concurrent $(CONCURRENT))
 
 ##@ Web
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ available tools and per-client setup instructions.
 | OpenReports | [v0.2.1](build/history/openreports.json) | 2 | 2026-07-07 |
 | Secrets Store CSI Driver | [v1.6.0](build/history/secrets-store-csi-driver.json) | 4 | 2026-07-07 |
 | Sigstore Policy Controller | [v0.15.1](build/history/sigstore-policy-controller.json) | 3 | 2026-07-07 |
-| SPIRE Controller Manager | [v0.6.6](build/history/spire-controller-manager.json) | 4 | 2026-07-07 |
 | Trust Manager | [v0.24.0](build/history/trust-manager.json) | 2 | 2026-07-07 |
 | Upbound AWS Provider | [v2.6.0](build/history/provider-upjet-aws.json) | 2364 | 2026-07-07 |
 | Upbound Azure Provider | [v2.6.0](build/history/provider-upjet-azure.json) | 1789 | 2026-07-07 |
@@ -119,6 +118,7 @@ available tools and per-client setup instructions.
 | Longhorn | [v1.12.0](build/history/longhorn.json) | 23 | 2026-07-07 |
 | Network Policy API | [v0.2.0](build/history/network-policy-api.json) | 1 | 2026-07-07 |
 | Rook | [v1.20.1](build/history/rook.json) | 21 | 2026-07-07 |
+| SPIRE Controller Manager | [v0.6.6](build/history/spire-controller-manager.json) | 4 | 2026-07-07 |
 | Submariner | [v0.24.0](build/history/submariner.json) | 9 | 2026-07-07 |
 | Submariner Operator | [v0.24.0](build/history/submariner-operator.json) | 3 | 2026-07-07 |
 | Tailscale | [v1.98.8](build/history/tailscale.json) | 7 | 2026-07-07 |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ available tools and per-client setup instructions.
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| Kubernetes | [v1.36.2](build/history/kubernetes.json) | 101 | 2026-07-05 |
-| OpenShift | [v4.20](build/history/openshift.json) | 133 | 2026-07-05 |
+| Kubernetes | [v1.36.2](build/history/kubernetes.json) | 101 | 2026-07-07 |
+| OpenShift | [v4.20](build/history/openshift.json) | 133 | 2026-07-07 |
 
 ### Provisioning
 

--- a/README.md
+++ b/README.md
@@ -62,139 +62,139 @@ available tools and per-client setup instructions.
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| 1Password Operator | [v1.12.0](build/history/onepassword-operator.json) | 1 | 2026-07-06 |
+| 1Password Operator | [v1.12.0](build/history/onepassword-operator.json) | 1 | 2026-07-07 |
 | AWS ACM Controller | [v1.4.2](build/history/ack-acm.json) | 1 | 2026-07-07 |
-| AWS API Gateway v2 Controller | [v1.3.2](build/history/ack-apigatewayv2.json) | 9 | 2026-07-05 |
-| AWS DynamoDB Controller | [v1.9.1](build/history/ack-dynamodb.json) | 3 | 2026-07-05 |
-| AWS EC2 Controller | [v1.17.0](build/history/ack-ec2.json) | 20 | 2026-07-05 |
-| AWS ECR Controller | [v1.6.2](build/history/ack-ecr.json) | 3 | 2026-07-05 |
-| AWS EFS Controller | [v1.4.0](build/history/ack-efs.json) | 3 | 2026-07-05 |
-| AWS EKS Controller | [v1.16.1](build/history/ack-eks.json) | 8 | 2026-07-05 |
-| AWS ElastiCache Controller | [v1.5.1](build/history/ack-elasticache.json) | 9 | 2026-07-05 |
-| AWS IAM Controller | [v1.7.2](build/history/ack-iam.json) | 7 | 2026-07-05 |
-| AWS Kinesis Controller | [v1.3.1](build/history/ack-kinesis.json) | 1 | 2026-07-05 |
-| AWS KMS Controller | [v1.3.2](build/history/ack-kms.json) | 3 | 2026-07-05 |
-| AWS Lambda Controller | [v1.14.0](build/history/ack-lambda.json) | 7 | 2026-07-05 |
-| AWS MemoryDB Controller | [v1.4.0](build/history/ack-memorydb.json) | 6 | 2026-07-05 |
-| AWS RDS Controller | [v1.10.0](build/history/ack-rds.json) | 10 | 2026-07-05 |
-| AWS Route 53 Controller | [v1.4.3](build/history/ack-route53.json) | 3 | 2026-07-05 |
-| AWS S3 Controller | [v1.7.1](build/history/ack-s3.json) | 1 | 2026-07-05 |
-| AWS SageMaker Controller | [v1.8.1](build/history/ack-sagemaker.json) | 26 | 2026-07-05 |
-| AWS Secrets Manager Controller | [v1.3.1](build/history/ack-secretsmanager.json) | 1 | 2026-07-05 |
-| AWS SNS Controller | [v1.7.0](build/history/ack-sns.json) | 4 | 2026-07-05 |
-| AWS SQS Controller | [v1.5.3](build/history/ack-sqs.json) | 1 | 2026-07-05 |
-| Azure Service Operator | [v2.20.0](build/history/azure-service-operator.json) | 1324 | 2026-07-05 |
+| AWS API Gateway v2 Controller | [v1.3.2](build/history/ack-apigatewayv2.json) | 9 | 2026-07-07 |
+| AWS DynamoDB Controller | [v1.9.1](build/history/ack-dynamodb.json) | 3 | 2026-07-07 |
+| AWS EC2 Controller | [v1.17.0](build/history/ack-ec2.json) | 20 | 2026-07-07 |
+| AWS ECR Controller | [v1.6.2](build/history/ack-ecr.json) | 3 | 2026-07-07 |
+| AWS EFS Controller | [v1.4.0](build/history/ack-efs.json) | 3 | 2026-07-07 |
+| AWS EKS Controller | [v1.16.1](build/history/ack-eks.json) | 8 | 2026-07-07 |
+| AWS ElastiCache Controller | [v1.5.1](build/history/ack-elasticache.json) | 9 | 2026-07-07 |
+| AWS IAM Controller | [v1.7.2](build/history/ack-iam.json) | 7 | 2026-07-07 |
+| AWS Kinesis Controller | [v1.3.1](build/history/ack-kinesis.json) | 1 | 2026-07-07 |
+| AWS KMS Controller | [v1.3.2](build/history/ack-kms.json) | 3 | 2026-07-07 |
+| AWS Lambda Controller | [v1.14.0](build/history/ack-lambda.json) | 7 | 2026-07-07 |
+| AWS MemoryDB Controller | [v1.4.0](build/history/ack-memorydb.json) | 6 | 2026-07-07 |
+| AWS RDS Controller | [v1.10.0](build/history/ack-rds.json) | 10 | 2026-07-07 |
+| AWS Route 53 Controller | [v1.4.3](build/history/ack-route53.json) | 3 | 2026-07-07 |
+| AWS S3 Controller | [v1.7.1](build/history/ack-s3.json) | 1 | 2026-07-07 |
+| AWS SageMaker Controller | [v1.8.1](build/history/ack-sagemaker.json) | 26 | 2026-07-07 |
+| AWS Secrets Manager Controller | [v1.3.1](build/history/ack-secretsmanager.json) | 1 | 2026-07-07 |
+| AWS SNS Controller | [v1.7.0](build/history/ack-sns.json) | 4 | 2026-07-07 |
+| AWS SQS Controller | [v1.5.3](build/history/ack-sqs.json) | 1 | 2026-07-07 |
+| Azure Service Operator | [v2.20.0](build/history/azure-service-operator.json) | 1324 | 2026-07-07 |
 | Capsule | [v0.13.9](build/history/capsule.json) | 12 | 2026-07-07 |
-| Cert Manager | [v1.20.3](build/history/cert-manager.json) | 6 | 2026-07-05 |
-| Cluster API | [v1.13.3](build/history/cluster-api.json) | 36 | 2026-07-05 |
-| Cluster API Add-on Provider Helm | [v0.6.4](build/history/cluster-api-addon-provider-helm.json) | 2 | 2026-07-05 |
-| Cluster API OpenStack | [v0.14.6](build/history/cluster-api-provider-openstack.json) | 7 | 2026-07-06 |
-| Cluster API Operator | [v0.27.0](build/history/cluster-api-operator.json) | 7 | 2026-07-05 |
-| Cluster API vSphere | [v1.16.1](build/history/cluster-api-provider-vsphere.json) | 16 | 2026-07-06 |
-| Crossplane | [v2.3.3](build/history/crossplane.json) | 25 | 2026-07-05 |
-| External Secrets | [v2.7.0](build/history/external-secrets.json) | 28 | 2026-07-05 |
+| Cert Manager | [v1.20.3](build/history/cert-manager.json) | 6 | 2026-07-07 |
+| Cluster API | [v1.13.3](build/history/cluster-api.json) | 36 | 2026-07-07 |
+| Cluster API Add-on Provider Helm | [v0.6.4](build/history/cluster-api-addon-provider-helm.json) | 2 | 2026-07-07 |
+| Cluster API OpenStack | [v0.14.6](build/history/cluster-api-provider-openstack.json) | 7 | 2026-07-07 |
+| Cluster API Operator | [v0.27.0](build/history/cluster-api-operator.json) | 7 | 2026-07-07 |
+| Cluster API vSphere | [v1.16.1](build/history/cluster-api-provider-vsphere.json) | 16 | 2026-07-07 |
+| Crossplane | [v2.3.3](build/history/crossplane.json) | 25 | 2026-07-07 |
+| External Secrets | [v2.7.0](build/history/external-secrets.json) | 28 | 2026-07-07 |
 | GCP Config Connector | [v1.153.0](build/history/config-connector.json) | 578 | 2026-07-07 |
-| kro | [v0.9.2](build/history/kro.json) | 2 | 2026-07-05 |
-| Kubewarden | [v1.36.0](build/history/kubewarden.json) | 8 | 2026-07-05 |
-| Kyverno | [v1.18.1](build/history/kyverno.json) | 47 | 2026-07-05 |
-| OPA Gatekeeper | [v3.22.2](build/history/gatekeeper.json) | 27 | 2026-07-05 |
-| OpenReports | [v0.2.1](build/history/openreports.json) | 2 | 2026-07-05 |
-| Secrets Store CSI Driver | [v1.6.0](build/history/secrets-store-csi-driver.json) | 4 | 2026-07-05 |
-| Sigstore Policy Controller | [v0.15.1](build/history/sigstore-policy-controller.json) | 3 | 2026-07-06 |
-| Trust Manager | [v0.24.0](build/history/trust-manager.json) | 2 | 2026-07-05 |
-| Upbound AWS Provider | [v2.6.0](build/history/provider-upjet-aws.json) | 2364 | 2026-07-05 |
-| Upbound Azure Provider | [v2.6.0](build/history/provider-upjet-azure.json) | 1789 | 2026-07-05 |
-| Upbound GCP Provider | [v2.6.0](build/history/provider-upjet-gcp.json) | 1018 | 2026-07-05 |
+| kro | [v0.9.2](build/history/kro.json) | 2 | 2026-07-07 |
+| Kubewarden | [v1.36.0](build/history/kubewarden.json) | 8 | 2026-07-07 |
+| Kyverno | [v1.18.1](build/history/kyverno.json) | 47 | 2026-07-07 |
+| OPA Gatekeeper | [v3.22.2](build/history/gatekeeper.json) | 27 | 2026-07-07 |
+| OpenReports | [v0.2.1](build/history/openreports.json) | 2 | 2026-07-07 |
+| Secrets Store CSI Driver | [v1.6.0](build/history/secrets-store-csi-driver.json) | 4 | 2026-07-07 |
+| Sigstore Policy Controller | [v0.15.1](build/history/sigstore-policy-controller.json) | 3 | 2026-07-07 |
+| SPIRE Controller Manager | [v0.6.6](build/history/spire-controller-manager.json) | 4 | 2026-07-07 |
+| Trust Manager | [v0.24.0](build/history/trust-manager.json) | 2 | 2026-07-07 |
+| Upbound AWS Provider | [v2.6.0](build/history/provider-upjet-aws.json) | 2364 | 2026-07-07 |
+| Upbound Azure Provider | [v2.6.0](build/history/provider-upjet-azure.json) | 1789 | 2026-07-07 |
+| Upbound GCP Provider | [v2.6.0](build/history/provider-upjet-gcp.json) | 1018 | 2026-07-07 |
 
 ### Runtime
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| Antrea | [v2.6.2](build/history/antrea.json) | 20 | 2026-07-05 |
-| Calico | [v3.32.1](build/history/calico.json) | 22 | 2026-07-05 |
-| Cilium | [v1.19.5](build/history/cilium.json) | 29 | 2026-07-05 |
-| Container Object Storage Interface | [v0.2.2](build/history/cosi.json) | 5 | 2026-07-05 |
-| Kube-OVN | [v1.16.2](build/history/kube-ovn.json) | 24 | 2026-07-05 |
-| Longhorn | [v1.12.0](build/history/longhorn.json) | 23 | 2026-07-05 |
-| Network Policy API | [v0.2.0](build/history/network-policy-api.json) | 1 | 2026-07-05 |
-| Rook | [v1.20.1](build/history/rook.json) | 21 | 2026-07-05 |
-| SPIRE Controller Manager | [v0.6.6](build/history/spire-controller-manager.json) | 4 | 2026-07-05 |
-| Submariner | [v0.24.0](build/history/submariner.json) | 9 | 2026-07-05 |
-| Submariner Operator | [v0.24.0](build/history/submariner-operator.json) | 3 | 2026-07-05 |
-| Tailscale | [v1.98.8](build/history/tailscale.json) | 7 | 2026-07-06 |
-| Tigera Operator | [v3.32.1](build/history/tigera-operator.json) | 9 | 2026-07-05 |
-| Velero | [v1.18.2](build/history/velero.json) | 11 | 2026-07-05 |
+| Antrea | [v2.6.2](build/history/antrea.json) | 20 | 2026-07-07 |
+| Calico | [v3.32.1](build/history/calico.json) | 22 | 2026-07-07 |
+| Cilium | [v1.19.5](build/history/cilium.json) | 29 | 2026-07-07 |
+| Container Object Storage Interface | [v0.2.2](build/history/cosi.json) | 5 | 2026-07-07 |
+| Kube-OVN | [v1.16.2](build/history/kube-ovn.json) | 24 | 2026-07-07 |
+| Longhorn | [v1.12.0](build/history/longhorn.json) | 23 | 2026-07-07 |
+| Network Policy API | [v0.2.0](build/history/network-policy-api.json) | 1 | 2026-07-07 |
+| Rook | [v1.20.1](build/history/rook.json) | 21 | 2026-07-07 |
+| Submariner | [v0.24.0](build/history/submariner.json) | 9 | 2026-07-07 |
+| Submariner Operator | [v0.24.0](build/history/submariner-operator.json) | 3 | 2026-07-07 |
+| Tailscale | [v1.98.8](build/history/tailscale.json) | 7 | 2026-07-07 |
+| Tigera Operator | [v3.32.1](build/history/tigera-operator.json) | 9 | 2026-07-07 |
+| Velero | [v1.18.2](build/history/velero.json) | 11 | 2026-07-07 |
 
 ### Orchestration & Management
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| AWS Load Balancer Controller | [v3.4.0](build/history/aws-load-balancer-controller.json) | 8 | 2026-07-05 |
-| Envoy Gateway | [v1.8.2](build/history/envoy-gateway.json) | 8 | 2026-07-05 |
-| ExternalDNS | [v0.21.0](build/history/external-dns.json) | 1 | 2026-07-05 |
+| AWS Load Balancer Controller | [v3.4.0](build/history/aws-load-balancer-controller.json) | 8 | 2026-07-07 |
+| Envoy Gateway | [v1.8.2](build/history/envoy-gateway.json) | 8 | 2026-07-07 |
+| ExternalDNS | [v0.21.0](build/history/external-dns.json) | 1 | 2026-07-07 |
 | Gateway API | [v1.6.0](build/history/gateway-api.json) | 21 | 2026-07-07 |
-| Istio | [1.30.2](build/history/istio.json) | 33 | 2026-07-05 |
-| JobSet | [v0.12.0](build/history/jobset.json) | 1 | 2026-07-05 |
-| Karpenter | [v1.13.0](build/history/karpenter.json) | 3 | 2026-07-05 |
-| Karpenter AWS | [v1.13.0](build/history/karpenter-aws.json) | 1 | 2026-07-05 |
-| Karpenter Azure | [v1.13.1](build/history/karpenter-azure.json) | 2 | 2026-07-05 |
-| Karpenter Cluster API | [v0.2.0](build/history/karpenter-provider-cluster-api.json) | 1 | 2026-07-05 |
-| Karpenter IBM Cloud | [v1.0.4](build/history/karpenter-provider-ibm-cloud.json) | 1 | 2026-07-05 |
-| KEDA | [v2.20.1](build/history/keda.json) | 6 | 2026-07-05 |
-| kgateway | [v2.3.5](build/history/kgateway.json) | 8 | 2026-07-06 |
-| kjob | [v0.1.0](build/history/kjob.json) | 5 | 2026-07-05 |
-| KubeEdge | [v1.23.0](build/history/kubeedge.json) | 18 | 2026-07-05 |
-| Kueue | [v0.18.2](build/history/kueue.json) | 22 | 2026-07-05 |
-| KWOK | [v0.8.0](build/history/kwok.json) | 12 | 2026-07-05 |
-| LeaderWorkerSet | [v0.9.0](build/history/lws.json) | 2 | 2026-07-05 |
-| NFD NodeResourceTopology | [v0.18.3](build/history/node-feature-discovery-nrt.json) | 2 | 2026-07-05 |
-| Node Feature Discovery | [v0.18.3](build/history/node-feature-discovery.json) | 3 | 2026-07-05 |
-| Vertical Pod Autoscaler | [1.7.0](build/history/vertical-pod-autoscaler.json) | 4 | 2026-07-06 |
-| Volcano | [v1.15.0](build/history/volcano.json) | 9 | 2026-07-05 |
-| Volcano JobFlow | [v1.15.0](build/history/volcano-jobflow.json) | 2 | 2026-07-05 |
+| Istio | [1.30.2](build/history/istio.json) | 33 | 2026-07-07 |
+| JobSet | [v0.12.0](build/history/jobset.json) | 1 | 2026-07-07 |
+| Karpenter | [v1.13.0](build/history/karpenter.json) | 3 | 2026-07-07 |
+| Karpenter AWS | [v1.13.0](build/history/karpenter-aws.json) | 1 | 2026-07-07 |
+| Karpenter Azure | [v1.13.1](build/history/karpenter-azure.json) | 2 | 2026-07-07 |
+| Karpenter Cluster API | [v0.2.0](build/history/karpenter-provider-cluster-api.json) | 1 | 2026-07-07 |
+| Karpenter IBM Cloud | [v1.0.4](build/history/karpenter-provider-ibm-cloud.json) | 1 | 2026-07-07 |
+| KEDA | [v2.20.1](build/history/keda.json) | 6 | 2026-07-07 |
+| kgateway | [v2.3.5](build/history/kgateway.json) | 8 | 2026-07-07 |
+| kjob | [v0.1.0](build/history/kjob.json) | 5 | 2026-07-07 |
+| KubeEdge | [v1.23.0](build/history/kubeedge.json) | 18 | 2026-07-07 |
+| Kueue | [v0.18.2](build/history/kueue.json) | 22 | 2026-07-07 |
+| KWOK | [v0.8.0](build/history/kwok.json) | 12 | 2026-07-07 |
+| LeaderWorkerSet | [v0.9.0](build/history/lws.json) | 2 | 2026-07-07 |
+| NFD NodeResourceTopology | [v0.18.3](build/history/node-feature-discovery-nrt.json) | 2 | 2026-07-07 |
+| Node Feature Discovery | [v0.18.3](build/history/node-feature-discovery.json) | 3 | 2026-07-07 |
+| Vertical Pod Autoscaler | [1.7.0](build/history/vertical-pod-autoscaler.json) | 4 | 2026-07-07 |
+| Volcano | [v1.15.0](build/history/volcano.json) | 9 | 2026-07-07 |
+| Volcano JobFlow | [v1.15.0](build/history/volcano-jobflow.json) | 2 | 2026-07-07 |
 
 ### App Definition & Development
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| Actions Runner Controller | [0.14.2](build/history/actions-runner-controller.json) | 9 | 2026-07-06 |
-| Argo CD | [v3.4.4](build/history/argo-cd.json) | 3 | 2026-07-05 |
-| Argo Events | [v1.9.10](build/history/argo-events.json) | 3 | 2026-07-05 |
-| Argo Rollouts | [v1.9.0](build/history/argo-rollouts.json) | 5 | 2026-07-05 |
+| Actions Runner Controller | [0.14.2](build/history/actions-runner-controller.json) | 9 | 2026-07-07 |
+| Argo CD | [v3.4.4](build/history/argo-cd.json) | 3 | 2026-07-07 |
+| Argo Events | [v1.9.10](build/history/argo-events.json) | 3 | 2026-07-07 |
+| Argo Rollouts | [v1.9.0](build/history/argo-rollouts.json) | 5 | 2026-07-07 |
 | Argo Workflows | [v4.0.7](build/history/argo-workflows.json) | 8 | 2026-07-07 |
-| CloudNativePG | [v1.30.0](build/history/cloudnative-pg.json) | 11 | 2026-07-05 |
-| Dapr | [v1.18.1](build/history/dapr.json) | 8 | 2026-07-05 |
-| Flagger | [v1.43.0](build/history/flagger.json) | 3 | 2026-07-05 |
+| CloudNativePG | [v1.30.0](build/history/cloudnative-pg.json) | 11 | 2026-07-07 |
+| Dapr | [v1.18.1](build/history/dapr.json) | 8 | 2026-07-07 |
+| Flagger | [v1.43.0](build/history/flagger.json) | 3 | 2026-07-07 |
 | Flux | [v2.9.1](build/history/flux.json) | 15 | 2026-07-07 |
 | Flux Operator | [v0.54.0](build/history/flux-operator.json) | 4 | 2026-07-07 |
-| Kargo | [v1.10.8](build/history/kargo.json) | 9 | 2026-07-06 |
-| Knative Eventing | [v1.22.2](build/history/knative-eventing.json) | 20 | 2026-07-06 |
-| Knative Serving | [v1.22.1](build/history/knative-serving.json) | 12 | 2026-07-06 |
-| KServe | [v0.19.0](build/history/kserve.json) | 6 | 2026-07-05 |
-| KServe LLM | [v0.19.0](build/history/kserve-llmisvc.json) | 4 | 2026-07-05 |
-| MariaDB Operator | [26.6.0](build/history/mariadb-operator.json) | 12 | 2026-07-06 |
-| NATS | [v0.23.0](build/history/nats.json) | 8 | 2026-07-05 |
-| OpenFeature Operator | [v0.9.2](build/history/open-feature-operator.json) | 9 | 2026-07-05 |
+| Kargo | [v1.10.8](build/history/kargo.json) | 9 | 2026-07-07 |
+| Knative Eventing | [v1.22.2](build/history/knative-eventing.json) | 20 | 2026-07-07 |
+| Knative Serving | [v1.22.1](build/history/knative-serving.json) | 12 | 2026-07-07 |
+| KServe | [v0.19.0](build/history/kserve.json) | 6 | 2026-07-07 |
+| KServe LLM | [v0.19.0](build/history/kserve-llmisvc.json) | 4 | 2026-07-07 |
+| MariaDB Operator | [26.6.0](build/history/mariadb-operator.json) | 12 | 2026-07-07 |
+| NATS | [v0.23.0](build/history/nats.json) | 8 | 2026-07-07 |
+| OpenFeature Operator | [v0.9.2](build/history/open-feature-operator.json) | 9 | 2026-07-07 |
 | RabbitMQ Cluster Operator | [v2.22.1](build/history/rabbitmq-cluster-operator.json) | 1 | 2026-07-07 |
-| Redis Operator | [v0.25.0](build/history/redis-operator.json) | 4 | 2026-07-05 |
-| ScyllaDB Operator | [v1.21.0](build/history/scylla-operator.json) | 11 | 2026-07-05 |
-| Strimzi | [0.51.0](build/history/strimzi.json) | 24 | 2026-07-05 |
-| Tekton Pipeline | [v1.14.0](build/history/tekton-pipeline.json) | 14 | 2026-07-05 |
-| Vitess Operator | [v2.17.0](build/history/vitess-operator.json) | 8 | 2026-07-05 |
+| Redis Operator | [v0.25.0](build/history/redis-operator.json) | 4 | 2026-07-07 |
+| ScyllaDB Operator | [v1.21.0](build/history/scylla-operator.json) | 11 | 2026-07-07 |
+| Strimzi | [0.51.0](build/history/strimzi.json) | 24 | 2026-07-07 |
+| Tekton Pipeline | [v1.14.0](build/history/tekton-pipeline.json) | 14 | 2026-07-07 |
+| Vitess Operator | [v2.17.0](build/history/vitess-operator.json) | 8 | 2026-07-07 |
 
 ### Observability & Analysis
 
 | Project | Version | Schemas | Updated |
 | --- | --- | --- | --- |
-| Elastic Cloud | [v3.4.1](build/history/eck-operator.json) | 19 | 2026-07-06 |
-| Fluent Operator | [v3.9.0](build/history/fluent-operator.json) | 22 | 2026-07-05 |
-| Grafana Operator | [v5.24.0](build/history/grafana-operator.json) | 13 | 2026-07-06 |
-| Loki Operator | [v0.10.2](build/history/loki-operator.json) | 9 | 2026-07-06 |
-| OpenSearch Operator | [3.0.2](build/history/opensearch-operator.json) | 20 | 2026-07-06 |
-| OpenTelemetry | [v0.154.0](build/history/opentelemetry.json) | 5 | 2026-07-05 |
-| Perses Operator | [v0.4.0](build/history/perses-operator.json) | 7 | 2026-07-06 |
-| Prometheus Operator | [v0.92.1](build/history/prometheus-operator.json) | 10 | 2026-07-05 |
-| VictoriaMetrics Operator | [v0.72.0](build/history/victoriametrics-operator.json) | 24 | 2026-07-05 |
+| Elastic Cloud | [v3.4.1](build/history/eck-operator.json) | 19 | 2026-07-07 |
+| Fluent Operator | [v3.9.0](build/history/fluent-operator.json) | 22 | 2026-07-07 |
+| Grafana Operator | [v5.24.0](build/history/grafana-operator.json) | 13 | 2026-07-07 |
+| Loki Operator | [v0.10.2](build/history/loki-operator.json) | 9 | 2026-07-07 |
+| OpenSearch Operator | [3.0.2](build/history/opensearch-operator.json) | 20 | 2026-07-07 |
+| OpenTelemetry | [v0.154.0](build/history/opentelemetry.json) | 5 | 2026-07-07 |
+| Perses Operator | [v0.4.0](build/history/perses-operator.json) | 7 | 2026-07-07 |
+| Prometheus Operator | [v0.92.1](build/history/prometheus-operator.json) | 10 | 2026-07-07 |
+| VictoriaMetrics Operator | [v0.72.0](build/history/victoriametrics-operator.json) | 24 | 2026-07-07 |
 <!-- versions:end -->
 
 ## Documentation

--- a/build/README.md
+++ b/build/README.md
@@ -115,7 +115,9 @@ with "document is not a YAML mapping". These show up as a leading license/usage
 banner (rook's `crds.yaml`) and, in helm-rendered installs, as interior
 `# Source: …` separators where a template produced no output (longhorn's
 `longhorn.yaml`). Splitting on column-0 `---` is safe because block-scalar
-content is always indented.
+content is always indented. The same normalized stream is parsed for CRD
+`spec.names` so history can record discovery names needed by kubectl-style
+resource references.
 
 **Pipeline stages are separate `$` calls on purpose.** A Bun-shell pipeline,
 like bash without pipefail, reports only the last command's exit code — a
@@ -127,9 +129,10 @@ output. Producers run alone via `.text()`, then the YAML is fed to
 
 `build/history/<name>.json` records repo, resolved version, build timestamp,
 flux-schema version, the sorted `kinds` array of original-cased `<group>/<Kind>`
-identifiers (one per indexed kind; the slug is recovered by lowercasing), and
-the sorted list of repo-root-relative catalog files the source owns. Everything
-derives from these manifests:
+identifiers (one per indexed kind; the slug is recovered by lowercasing),
+optional CRD discovery names keyed by `<group>/<Kind>`, and the sorted list of
+repo-root-relative catalog files the source owns. Everything derives from these
+manifests:
 
 - **Skip detection**: resolved version == manifest version AND every listed
   file exists on disk (the existence check makes a partially-synced catalog

--- a/build/README.md
+++ b/build/README.md
@@ -157,10 +157,11 @@ never blocks the others; the run exits 1 at the end.
 
 ```shell
 cd build
-bun src/main.ts build [--source <name>] [--force] [--summary <path>]
-bun src/main.ts regen [--source <name>]
+bun src/main.ts build [--source <name>] [--force] [--summary <path>] [--concurrent <n>]
+bun src/main.ts regen [--source <name>] [--concurrent <n>]
 # or from the repo root: make deps / lint / test / build
-# make build honors FORCE_BUILD=1 and BUILD_SUMMARY=<path> env/vars
+# make build honors FORCE_BUILD=1, BUILD_SUMMARY=<path>, RUN_TO_COMPLETION=1
+# and CONCURRENT=<n> env/vars
 ```
 
 Env: `FLUX_SCHEMA_BIN` (single binary path, not a command line),
@@ -168,6 +169,10 @@ Env: `FLUX_SCHEMA_BIN` (single binary path, not a command line),
 backoff and reports an exhausted limit explicitly), `GITHUB_OUTPUT` (when set,
 the build appends `changed=true|false`; the update workflow gates the
 Create PR and smoke-test steps on it).
+
+`--concurrent` defaults to `2` and controls how many sources are processed at
+once; per-source failure handling is unchanged, every source is always
+attempted.
 
 ## Testing boundaries
 

--- a/build/config/sources.yaml
+++ b/build/config/sources.yaml
@@ -827,7 +827,7 @@ sources:
 
   - name: spire-controller-manager
     alias: SPIRE Controller Manager
-    category: "Provisioning"
+    category: "Runtime"
     cncf: graduated
     url: https://github.com/spiffe/spire-controller-manager
     extract: crd

--- a/build/history/ack-acm.json
+++ b/build/history/ack-acm.json
@@ -2,11 +2,17 @@
   "name": "ack-acm",
   "repo": "aws-controllers-k8s/acm-controller",
   "version": "v1.4.2",
-  "builtAt": "2026-07-07T07:24:27.367Z",
+  "builtAt": "2026-07-07T19:09:02.185Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "acm.services.k8s.aws/Certificate"
   ],
+  "resources": {
+    "acm.services.k8s.aws/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    }
+  },
   "files": [
     "catalog/acm.services.k8s.aws/certificate_v1alpha1.fields.txt",
     "catalog/acm.services.k8s.aws/certificate_v1alpha1.json"

--- a/build/history/ack-apigatewayv2.json
+++ b/build/history/ack-apigatewayv2.json
@@ -2,8 +2,8 @@
   "name": "ack-apigatewayv2",
   "repo": "aws-controllers-k8s/apigatewayv2-controller",
   "version": "v1.3.2",
-  "builtAt": "2026-07-05T15:31:46.082Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:04.489Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "apigatewayv2.services.k8s.aws/API",
     "apigatewayv2.services.k8s.aws/APIMapping",
@@ -15,6 +15,44 @@
     "apigatewayv2.services.k8s.aws/Stage",
     "apigatewayv2.services.k8s.aws/VPCLink"
   ],
+  "resources": {
+    "apigatewayv2.services.k8s.aws/API": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apigatewayv2.services.k8s.aws/APIMapping": {
+      "singular": "apimapping",
+      "plural": "apimappings"
+    },
+    "apigatewayv2.services.k8s.aws/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "apigatewayv2.services.k8s.aws/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "apigatewayv2.services.k8s.aws/DomainName": {
+      "singular": "domainname",
+      "plural": "domainnames"
+    },
+    "apigatewayv2.services.k8s.aws/Integration": {
+      "singular": "integration",
+      "plural": "integrations"
+    },
+    "apigatewayv2.services.k8s.aws/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "apigatewayv2.services.k8s.aws/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "apigatewayv2.services.k8s.aws/VPCLink": {
+      "singular": "vpclink",
+      "plural": "vpclinks"
+    }
+  },
   "files": [
     "catalog/apigatewayv2.services.k8s.aws/api_v1alpha1.fields.txt",
     "catalog/apigatewayv2.services.k8s.aws/api_v1alpha1.json",

--- a/build/history/ack-dynamodb.json
+++ b/build/history/ack-dynamodb.json
@@ -2,13 +2,27 @@
   "name": "ack-dynamodb",
   "repo": "aws-controllers-k8s/dynamodb-controller",
   "version": "v1.9.1",
-  "builtAt": "2026-07-05T15:31:22.543Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:49.780Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "dynamodb.services.k8s.aws/Backup",
     "dynamodb.services.k8s.aws/GlobalTable",
     "dynamodb.services.k8s.aws/Table"
   ],
+  "resources": {
+    "dynamodb.services.k8s.aws/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "dynamodb.services.k8s.aws/GlobalTable": {
+      "singular": "globaltable",
+      "plural": "globaltables"
+    },
+    "dynamodb.services.k8s.aws/Table": {
+      "singular": "table",
+      "plural": "tables"
+    }
+  },
   "files": [
     "catalog/dynamodb.services.k8s.aws/backup_v1alpha1.fields.txt",
     "catalog/dynamodb.services.k8s.aws/backup_v1alpha1.json",

--- a/build/history/ack-ec2.json
+++ b/build/history/ack-ec2.json
@@ -2,8 +2,8 @@
   "name": "ack-ec2",
   "repo": "aws-controllers-k8s/ec2-controller",
   "version": "v1.17.0",
-  "builtAt": "2026-07-05T15:31:18.533Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:48.110Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "ec2.services.k8s.aws/CapacityReservation",
     "ec2.services.k8s.aws/DHCPOptions",
@@ -26,6 +26,88 @@
     "ec2.services.k8s.aws/VPCEndpointServiceConfiguration",
     "ec2.services.k8s.aws/VPCPeeringConnection"
   ],
+  "resources": {
+    "ec2.services.k8s.aws/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "ec2.services.k8s.aws/DHCPOptions": {
+      "singular": "dhcpoptions",
+      "plural": "dhcpoptions"
+    },
+    "ec2.services.k8s.aws/EgressOnlyInternetGateway": {
+      "singular": "egressonlyinternetgateway",
+      "plural": "egressonlyinternetgateways"
+    },
+    "ec2.services.k8s.aws/ElasticIPAddress": {
+      "singular": "elasticipaddress",
+      "plural": "elasticipaddresses"
+    },
+    "ec2.services.k8s.aws/FlowLog": {
+      "singular": "flowlog",
+      "plural": "flowlogs"
+    },
+    "ec2.services.k8s.aws/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "ec2.services.k8s.aws/InternetGateway": {
+      "singular": "internetgateway",
+      "plural": "internetgateways"
+    },
+    "ec2.services.k8s.aws/LaunchTemplate": {
+      "singular": "launchtemplate",
+      "plural": "launchtemplates"
+    },
+    "ec2.services.k8s.aws/ManagedPrefixList": {
+      "singular": "managedprefixlist",
+      "plural": "managedprefixlists"
+    },
+    "ec2.services.k8s.aws/NATGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "ec2.services.k8s.aws/NetworkACL": {
+      "singular": "networkacl",
+      "plural": "networkacls"
+    },
+    "ec2.services.k8s.aws/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "ec2.services.k8s.aws/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "ec2.services.k8s.aws/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets"
+    },
+    "ec2.services.k8s.aws/TransitGateway": {
+      "singular": "transitgateway",
+      "plural": "transitgateways"
+    },
+    "ec2.services.k8s.aws/TransitGatewayVPCAttachment": {
+      "singular": "transitgatewayvpcattachment",
+      "plural": "transitgatewayvpcattachments"
+    },
+    "ec2.services.k8s.aws/VPC": {
+      "singular": "vpc",
+      "plural": "vpcs"
+    },
+    "ec2.services.k8s.aws/VPCEndpoint": {
+      "singular": "vpcendpoint",
+      "plural": "vpcendpoints"
+    },
+    "ec2.services.k8s.aws/VPCEndpointServiceConfiguration": {
+      "singular": "vpcendpointserviceconfiguration",
+      "plural": "vpcendpointserviceconfigurations"
+    },
+    "ec2.services.k8s.aws/VPCPeeringConnection": {
+      "singular": "vpcpeeringconnection",
+      "plural": "vpcpeeringconnections"
+    }
+  },
   "files": [
     "catalog/ec2.services.k8s.aws/capacityreservation_v1alpha1.fields.txt",
     "catalog/ec2.services.k8s.aws/capacityreservation_v1alpha1.json",

--- a/build/history/ack-ecr.json
+++ b/build/history/ack-ecr.json
@@ -2,13 +2,27 @@
   "name": "ack-ecr",
   "repo": "aws-controllers-k8s/ecr-controller",
   "version": "v1.6.2",
-  "builtAt": "2026-07-05T15:31:27.575Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:52.341Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "ecr.services.k8s.aws/PullThroughCacheRule",
     "ecr.services.k8s.aws/Repository",
     "ecr.services.k8s.aws/RepositoryCreationTemplate"
   ],
+  "resources": {
+    "ecr.services.k8s.aws/PullThroughCacheRule": {
+      "singular": "pullthroughcacherule",
+      "plural": "pullthroughcacherules"
+    },
+    "ecr.services.k8s.aws/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "ecr.services.k8s.aws/RepositoryCreationTemplate": {
+      "singular": "repositorycreationtemplate",
+      "plural": "repositorycreationtemplates"
+    }
+  },
   "files": [
     "catalog/ecr.services.k8s.aws/pullthroughcacherule_v1alpha1.fields.txt",
     "catalog/ecr.services.k8s.aws/pullthroughcacherule_v1alpha1.json",

--- a/build/history/ack-efs.json
+++ b/build/history/ack-efs.json
@@ -2,13 +2,27 @@
   "name": "ack-efs",
   "repo": "aws-controllers-k8s/efs-controller",
   "version": "v1.4.0",
-  "builtAt": "2026-07-05T15:31:44.621Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:03.752Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "efs.services.k8s.aws/AccessPoint",
     "efs.services.k8s.aws/FileSystem",
     "efs.services.k8s.aws/MountTarget"
   ],
+  "resources": {
+    "efs.services.k8s.aws/AccessPoint": {
+      "singular": "accesspoint",
+      "plural": "accesspoints"
+    },
+    "efs.services.k8s.aws/FileSystem": {
+      "singular": "filesystem",
+      "plural": "filesystems"
+    },
+    "efs.services.k8s.aws/MountTarget": {
+      "singular": "mounttarget",
+      "plural": "mounttargets"
+    }
+  },
   "files": [
     "catalog/efs.services.k8s.aws/accesspoint_v1alpha1.fields.txt",
     "catalog/efs.services.k8s.aws/accesspoint_v1alpha1.json",

--- a/build/history/ack-eks.json
+++ b/build/history/ack-eks.json
@@ -2,8 +2,8 @@
   "name": "ack-eks",
   "repo": "aws-controllers-k8s/eks-controller",
   "version": "v1.16.1",
-  "builtAt": "2026-07-05T15:31:26.226Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:51.613Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "eks.services.k8s.aws/AccessEntry",
     "eks.services.k8s.aws/Addon",
@@ -14,6 +14,40 @@
     "eks.services.k8s.aws/Nodegroup",
     "eks.services.k8s.aws/PodIdentityAssociation"
   ],
+  "resources": {
+    "eks.services.k8s.aws/AccessEntry": {
+      "singular": "accessentry",
+      "plural": "accessentries"
+    },
+    "eks.services.k8s.aws/Addon": {
+      "singular": "addon",
+      "plural": "addons"
+    },
+    "eks.services.k8s.aws/Capability": {
+      "singular": "capability",
+      "plural": "capabilities"
+    },
+    "eks.services.k8s.aws/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "eks.services.k8s.aws/FargateProfile": {
+      "singular": "fargateprofile",
+      "plural": "fargateprofiles"
+    },
+    "eks.services.k8s.aws/IdentityProviderConfig": {
+      "singular": "identityproviderconfig",
+      "plural": "identityproviderconfigs"
+    },
+    "eks.services.k8s.aws/Nodegroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups"
+    },
+    "eks.services.k8s.aws/PodIdentityAssociation": {
+      "singular": "podidentityassociation",
+      "plural": "podidentityassociations"
+    }
+  },
   "files": [
     "catalog/eks.services.k8s.aws/accessentry_v1alpha1.fields.txt",
     "catalog/eks.services.k8s.aws/accessentry_v1alpha1.json",

--- a/build/history/ack-elasticache.json
+++ b/build/history/ack-elasticache.json
@@ -2,8 +2,8 @@
   "name": "ack-elasticache",
   "repo": "aws-controllers-k8s/elasticache-controller",
   "version": "v1.5.1",
-  "builtAt": "2026-07-05T15:31:32.180Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:55.307Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "elasticache.services.k8s.aws/CacheCluster",
     "elasticache.services.k8s.aws/CacheParameterGroup",
@@ -15,6 +15,44 @@
     "elasticache.services.k8s.aws/User",
     "elasticache.services.k8s.aws/UserGroup"
   ],
+  "resources": {
+    "elasticache.services.k8s.aws/CacheCluster": {
+      "singular": "cachecluster",
+      "plural": "cacheclusters"
+    },
+    "elasticache.services.k8s.aws/CacheParameterGroup": {
+      "singular": "cacheparametergroup",
+      "plural": "cacheparametergroups"
+    },
+    "elasticache.services.k8s.aws/CacheSubnetGroup": {
+      "singular": "cachesubnetgroup",
+      "plural": "cachesubnetgroups"
+    },
+    "elasticache.services.k8s.aws/ReplicationGroup": {
+      "singular": "replicationgroup",
+      "plural": "replicationgroups"
+    },
+    "elasticache.services.k8s.aws/ServerlessCache": {
+      "singular": "serverlesscache",
+      "plural": "serverlesscaches"
+    },
+    "elasticache.services.k8s.aws/ServerlessCacheSnapshot": {
+      "singular": "serverlesscachesnapshot",
+      "plural": "serverlesscachesnapshots"
+    },
+    "elasticache.services.k8s.aws/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "elasticache.services.k8s.aws/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "elasticache.services.k8s.aws/UserGroup": {
+      "singular": "usergroup",
+      "plural": "usergroups"
+    }
+  },
   "files": [
     "catalog/elasticache.services.k8s.aws/cachecluster_v1alpha1.fields.txt",
     "catalog/elasticache.services.k8s.aws/cachecluster_v1alpha1.json",

--- a/build/history/ack-iam.json
+++ b/build/history/ack-iam.json
@@ -2,8 +2,8 @@
   "name": "ack-iam",
   "repo": "aws-controllers-k8s/iam-controller",
   "version": "v1.7.2",
-  "builtAt": "2026-07-05T15:31:20.620Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:48.885Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "iam.services.k8s.aws/Group",
     "iam.services.k8s.aws/InstanceProfile",
@@ -13,6 +13,36 @@
     "iam.services.k8s.aws/ServiceLinkedRole",
     "iam.services.k8s.aws/User"
   ],
+  "resources": {
+    "iam.services.k8s.aws/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "iam.services.k8s.aws/InstanceProfile": {
+      "singular": "instanceprofile",
+      "plural": "instanceprofiles"
+    },
+    "iam.services.k8s.aws/OpenIDConnectProvider": {
+      "singular": "openidconnectprovider",
+      "plural": "openidconnectproviders"
+    },
+    "iam.services.k8s.aws/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "iam.services.k8s.aws/Role": {
+      "singular": "role",
+      "plural": "roles"
+    },
+    "iam.services.k8s.aws/ServiceLinkedRole": {
+      "singular": "servicelinkedrole",
+      "plural": "servicelinkedroles"
+    },
+    "iam.services.k8s.aws/User": {
+      "singular": "user",
+      "plural": "users"
+    }
+  },
   "files": [
     "catalog/iam.services.k8s.aws/group_v1alpha1.fields.txt",
     "catalog/iam.services.k8s.aws/group_v1alpha1.json",

--- a/build/history/ack-kinesis.json
+++ b/build/history/ack-kinesis.json
@@ -2,11 +2,17 @@
   "name": "ack-kinesis",
   "repo": "aws-controllers-k8s/kinesis-controller",
   "version": "v1.3.1",
-  "builtAt": "2026-07-05T15:31:40.206Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:01.208Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kinesis.services.k8s.aws/Stream"
   ],
+  "resources": {
+    "kinesis.services.k8s.aws/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    }
+  },
   "files": [
     "catalog/kinesis.services.k8s.aws/stream_v1alpha1.fields.txt",
     "catalog/kinesis.services.k8s.aws/stream_v1alpha1.json"

--- a/build/history/ack-kms.json
+++ b/build/history/ack-kms.json
@@ -2,13 +2,27 @@
   "name": "ack-kms",
   "repo": "aws-controllers-k8s/kms-controller",
   "version": "v1.3.2",
-  "builtAt": "2026-07-05T15:31:33.551Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:55.973Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kms.services.k8s.aws/Alias",
     "kms.services.k8s.aws/Grant",
     "kms.services.k8s.aws/Key"
   ],
+  "resources": {
+    "kms.services.k8s.aws/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "kms.services.k8s.aws/Grant": {
+      "singular": "grant",
+      "plural": "grants"
+    },
+    "kms.services.k8s.aws/Key": {
+      "singular": "key",
+      "plural": "keys"
+    }
+  },
   "files": [
     "catalog/kms.services.k8s.aws/alias_v1alpha1.fields.txt",
     "catalog/kms.services.k8s.aws/alias_v1alpha1.json",

--- a/build/history/ack-lambda.json
+++ b/build/history/ack-lambda.json
@@ -2,8 +2,8 @@
   "name": "ack-lambda",
   "repo": "aws-controllers-k8s/lambda-controller",
   "version": "v1.14.0",
-  "builtAt": "2026-07-05T15:31:24.340Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:50.568Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "lambda.services.k8s.aws/Alias",
     "lambda.services.k8s.aws/CodeSigningConfig",
@@ -13,6 +13,36 @@
     "lambda.services.k8s.aws/LayerVersion",
     "lambda.services.k8s.aws/Version"
   ],
+  "resources": {
+    "lambda.services.k8s.aws/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "lambda.services.k8s.aws/CodeSigningConfig": {
+      "singular": "codesigningconfig",
+      "plural": "codesigningconfigs"
+    },
+    "lambda.services.k8s.aws/EventSourceMapping": {
+      "singular": "eventsourcemapping",
+      "plural": "eventsourcemappings"
+    },
+    "lambda.services.k8s.aws/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "lambda.services.k8s.aws/FunctionURLConfig": {
+      "singular": "functionurlconfig",
+      "plural": "functionurlconfigs"
+    },
+    "lambda.services.k8s.aws/LayerVersion": {
+      "singular": "layerversion",
+      "plural": "layerversions"
+    },
+    "lambda.services.k8s.aws/Version": {
+      "singular": "version",
+      "plural": "versions"
+    }
+  },
   "files": [
     "catalog/lambda.services.k8s.aws/alias_v1alpha1.fields.txt",
     "catalog/lambda.services.k8s.aws/alias_v1alpha1.json",

--- a/build/history/ack-memorydb.json
+++ b/build/history/ack-memorydb.json
@@ -2,8 +2,8 @@
   "name": "ack-memorydb",
   "repo": "aws-controllers-k8s/memorydb-controller",
   "version": "v1.4.0",
-  "builtAt": "2026-07-05T15:31:38.806Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:00.558Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "memorydb.services.k8s.aws/ACL",
     "memorydb.services.k8s.aws/Cluster",
@@ -12,6 +12,32 @@
     "memorydb.services.k8s.aws/SubnetGroup",
     "memorydb.services.k8s.aws/User"
   ],
+  "resources": {
+    "memorydb.services.k8s.aws/ACL": {
+      "singular": "acl",
+      "plural": "acls"
+    },
+    "memorydb.services.k8s.aws/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "memorydb.services.k8s.aws/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "memorydb.services.k8s.aws/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "memorydb.services.k8s.aws/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "memorydb.services.k8s.aws/User": {
+      "singular": "user",
+      "plural": "users"
+    }
+  },
   "files": [
     "catalog/memorydb.services.k8s.aws/acl_v1alpha1.fields.txt",
     "catalog/memorydb.services.k8s.aws/acl_v1alpha1.json",

--- a/build/history/ack-rds.json
+++ b/build/history/ack-rds.json
@@ -2,8 +2,8 @@
   "name": "ack-rds",
   "repo": "aws-controllers-k8s/rds-controller",
   "version": "v1.10.0",
-  "builtAt": "2026-07-05T15:31:16.448Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:46.786Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "rds.services.k8s.aws/DBCluster",
     "rds.services.k8s.aws/DBClusterEndpoint",
@@ -16,6 +16,48 @@
     "rds.services.k8s.aws/DBSubnetGroup",
     "rds.services.k8s.aws/GlobalCluster"
   ],
+  "resources": {
+    "rds.services.k8s.aws/DBCluster": {
+      "singular": "dbcluster",
+      "plural": "dbclusters"
+    },
+    "rds.services.k8s.aws/DBClusterEndpoint": {
+      "singular": "dbclusterendpoint",
+      "plural": "dbclusterendpoints"
+    },
+    "rds.services.k8s.aws/DBClusterParameterGroup": {
+      "singular": "dbclusterparametergroup",
+      "plural": "dbclusterparametergroups"
+    },
+    "rds.services.k8s.aws/DBClusterSnapshot": {
+      "singular": "dbclustersnapshot",
+      "plural": "dbclustersnapshots"
+    },
+    "rds.services.k8s.aws/DBInstance": {
+      "singular": "dbinstance",
+      "plural": "dbinstances"
+    },
+    "rds.services.k8s.aws/DBParameterGroup": {
+      "singular": "dbparametergroup",
+      "plural": "dbparametergroups"
+    },
+    "rds.services.k8s.aws/DBProxy": {
+      "singular": "dbproxy",
+      "plural": "dbproxies"
+    },
+    "rds.services.k8s.aws/DBSnapshot": {
+      "singular": "dbsnapshot",
+      "plural": "dbsnapshots"
+    },
+    "rds.services.k8s.aws/DBSubnetGroup": {
+      "singular": "dbsubnetgroup",
+      "plural": "dbsubnetgroups"
+    },
+    "rds.services.k8s.aws/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    }
+  },
   "files": [
     "catalog/rds.services.k8s.aws/dbcluster_v1alpha1.fields.txt",
     "catalog/rds.services.k8s.aws/dbcluster_v1alpha1.json",

--- a/build/history/ack-route53.json
+++ b/build/history/ack-route53.json
@@ -2,13 +2,27 @@
   "name": "ack-route53",
   "repo": "aws-controllers-k8s/route53-controller",
   "version": "v1.4.3",
-  "builtAt": "2026-07-05T15:31:43.147Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:02.903Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "route53.services.k8s.aws/HealthCheck",
     "route53.services.k8s.aws/HostedZone",
     "route53.services.k8s.aws/RecordSet"
   ],
+  "resources": {
+    "route53.services.k8s.aws/HealthCheck": {
+      "singular": "healthcheck",
+      "plural": "healthchecks"
+    },
+    "route53.services.k8s.aws/HostedZone": {
+      "singular": "hostedzone",
+      "plural": "hostedzones"
+    },
+    "route53.services.k8s.aws/RecordSet": {
+      "singular": "recordset",
+      "plural": "recordsets"
+    }
+  },
   "files": [
     "catalog/route53.services.k8s.aws/healthcheck_v1alpha1.fields.txt",
     "catalog/route53.services.k8s.aws/healthcheck_v1alpha1.json",

--- a/build/history/ack-s3.json
+++ b/build/history/ack-s3.json
@@ -2,11 +2,17 @@
   "name": "ack-s3",
   "repo": "aws-controllers-k8s/s3-controller",
   "version": "v1.7.1",
-  "builtAt": "2026-07-05T15:31:14.823Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:45.823Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "s3.services.k8s.aws/Bucket"
   ],
+  "resources": {
+    "s3.services.k8s.aws/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    }
+  },
   "files": [
     "catalog/s3.services.k8s.aws/bucket_v1alpha1.fields.txt",
     "catalog/s3.services.k8s.aws/bucket_v1alpha1.json"

--- a/build/history/ack-sagemaker.json
+++ b/build/history/ack-sagemaker.json
@@ -2,8 +2,8 @@
   "name": "ack-sagemaker",
   "repo": "aws-controllers-k8s/sagemaker-controller",
   "version": "v1.8.1",
-  "builtAt": "2026-07-05T15:31:37.178Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:59.742Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "sagemaker.services.k8s.aws/App",
     "sagemaker.services.k8s.aws/DataQualityJobDefinition",
@@ -32,6 +32,112 @@
     "sagemaker.services.k8s.aws/TransformJob",
     "sagemaker.services.k8s.aws/UserProfile"
   ],
+  "resources": {
+    "sagemaker.services.k8s.aws/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "sagemaker.services.k8s.aws/DataQualityJobDefinition": {
+      "singular": "dataqualityjobdefinition",
+      "plural": "dataqualityjobdefinitions"
+    },
+    "sagemaker.services.k8s.aws/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "sagemaker.services.k8s.aws/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "sagemaker.services.k8s.aws/EndpointConfig": {
+      "singular": "endpointconfig",
+      "plural": "endpointconfigs"
+    },
+    "sagemaker.services.k8s.aws/FeatureGroup": {
+      "singular": "featuregroup",
+      "plural": "featuregroups"
+    },
+    "sagemaker.services.k8s.aws/HyperParameterTuningJob": {
+      "singular": "hyperparametertuningjob",
+      "plural": "hyperparametertuningjobs"
+    },
+    "sagemaker.services.k8s.aws/InferenceComponent": {
+      "singular": "inferencecomponent",
+      "plural": "inferencecomponents"
+    },
+    "sagemaker.services.k8s.aws/LabelingJob": {
+      "singular": "labelingjob",
+      "plural": "labelingjobs"
+    },
+    "sagemaker.services.k8s.aws/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "sagemaker.services.k8s.aws/ModelBiasJobDefinition": {
+      "singular": "modelbiasjobdefinition",
+      "plural": "modelbiasjobdefinitions"
+    },
+    "sagemaker.services.k8s.aws/ModelExplainabilityJobDefinition": {
+      "singular": "modelexplainabilityjobdefinition",
+      "plural": "modelexplainabilityjobdefinitions"
+    },
+    "sagemaker.services.k8s.aws/ModelPackage": {
+      "singular": "modelpackage",
+      "plural": "modelpackages"
+    },
+    "sagemaker.services.k8s.aws/ModelPackageGroup": {
+      "singular": "modelpackagegroup",
+      "plural": "modelpackagegroups"
+    },
+    "sagemaker.services.k8s.aws/ModelQualityJobDefinition": {
+      "singular": "modelqualityjobdefinition",
+      "plural": "modelqualityjobdefinitions"
+    },
+    "sagemaker.services.k8s.aws/MonitoringSchedule": {
+      "singular": "monitoringschedule",
+      "plural": "monitoringschedules"
+    },
+    "sagemaker.services.k8s.aws/NotebookInstance": {
+      "singular": "notebookinstance",
+      "plural": "notebookinstances"
+    },
+    "sagemaker.services.k8s.aws/NotebookInstanceLifecycleConfig": {
+      "singular": "notebookinstancelifecycleconfig",
+      "plural": "notebookinstancelifecycleconfigs"
+    },
+    "sagemaker.services.k8s.aws/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "sagemaker.services.k8s.aws/PipelineExecution": {
+      "singular": "pipelineexecution",
+      "plural": "pipelineexecutions"
+    },
+    "sagemaker.services.k8s.aws/ProcessingJob": {
+      "singular": "processingjob",
+      "plural": "processingjobs"
+    },
+    "sagemaker.services.k8s.aws/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "sagemaker.services.k8s.aws/Space": {
+      "singular": "space",
+      "plural": "spaces"
+    },
+    "sagemaker.services.k8s.aws/TrainingJob": {
+      "singular": "trainingjob",
+      "plural": "trainingjobs"
+    },
+    "sagemaker.services.k8s.aws/TransformJob": {
+      "singular": "transformjob",
+      "plural": "transformjobs"
+    },
+    "sagemaker.services.k8s.aws/UserProfile": {
+      "singular": "userprofile",
+      "plural": "userprofiles"
+    }
+  },
   "files": [
     "catalog/sagemaker.services.k8s.aws/app_v1alpha1.fields.txt",
     "catalog/sagemaker.services.k8s.aws/app_v1alpha1.json",

--- a/build/history/ack-secretsmanager.json
+++ b/build/history/ack-secretsmanager.json
@@ -2,11 +2,17 @@
   "name": "ack-secretsmanager",
   "repo": "aws-controllers-k8s/secretsmanager-controller",
   "version": "v1.3.1",
-  "builtAt": "2026-07-05T15:31:34.818Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:56.896Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "secretsmanager.services.k8s.aws/Secret"
   ],
+  "resources": {
+    "secretsmanager.services.k8s.aws/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    }
+  },
   "files": [
     "catalog/secretsmanager.services.k8s.aws/secret_v1alpha1.fields.txt",
     "catalog/secretsmanager.services.k8s.aws/secret_v1alpha1.json"

--- a/build/history/ack-sns.json
+++ b/build/history/ack-sns.json
@@ -2,14 +2,32 @@
   "name": "ack-sns",
   "repo": "aws-controllers-k8s/sns-controller",
   "version": "v1.7.0",
-  "builtAt": "2026-07-05T15:31:29.139Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:53.273Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "sns.services.k8s.aws/PlatformApplication",
     "sns.services.k8s.aws/PlatformEndpoint",
     "sns.services.k8s.aws/Subscription",
     "sns.services.k8s.aws/Topic"
   ],
+  "resources": {
+    "sns.services.k8s.aws/PlatformApplication": {
+      "singular": "platformapplication",
+      "plural": "platformapplications"
+    },
+    "sns.services.k8s.aws/PlatformEndpoint": {
+      "singular": "platformendpoint",
+      "plural": "platformendpoints"
+    },
+    "sns.services.k8s.aws/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "sns.services.k8s.aws/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    }
+  },
   "files": [
     "catalog/sns.services.k8s.aws/platformapplication_v1alpha1.fields.txt",
     "catalog/sns.services.k8s.aws/platformapplication_v1alpha1.json",

--- a/build/history/ack-sqs.json
+++ b/build/history/ack-sqs.json
@@ -2,11 +2,17 @@
   "name": "ack-sqs",
   "repo": "aws-controllers-k8s/sqs-controller",
   "version": "v1.5.3",
-  "builtAt": "2026-07-05T15:31:30.501Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:54.087Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "sqs.services.k8s.aws/Queue"
   ],
+  "resources": {
+    "sqs.services.k8s.aws/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    }
+  },
   "files": [
     "catalog/sqs.services.k8s.aws/queue_v1alpha1.fields.txt",
     "catalog/sqs.services.k8s.aws/queue_v1alpha1.json"

--- a/build/history/actions-runner-controller.json
+++ b/build/history/actions-runner-controller.json
@@ -2,7 +2,7 @@
   "name": "actions-runner-controller",
   "repo": "actions/actions-runner-controller",
   "version": "gha-runner-scale-set-0.14.2",
-  "builtAt": "2026-07-06T23:14:08.565Z",
+  "builtAt": "2026-07-07T19:06:51.490Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "actions.github.com/AutoscalingListener",
@@ -15,6 +15,53 @@
     "actions.summerwind.dev/RunnerReplicaSet",
     "actions.summerwind.dev/RunnerSet"
   ],
+  "resources": {
+    "actions.github.com/AutoscalingListener": {
+      "singular": "autoscalinglistener",
+      "plural": "autoscalinglisteners"
+    },
+    "actions.github.com/AutoscalingRunnerSet": {
+      "singular": "autoscalingrunnerset",
+      "plural": "autoscalingrunnersets"
+    },
+    "actions.github.com/EphemeralRunner": {
+      "singular": "ephemeralrunner",
+      "plural": "ephemeralrunners"
+    },
+    "actions.github.com/EphemeralRunnerSet": {
+      "singular": "ephemeralrunnerset",
+      "plural": "ephemeralrunnersets"
+    },
+    "actions.summerwind.dev/HorizontalRunnerAutoscaler": {
+      "singular": "horizontalrunnerautoscaler",
+      "plural": "horizontalrunnerautoscalers",
+      "shortNames": [
+        "hra"
+      ]
+    },
+    "actions.summerwind.dev/Runner": {
+      "singular": "runner",
+      "plural": "runners"
+    },
+    "actions.summerwind.dev/RunnerDeployment": {
+      "singular": "runnerdeployment",
+      "plural": "runnerdeployments",
+      "shortNames": [
+        "rdeploy"
+      ]
+    },
+    "actions.summerwind.dev/RunnerReplicaSet": {
+      "singular": "runnerreplicaset",
+      "plural": "runnerreplicasets",
+      "shortNames": [
+        "rrs"
+      ]
+    },
+    "actions.summerwind.dev/RunnerSet": {
+      "singular": "runnerset",
+      "plural": "runnersets"
+    }
+  },
   "files": [
     "catalog/actions.github.com/autoscalinglistener_v1alpha1.fields.txt",
     "catalog/actions.github.com/autoscalinglistener_v1alpha1.json",

--- a/build/history/antrea.json
+++ b/build/history/antrea.json
@@ -2,7 +2,7 @@
   "name": "antrea",
   "repo": "antrea-io/antrea",
   "version": "v2.6.2",
-  "builtAt": "2026-07-05T18:58:37.093Z",
+  "builtAt": "2026-07-07T19:14:55.194Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "crd.antrea.io/AntreaAgentInfo",
@@ -25,6 +25,139 @@
     "crd.antrea.io/Traceflow",
     "crd.antrea.io/TrafficControl"
   ],
+  "resources": {
+    "crd.antrea.io/AntreaAgentInfo": {
+      "singular": "antreaagentinfo",
+      "plural": "antreaagentinfos",
+      "shortNames": [
+        "aai"
+      ]
+    },
+    "crd.antrea.io/AntreaControllerInfo": {
+      "singular": "antreacontrollerinfo",
+      "plural": "antreacontrollerinfos",
+      "shortNames": [
+        "aci"
+      ]
+    },
+    "crd.antrea.io/BGPPolicy": {
+      "singular": "bgppolicy",
+      "plural": "bgppolicies"
+    },
+    "crd.antrea.io/ClusterGroup": {
+      "singular": "clustergroup",
+      "plural": "clustergroups",
+      "shortNames": [
+        "cg"
+      ]
+    },
+    "crd.antrea.io/ClusterNetworkPolicy": {
+      "singular": "clusternetworkpolicy",
+      "plural": "clusternetworkpolicies",
+      "shortNames": [
+        "acnp"
+      ]
+    },
+    "crd.antrea.io/Egress": {
+      "singular": "egress",
+      "plural": "egresses",
+      "shortNames": [
+        "eg"
+      ]
+    },
+    "crd.antrea.io/ExternalEntity": {
+      "singular": "externalentity",
+      "plural": "externalentities",
+      "shortNames": [
+        "ee"
+      ]
+    },
+    "crd.antrea.io/ExternalIPPool": {
+      "singular": "externalippool",
+      "plural": "externalippools",
+      "shortNames": [
+        "eip"
+      ]
+    },
+    "crd.antrea.io/ExternalNode": {
+      "singular": "externalnode",
+      "plural": "externalnodes",
+      "shortNames": [
+        "en"
+      ]
+    },
+    "crd.antrea.io/FlowExporterDestination": {
+      "singular": "flowexporterdestination",
+      "plural": "flowexporterdestinations",
+      "shortNames": [
+        "flowexporterdest"
+      ]
+    },
+    "crd.antrea.io/Group": {
+      "singular": "group",
+      "plural": "groups",
+      "shortNames": [
+        "grp"
+      ]
+    },
+    "crd.antrea.io/IPPool": {
+      "singular": "ippool",
+      "plural": "ippools",
+      "shortNames": [
+        "ipp"
+      ]
+    },
+    "crd.antrea.io/NetworkPolicy": {
+      "singular": "networkpolicy",
+      "plural": "networkpolicies",
+      "shortNames": [
+        "annp",
+        "anp"
+      ]
+    },
+    "crd.antrea.io/NodeLatencyMonitor": {
+      "singular": "nodelatencymonitor",
+      "plural": "nodelatencymonitors",
+      "shortNames": [
+        "nlm"
+      ]
+    },
+    "crd.antrea.io/PacketCapture": {
+      "singular": "packetcapture",
+      "plural": "packetcaptures",
+      "shortNames": [
+        "pcap"
+      ]
+    },
+    "crd.antrea.io/SupportBundleCollection": {
+      "singular": "supportbundlecollection",
+      "plural": "supportbundlecollections",
+      "shortNames": [
+        "sbc"
+      ]
+    },
+    "crd.antrea.io/Tier": {
+      "singular": "tier",
+      "plural": "tiers",
+      "shortNames": [
+        "tr"
+      ]
+    },
+    "crd.antrea.io/Traceflow": {
+      "singular": "traceflow",
+      "plural": "traceflows",
+      "shortNames": [
+        "tf"
+      ]
+    },
+    "crd.antrea.io/TrafficControl": {
+      "singular": "trafficcontrol",
+      "plural": "trafficcontrols",
+      "shortNames": [
+        "tc"
+      ]
+    }
+  },
   "files": [
     "catalog/crd.antrea.io/antreaagentinfo_v1beta1.fields.txt",
     "catalog/crd.antrea.io/antreaagentinfo_v1beta1.json",

--- a/build/history/argo-cd.json
+++ b/build/history/argo-cd.json
@@ -2,13 +2,39 @@
   "name": "argo-cd",
   "repo": "argoproj/argo-cd",
   "version": "v3.4.4",
-  "builtAt": "2026-07-05T16:55:42.807Z",
+  "builtAt": "2026-07-07T19:10:19.717Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "argoproj.io/AppProject",
     "argoproj.io/Application",
     "argoproj.io/ApplicationSet"
   ],
+  "resources": {
+    "argoproj.io/AppProject": {
+      "singular": "appproject",
+      "plural": "appprojects",
+      "shortNames": [
+        "appproj",
+        "appprojs"
+      ]
+    },
+    "argoproj.io/Application": {
+      "singular": "application",
+      "plural": "applications",
+      "shortNames": [
+        "app",
+        "apps"
+      ]
+    },
+    "argoproj.io/ApplicationSet": {
+      "singular": "applicationset",
+      "plural": "applicationsets",
+      "shortNames": [
+        "appset",
+        "appsets"
+      ]
+    }
+  },
   "files": [
     "catalog/argoproj.io/application_v1alpha1.fields.txt",
     "catalog/argoproj.io/application_v1alpha1.json",

--- a/build/history/argo-events.json
+++ b/build/history/argo-events.json
@@ -2,13 +2,36 @@
   "name": "argo-events",
   "repo": "argoproj/argo-events",
   "version": "v1.9.10",
-  "builtAt": "2026-07-05T16:55:59.999Z",
+  "builtAt": "2026-07-07T19:10:40.857Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "argoproj.io/EventBus",
     "argoproj.io/EventSource",
     "argoproj.io/Sensor"
   ],
+  "resources": {
+    "argoproj.io/EventBus": {
+      "singular": "eventbus",
+      "plural": "eventbus",
+      "shortNames": [
+        "eb"
+      ]
+    },
+    "argoproj.io/EventSource": {
+      "singular": "eventsource",
+      "plural": "eventsources",
+      "shortNames": [
+        "es"
+      ]
+    },
+    "argoproj.io/Sensor": {
+      "singular": "sensor",
+      "plural": "sensors",
+      "shortNames": [
+        "sn"
+      ]
+    }
+  },
   "files": [
     "catalog/argoproj.io/eventbus_v1alpha1.fields.txt",
     "catalog/argoproj.io/eventbus_v1alpha1.json",

--- a/build/history/argo-rollouts.json
+++ b/build/history/argo-rollouts.json
@@ -2,7 +2,7 @@
   "name": "argo-rollouts",
   "repo": "argoproj/argo-rollouts",
   "version": "v1.9.0",
-  "builtAt": "2026-07-05T16:55:48.427Z",
+  "builtAt": "2026-07-07T19:10:22.452Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "argoproj.io/AnalysisRun",
@@ -11,6 +11,43 @@
     "argoproj.io/Experiment",
     "argoproj.io/Rollout"
   ],
+  "resources": {
+    "argoproj.io/AnalysisRun": {
+      "singular": "analysisrun",
+      "plural": "analysisruns",
+      "shortNames": [
+        "ar"
+      ]
+    },
+    "argoproj.io/AnalysisTemplate": {
+      "singular": "analysistemplate",
+      "plural": "analysistemplates",
+      "shortNames": [
+        "at"
+      ]
+    },
+    "argoproj.io/ClusterAnalysisTemplate": {
+      "singular": "clusteranalysistemplate",
+      "plural": "clusteranalysistemplates",
+      "shortNames": [
+        "cat"
+      ]
+    },
+    "argoproj.io/Experiment": {
+      "singular": "experiment",
+      "plural": "experiments",
+      "shortNames": [
+        "exp"
+      ]
+    },
+    "argoproj.io/Rollout": {
+      "singular": "rollout",
+      "plural": "rollouts",
+      "shortNames": [
+        "ro"
+      ]
+    }
+  },
   "files": [
     "catalog/argoproj.io/analysisrun_v1alpha1.fields.txt",
     "catalog/argoproj.io/analysisrun_v1alpha1.json",

--- a/build/history/argo-workflows.json
+++ b/build/history/argo-workflows.json
@@ -2,7 +2,7 @@
   "name": "argo-workflows",
   "repo": "argoproj/argo-workflows",
   "version": "v4.0.7",
-  "builtAt": "2026-07-07T16:07:11.575Z",
+  "builtAt": "2026-07-07T19:10:27.031Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "argoproj.io/ClusterWorkflowTemplate",
@@ -14,6 +14,63 @@
     "argoproj.io/WorkflowTaskSet",
     "argoproj.io/WorkflowTemplate"
   ],
+  "resources": {
+    "argoproj.io/ClusterWorkflowTemplate": {
+      "singular": "clusterworkflowtemplate",
+      "plural": "clusterworkflowtemplates",
+      "shortNames": [
+        "clusterwftmpl",
+        "cwft"
+      ]
+    },
+    "argoproj.io/CronWorkflow": {
+      "singular": "cronworkflow",
+      "plural": "cronworkflows",
+      "shortNames": [
+        "cwf",
+        "cronwf"
+      ]
+    },
+    "argoproj.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows",
+      "shortNames": [
+        "wf"
+      ]
+    },
+    "argoproj.io/WorkflowArtifactGCTask": {
+      "singular": "workflowartifactgctask",
+      "plural": "workflowartifactgctasks",
+      "shortNames": [
+        "wfat"
+      ]
+    },
+    "argoproj.io/WorkflowEventBinding": {
+      "singular": "workfloweventbinding",
+      "plural": "workfloweventbindings",
+      "shortNames": [
+        "wfeb"
+      ]
+    },
+    "argoproj.io/WorkflowTaskResult": {
+      "singular": "workflowtaskresult",
+      "plural": "workflowtaskresults"
+    },
+    "argoproj.io/WorkflowTaskSet": {
+      "singular": "workflowtaskset",
+      "plural": "workflowtasksets",
+      "shortNames": [
+        "wfts"
+      ]
+    },
+    "argoproj.io/WorkflowTemplate": {
+      "singular": "workflowtemplate",
+      "plural": "workflowtemplates",
+      "shortNames": [
+        "wftmpl"
+      ]
+    }
+  },
   "files": [
     "catalog/argoproj.io/clusterworkflowtemplate_v1alpha1.fields.txt",
     "catalog/argoproj.io/clusterworkflowtemplate_v1alpha1.json",

--- a/build/history/aws-load-balancer-controller.json
+++ b/build/history/aws-load-balancer-controller.json
@@ -2,7 +2,7 @@
   "name": "aws-load-balancer-controller",
   "repo": "kubernetes-sigs/aws-load-balancer-controller",
   "version": "v3.4.0",
-  "builtAt": "2026-07-05T17:58:00.033Z",
+  "builtAt": "2026-07-07T19:12:49.812Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "aga.k8s.aws/GlobalAccelerator",
@@ -13,6 +13,36 @@
     "gateway.k8s.aws/LoadBalancerConfiguration",
     "gateway.k8s.aws/TargetGroupConfiguration"
   ],
+  "resources": {
+    "aga.k8s.aws/GlobalAccelerator": {
+      "singular": "globalaccelerator",
+      "plural": "globalaccelerators"
+    },
+    "elbv2.k8s.aws/ALBTargetControlConfig": {
+      "singular": "albtargetcontrolconfig",
+      "plural": "albtargetcontrolconfigs"
+    },
+    "elbv2.k8s.aws/IngressClassParams": {
+      "singular": "ingressclassparam",
+      "plural": "ingressclassparams"
+    },
+    "elbv2.k8s.aws/TargetGroupBinding": {
+      "singular": "targetgroupbinding",
+      "plural": "targetgroupbindings"
+    },
+    "gateway.k8s.aws/ListenerRuleConfiguration": {
+      "singular": "listenerruleconfiguration",
+      "plural": "listenerruleconfigurations"
+    },
+    "gateway.k8s.aws/LoadBalancerConfiguration": {
+      "singular": "loadbalancerconfiguration",
+      "plural": "loadbalancerconfigurations"
+    },
+    "gateway.k8s.aws/TargetGroupConfiguration": {
+      "singular": "targetgroupconfiguration",
+      "plural": "targetgroupconfigurations"
+    }
+  },
   "files": [
     "catalog/aga.k8s.aws/globalaccelerator_v1beta1.fields.txt",
     "catalog/aga.k8s.aws/globalaccelerator_v1beta1.json",

--- a/build/history/azure-service-operator.json
+++ b/build/history/azure-service-operator.json
@@ -2,8 +2,8 @@
   "name": "azure-service-operator",
   "repo": "Azure/azure-service-operator",
   "version": "v2.20.0",
-  "builtAt": "2026-07-05T15:38:57.887Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:09:43.099Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "alertsmanagement.azure.com/PrometheusRuleGroup",
     "alertsmanagement.azure.com/SmartDetectorAlertRule",
@@ -289,6 +289,1140 @@
     "web.azure.com/Site",
     "web.azure.com/SitesSourcecontrol"
   ],
+  "resources": {
+    "alertsmanagement.azure.com/PrometheusRuleGroup": {
+      "singular": "prometheusrulegroup",
+      "plural": "prometheusrulegroups"
+    },
+    "alertsmanagement.azure.com/SmartDetectorAlertRule": {
+      "singular": "smartdetectoralertrule",
+      "plural": "smartdetectoralertrules"
+    },
+    "apimanagement.azure.com/Api": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apimanagement.azure.com/ApiDiagnostic": {
+      "singular": "apidiagnostic",
+      "plural": "apidiagnostics"
+    },
+    "apimanagement.azure.com/ApiPolicy": {
+      "singular": "apipolicy",
+      "plural": "apipolicies"
+    },
+    "apimanagement.azure.com/ApiVersionSet": {
+      "singular": "apiversionset",
+      "plural": "apiversionsets"
+    },
+    "apimanagement.azure.com/AuthorizationProvider": {
+      "singular": "authorizationprovider",
+      "plural": "authorizationproviders"
+    },
+    "apimanagement.azure.com/AuthorizationProvidersAuthorization": {
+      "singular": "authorizationprovidersauthorization",
+      "plural": "authorizationprovidersauthorizations"
+    },
+    "apimanagement.azure.com/AuthorizationProvidersAuthorizationsAccessPolicy": {
+      "singular": "authorizationprovidersauthorizationsaccesspolicy",
+      "plural": "authorizationprovidersauthorizationsaccesspolicies"
+    },
+    "apimanagement.azure.com/Backend": {
+      "singular": "backend",
+      "plural": "backends"
+    },
+    "apimanagement.azure.com/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "apimanagement.azure.com/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "apimanagement.azure.com/Logger": {
+      "singular": "logger",
+      "plural": "loggers"
+    },
+    "apimanagement.azure.com/NamedValue": {
+      "singular": "namedvalue",
+      "plural": "namedvalues"
+    },
+    "apimanagement.azure.com/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "apimanagement.azure.com/PolicyFragment": {
+      "singular": "policyfragment",
+      "plural": "policyfragments"
+    },
+    "apimanagement.azure.com/Product": {
+      "singular": "product",
+      "plural": "products"
+    },
+    "apimanagement.azure.com/ProductApi": {
+      "singular": "productapi",
+      "plural": "productapis"
+    },
+    "apimanagement.azure.com/ProductGroup": {
+      "singular": "productgroup",
+      "plural": "productgroups"
+    },
+    "apimanagement.azure.com/ProductPolicy": {
+      "singular": "productpolicy",
+      "plural": "productpolicies"
+    },
+    "apimanagement.azure.com/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "apimanagement.azure.com/ServiceGateway": {
+      "singular": "servicegateway",
+      "plural": "servicegateways"
+    },
+    "apimanagement.azure.com/ServiceGatewayApi": {
+      "singular": "servicegatewayapi",
+      "plural": "servicegatewayapis"
+    },
+    "apimanagement.azure.com/ServiceGatewayCertificateAuthority": {
+      "singular": "servicegatewaycertificateauthority",
+      "plural": "servicegatewaycertificateauthorities"
+    },
+    "apimanagement.azure.com/ServiceGatewayHostnameConfiguration": {
+      "singular": "servicegatewayhostnameconfiguration",
+      "plural": "servicegatewayhostnameconfigurations"
+    },
+    "apimanagement.azure.com/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "apimanagement.azure.com/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "app.azure.com/AuthConfig": {
+      "singular": "authconfig",
+      "plural": "authconfigs"
+    },
+    "app.azure.com/ContainerApp": {
+      "singular": "containerapp",
+      "plural": "containerapps"
+    },
+    "app.azure.com/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "app.azure.com/ManagedEnvironment": {
+      "singular": "managedenvironment",
+      "plural": "managedenvironments"
+    },
+    "appconfiguration.azure.com/ConfigurationStore": {
+      "singular": "configurationstore",
+      "plural": "configurationstores"
+    },
+    "appconfiguration.azure.com/KeyValue": {
+      "singular": "keyvalue",
+      "plural": "keyvalues"
+    },
+    "appconfiguration.azure.com/Replica": {
+      "singular": "replica",
+      "plural": "replicas"
+    },
+    "appconfiguration.azure.com/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "authorization.azure.com/RoleAssignment": {
+      "singular": "roleassignment",
+      "plural": "roleassignments"
+    },
+    "authorization.azure.com/RoleDefinition": {
+      "singular": "roledefinition",
+      "plural": "roledefinitions"
+    },
+    "batch.azure.com/BatchAccount": {
+      "singular": "batchaccount",
+      "plural": "batchaccounts"
+    },
+    "cache.azure.com/Redis": {
+      "singular": "redis",
+      "plural": "redis"
+    },
+    "cache.azure.com/RedisAccessPolicy": {
+      "singular": "redisaccesspolicy",
+      "plural": "redisaccesspolicies"
+    },
+    "cache.azure.com/RedisAccessPolicyAssignment": {
+      "singular": "redisaccesspolicyassignment",
+      "plural": "redisaccesspolicyassignments"
+    },
+    "cache.azure.com/RedisEnterprise": {
+      "singular": "redisenterprise",
+      "plural": "redisenterprises"
+    },
+    "cache.azure.com/RedisEnterpriseDatabase": {
+      "singular": "redisenterprisedatabase",
+      "plural": "redisenterprisedatabases"
+    },
+    "cache.azure.com/RedisEnterpriseDatabaseAccessPolicyAssignment": {
+      "singular": "redisenterprisedatabaseaccesspolicyassignment",
+      "plural": "redisenterprisedatabaseaccesspolicyassignments"
+    },
+    "cache.azure.com/RedisFirewallRule": {
+      "singular": "redisfirewallrule",
+      "plural": "redisfirewallrules"
+    },
+    "cache.azure.com/RedisLinkedServer": {
+      "singular": "redislinkedserver",
+      "plural": "redislinkedservers"
+    },
+    "cache.azure.com/RedisPatchSchedule": {
+      "singular": "redispatchschedule",
+      "plural": "redispatchschedules"
+    },
+    "cdn.azure.com/AfdCustomDomain": {
+      "singular": "afdcustomdomain",
+      "plural": "afdcustomdomains"
+    },
+    "cdn.azure.com/AfdEndpoint": {
+      "singular": "afdendpoint",
+      "plural": "afdendpoints"
+    },
+    "cdn.azure.com/AfdOrigin": {
+      "singular": "afdorigin",
+      "plural": "afdorigins"
+    },
+    "cdn.azure.com/AfdOriginGroup": {
+      "singular": "afdorigingroup",
+      "plural": "afdorigingroups"
+    },
+    "cdn.azure.com/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "cdn.azure.com/ProfilesEndpoint": {
+      "singular": "profilesendpoint",
+      "plural": "profilesendpoints"
+    },
+    "cdn.azure.com/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "cdn.azure.com/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "cdn.azure.com/RuleSet": {
+      "singular": "ruleset",
+      "plural": "rulesets"
+    },
+    "cdn.azure.com/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "cdn.azure.com/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies"
+    },
+    "cognitiveservices.azure.com/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "cognitiveservices.azure.com/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "cognitiveservices.azure.com/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "communication.azure.com/CommunicationService": {
+      "singular": "communicationservice",
+      "plural": "communicationservices"
+    },
+    "communication.azure.com/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "communication.azure.com/EmailService": {
+      "singular": "emailservice",
+      "plural": "emailservices"
+    },
+    "communication.azure.com/SenderUsername": {
+      "singular": "senderusername",
+      "plural": "senderusernames"
+    },
+    "compute.azure.com/AvailabilitySet": {
+      "singular": "availabilityset",
+      "plural": "availabilitysets"
+    },
+    "compute.azure.com/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "compute.azure.com/CapacityReservationGroup": {
+      "singular": "capacityreservationgroup",
+      "plural": "capacityreservationgroups"
+    },
+    "compute.azure.com/Disk": {
+      "singular": "disk",
+      "plural": "disks"
+    },
+    "compute.azure.com/DiskAccess": {
+      "singular": "diskaccess",
+      "plural": "diskaccesses"
+    },
+    "compute.azure.com/DiskEncryptionSet": {
+      "singular": "diskencryptionset",
+      "plural": "diskencryptionsets"
+    },
+    "compute.azure.com/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "compute.azure.com/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "compute.azure.com/VirtualMachine": {
+      "singular": "virtualmachine",
+      "plural": "virtualmachines"
+    },
+    "compute.azure.com/VirtualMachineScaleSet": {
+      "singular": "virtualmachinescaleset",
+      "plural": "virtualmachinescalesets"
+    },
+    "compute.azure.com/VirtualMachineScaleSetsExtension": {
+      "singular": "virtualmachinescalesetsextension",
+      "plural": "virtualmachinescalesetsextensions"
+    },
+    "compute.azure.com/VirtualMachinesExtension": {
+      "singular": "virtualmachinesextension",
+      "plural": "virtualmachinesextensions"
+    },
+    "containerinstance.azure.com/ContainerGroup": {
+      "singular": "containergroup",
+      "plural": "containergroups"
+    },
+    "containerregistry.azure.com/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "containerregistry.azure.com/RegistryReplication": {
+      "singular": "registryreplication",
+      "plural": "registryreplications"
+    },
+    "containerservice.azure.com/Fleet": {
+      "singular": "fleet",
+      "plural": "fleets"
+    },
+    "containerservice.azure.com/FleetsAutoUpgradeProfile": {
+      "singular": "fleetsautoupgradeprofile",
+      "plural": "fleetsautoupgradeprofiles"
+    },
+    "containerservice.azure.com/FleetsMember": {
+      "singular": "fleetsmember",
+      "plural": "fleetsmembers"
+    },
+    "containerservice.azure.com/FleetsUpdateRun": {
+      "singular": "fleetsupdaterun",
+      "plural": "fleetsupdateruns"
+    },
+    "containerservice.azure.com/FleetsUpdateStrategy": {
+      "singular": "fleetsupdatestrategy",
+      "plural": "fleetsupdatestrategies"
+    },
+    "containerservice.azure.com/MaintenanceConfiguration": {
+      "singular": "maintenanceconfiguration",
+      "plural": "maintenanceconfigurations"
+    },
+    "containerservice.azure.com/ManagedCluster": {
+      "singular": "managedcluster",
+      "plural": "managedclusters"
+    },
+    "containerservice.azure.com/ManagedClustersAgentPool": {
+      "singular": "managedclustersagentpool",
+      "plural": "managedclustersagentpools"
+    },
+    "containerservice.azure.com/TrustedAccessRoleBinding": {
+      "singular": "trustedaccessrolebinding",
+      "plural": "trustedaccessrolebindings"
+    },
+    "datafactory.azure.com/Factory": {
+      "singular": "factory",
+      "plural": "factories"
+    },
+    "dataprotection.azure.com/BackupVault": {
+      "singular": "backupvault",
+      "plural": "backupvaults"
+    },
+    "dataprotection.azure.com/BackupVaultsBackupInstance": {
+      "singular": "backupvaultsbackupinstance",
+      "plural": "backupvaultsbackupinstances"
+    },
+    "dataprotection.azure.com/BackupVaultsBackupPolicy": {
+      "singular": "backupvaultsbackuppolicy",
+      "plural": "backupvaultsbackuppolicies"
+    },
+    "dbformariadb.azure.com/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "dbformariadb.azure.com/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "dbformariadb.azure.com/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "dbformysql.azure.com/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbformysql.azure.com/FlexibleServersAdministrator": {
+      "singular": "flexibleserversadministrator",
+      "plural": "flexibleserversadministrators"
+    },
+    "dbformysql.azure.com/FlexibleServersConfiguration": {
+      "singular": "flexibleserversconfiguration",
+      "plural": "flexibleserversconfigurations"
+    },
+    "dbformysql.azure.com/FlexibleServersDatabase": {
+      "singular": "flexibleserversdatabase",
+      "plural": "flexibleserversdatabases"
+    },
+    "dbformysql.azure.com/FlexibleServersFirewallRule": {
+      "singular": "flexibleserversfirewallrule",
+      "plural": "flexibleserversfirewallrules"
+    },
+    "dbformysql.azure.com/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "dbforpostgresql.azure.com/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersAdministrator": {
+      "singular": "flexibleserversadministrator",
+      "plural": "flexibleserversadministrators"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersAdvancedThreatProtectionSettings": {
+      "singular": "flexibleserversadvancedthreatprotectionsettings",
+      "plural": "flexibleserversadvancedthreatprotectionsettings"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersBackup": {
+      "singular": "flexibleserversbackup",
+      "plural": "flexibleserversbackups"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersConfiguration": {
+      "singular": "flexibleserversconfiguration",
+      "plural": "flexibleserversconfigurations"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersDatabase": {
+      "singular": "flexibleserversdatabase",
+      "plural": "flexibleserversdatabases"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersFirewallRule": {
+      "singular": "flexibleserversfirewallrule",
+      "plural": "flexibleserversfirewallrules"
+    },
+    "dbforpostgresql.azure.com/FlexibleServersVirtualEndpoint": {
+      "singular": "flexibleserversvirtualendpoint",
+      "plural": "flexibleserversvirtualendpoints"
+    },
+    "dbforpostgresql.azure.com/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "devices.azure.com/IotHub": {
+      "singular": "iothub",
+      "plural": "iothubs"
+    },
+    "documentdb.azure.com/CassandraCluster": {
+      "singular": "cassandracluster",
+      "plural": "cassandraclusters"
+    },
+    "documentdb.azure.com/CassandraDataCenter": {
+      "singular": "cassandradatacenter",
+      "plural": "cassandradatacenters"
+    },
+    "documentdb.azure.com/DatabaseAccount": {
+      "singular": "databaseaccount",
+      "plural": "databaseaccounts"
+    },
+    "documentdb.azure.com/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "documentdb.azure.com/MongoCluster": {
+      "singular": "mongocluster",
+      "plural": "mongoclusters"
+    },
+    "documentdb.azure.com/MongodbDatabase": {
+      "singular": "mongodbdatabase",
+      "plural": "mongodbdatabases"
+    },
+    "documentdb.azure.com/MongodbDatabaseCollection": {
+      "singular": "mongodbdatabasecollection",
+      "plural": "mongodbdatabasecollections"
+    },
+    "documentdb.azure.com/MongodbDatabaseCollectionThroughputSetting": {
+      "singular": "mongodbdatabasecollectionthroughputsetting",
+      "plural": "mongodbdatabasecollectionthroughputsettings"
+    },
+    "documentdb.azure.com/MongodbDatabaseThroughputSetting": {
+      "singular": "mongodbdatabasethroughputsetting",
+      "plural": "mongodbdatabasethroughputsettings"
+    },
+    "documentdb.azure.com/MongodbRoleDefinition": {
+      "singular": "mongodbroledefinition",
+      "plural": "mongodbroledefinitions"
+    },
+    "documentdb.azure.com/MongodbUserDefinition": {
+      "singular": "mongodbuserdefinition",
+      "plural": "mongodbuserdefinitions"
+    },
+    "documentdb.azure.com/SqlDatabase": {
+      "singular": "sqldatabase",
+      "plural": "sqldatabases"
+    },
+    "documentdb.azure.com/SqlDatabaseContainer": {
+      "singular": "sqldatabasecontainer",
+      "plural": "sqldatabasecontainers"
+    },
+    "documentdb.azure.com/SqlDatabaseContainerStoredProcedure": {
+      "singular": "sqldatabasecontainerstoredprocedure",
+      "plural": "sqldatabasecontainerstoredprocedures"
+    },
+    "documentdb.azure.com/SqlDatabaseContainerThroughputSetting": {
+      "singular": "sqldatabasecontainerthroughputsetting",
+      "plural": "sqldatabasecontainerthroughputsettings"
+    },
+    "documentdb.azure.com/SqlDatabaseContainerTrigger": {
+      "singular": "sqldatabasecontainertrigger",
+      "plural": "sqldatabasecontainertriggers"
+    },
+    "documentdb.azure.com/SqlDatabaseContainerUserDefinedFunction": {
+      "singular": "sqldatabasecontaineruserdefinedfunction",
+      "plural": "sqldatabasecontaineruserdefinedfunctions"
+    },
+    "documentdb.azure.com/SqlDatabaseThroughputSetting": {
+      "singular": "sqldatabasethroughputsetting",
+      "plural": "sqldatabasethroughputsettings"
+    },
+    "documentdb.azure.com/SqlRoleAssignment": {
+      "singular": "sqlroleassignment",
+      "plural": "sqlroleassignments"
+    },
+    "entra.azure.com/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "eventgrid.azure.com/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "eventgrid.azure.com/DomainsTopic": {
+      "singular": "domainstopic",
+      "plural": "domainstopics"
+    },
+    "eventgrid.azure.com/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "eventgrid.azure.com/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "eventhub.azure.com/Namespace": {
+      "singular": "namespace",
+      "plural": "namespaces"
+    },
+    "eventhub.azure.com/NamespacesAuthorizationRule": {
+      "singular": "namespacesauthorizationrule",
+      "plural": "namespacesauthorizationrules"
+    },
+    "eventhub.azure.com/NamespacesEventhub": {
+      "singular": "namespaceseventhub",
+      "plural": "namespaceseventhubs"
+    },
+    "eventhub.azure.com/NamespacesEventhubsAuthorizationRule": {
+      "singular": "namespaceseventhubsauthorizationrule",
+      "plural": "namespaceseventhubsauthorizationrules"
+    },
+    "eventhub.azure.com/NamespacesEventhubsConsumerGroup": {
+      "singular": "namespaceseventhubsconsumergroup",
+      "plural": "namespaceseventhubsconsumergroups"
+    },
+    "insights.azure.com/ActionGroup": {
+      "singular": "actiongroup",
+      "plural": "actiongroups"
+    },
+    "insights.azure.com/ActivityLogAlert": {
+      "singular": "activitylogalert",
+      "plural": "activitylogalerts"
+    },
+    "insights.azure.com/AutoscaleSetting": {
+      "singular": "autoscalesetting",
+      "plural": "autoscalesettings"
+    },
+    "insights.azure.com/Component": {
+      "singular": "component",
+      "plural": "components"
+    },
+    "insights.azure.com/DataCollectionEndpoint": {
+      "singular": "datacollectionendpoint",
+      "plural": "datacollectionendpoints"
+    },
+    "insights.azure.com/DataCollectionRule": {
+      "singular": "datacollectionrule",
+      "plural": "datacollectionrules"
+    },
+    "insights.azure.com/DataCollectionRuleAssociation": {
+      "singular": "datacollectionruleassociation",
+      "plural": "datacollectionruleassociations"
+    },
+    "insights.azure.com/DiagnosticSetting": {
+      "singular": "diagnosticsetting",
+      "plural": "diagnosticsettings"
+    },
+    "insights.azure.com/MetricAlert": {
+      "singular": "metricalert",
+      "plural": "metricalerts"
+    },
+    "insights.azure.com/PricingPlan": {
+      "singular": "pricingplan",
+      "plural": "pricingplans"
+    },
+    "insights.azure.com/ScheduledQueryRule": {
+      "singular": "scheduledqueryrule",
+      "plural": "scheduledqueryrules"
+    },
+    "insights.azure.com/Webtest": {
+      "singular": "webtest",
+      "plural": "webtests"
+    },
+    "insights.azure.com/Workbook": {
+      "singular": "workbook",
+      "plural": "workbooks"
+    },
+    "keyvault.azure.com/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "kubernetesconfiguration.azure.com/Extension": {
+      "singular": "extension",
+      "plural": "extensions"
+    },
+    "kubernetesconfiguration.azure.com/FluxConfiguration": {
+      "singular": "fluxconfiguration",
+      "plural": "fluxconfigurations"
+    },
+    "kusto.azure.com/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "kusto.azure.com/DataConnection": {
+      "singular": "dataconnection",
+      "plural": "dataconnections"
+    },
+    "kusto.azure.com/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "kusto.azure.com/PrincipalAssignment": {
+      "singular": "principalassignment",
+      "plural": "principalassignments"
+    },
+    "machinelearningservices.azure.com/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "machinelearningservices.azure.com/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "machinelearningservices.azure.com/WorkspacesCompute": {
+      "singular": "workspacescompute",
+      "plural": "workspacescomputes"
+    },
+    "machinelearningservices.azure.com/WorkspacesConnection": {
+      "singular": "workspacesconnection",
+      "plural": "workspacesconnections"
+    },
+    "managedidentity.azure.com/FederatedIdentityCredential": {
+      "singular": "federatedidentitycredential",
+      "plural": "federatedidentitycredentials"
+    },
+    "managedidentity.azure.com/UserAssignedIdentity": {
+      "singular": "userassignedidentity",
+      "plural": "userassignedidentities"
+    },
+    "monitor.azure.com/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "network.azure.com/ApplicationGateway": {
+      "singular": "applicationgateway",
+      "plural": "applicationgateways"
+    },
+    "network.azure.com/ApplicationSecurityGroup": {
+      "singular": "applicationsecuritygroup",
+      "plural": "applicationsecuritygroups"
+    },
+    "network.azure.com/AzureFirewall": {
+      "singular": "azurefirewall",
+      "plural": "azurefirewalls"
+    },
+    "network.azure.com/BastionHost": {
+      "singular": "bastionhost",
+      "plural": "bastionhosts"
+    },
+    "network.azure.com/DnsForwardingRuleSetsForwardingRule": {
+      "singular": "dnsforwardingrulesetsforwardingrule",
+      "plural": "dnsforwardingrulesetsforwardingrules"
+    },
+    "network.azure.com/DnsForwardingRuleSetsVirtualNetworkLink": {
+      "singular": "dnsforwardingrulesetsvirtualnetworklink",
+      "plural": "dnsforwardingrulesetsvirtualnetworklinks"
+    },
+    "network.azure.com/DnsForwardingRuleset": {
+      "singular": "dnsforwardingruleset",
+      "plural": "dnsforwardingrulesets"
+    },
+    "network.azure.com/DnsResolver": {
+      "singular": "dnsresolver",
+      "plural": "dnsresolvers"
+    },
+    "network.azure.com/DnsResolversInboundEndpoint": {
+      "singular": "dnsresolversinboundendpoint",
+      "plural": "dnsresolversinboundendpoints"
+    },
+    "network.azure.com/DnsResolversOutboundEndpoint": {
+      "singular": "dnsresolversoutboundendpoint",
+      "plural": "dnsresolversoutboundendpoints"
+    },
+    "network.azure.com/DnsZone": {
+      "singular": "dnszone",
+      "plural": "dnszones"
+    },
+    "network.azure.com/DnsZonesAAAARecord": {
+      "singular": "dnszonesaaaarecord",
+      "plural": "dnszonesaaaarecords"
+    },
+    "network.azure.com/DnsZonesARecord": {
+      "singular": "dnszonesarecord",
+      "plural": "dnszonesarecords"
+    },
+    "network.azure.com/DnsZonesCAARecord": {
+      "singular": "dnszonescaarecord",
+      "plural": "dnszonescaarecords"
+    },
+    "network.azure.com/DnsZonesCNAMERecord": {
+      "singular": "dnszonescnamerecord",
+      "plural": "dnszonescnamerecords"
+    },
+    "network.azure.com/DnsZonesMXRecord": {
+      "singular": "dnszonesmxrecord",
+      "plural": "dnszonesmxrecords"
+    },
+    "network.azure.com/DnsZonesNSRecord": {
+      "singular": "dnszonesnsrecord",
+      "plural": "dnszonesnsrecords"
+    },
+    "network.azure.com/DnsZonesPTRRecord": {
+      "singular": "dnszonesptrrecord",
+      "plural": "dnszonesptrrecords"
+    },
+    "network.azure.com/DnsZonesSRVRecord": {
+      "singular": "dnszonessrvrecord",
+      "plural": "dnszonessrvrecords"
+    },
+    "network.azure.com/DnsZonesTXTRecord": {
+      "singular": "dnszonestxtrecord",
+      "plural": "dnszonestxtrecords"
+    },
+    "network.azure.com/FirewallPoliciesRuleCollectionGroup": {
+      "singular": "firewallpoliciesrulecollectiongroup",
+      "plural": "firewallpoliciesrulecollectiongroups"
+    },
+    "network.azure.com/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "network.azure.com/LoadBalancer": {
+      "singular": "loadbalancer",
+      "plural": "loadbalancers"
+    },
+    "network.azure.com/LoadBalancersInboundNatRule": {
+      "singular": "loadbalancersinboundnatrule",
+      "plural": "loadbalancersinboundnatrules"
+    },
+    "network.azure.com/NatGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "network.azure.com/NetworkInterface": {
+      "singular": "networkinterface",
+      "plural": "networkinterfaces"
+    },
+    "network.azure.com/NetworkSecurityGroup": {
+      "singular": "networksecuritygroup",
+      "plural": "networksecuritygroups"
+    },
+    "network.azure.com/NetworkSecurityGroupsSecurityRule": {
+      "singular": "networksecuritygroupssecurityrule",
+      "plural": "networksecuritygroupssecurityrules"
+    },
+    "network.azure.com/NetworkWatcher": {
+      "singular": "networkwatcher",
+      "plural": "networkwatchers"
+    },
+    "network.azure.com/NetworkWatchersFlowLog": {
+      "singular": "networkwatchersflowlog",
+      "plural": "networkwatchersflowlogs"
+    },
+    "network.azure.com/PrivateDnsZone": {
+      "singular": "privatednszone",
+      "plural": "privatednszones"
+    },
+    "network.azure.com/PrivateDnsZonesAAAARecord": {
+      "singular": "privatednszonesaaaarecord",
+      "plural": "privatednszonesaaaarecords"
+    },
+    "network.azure.com/PrivateDnsZonesARecord": {
+      "singular": "privatednszonesarecord",
+      "plural": "privatednszonesarecords"
+    },
+    "network.azure.com/PrivateDnsZonesCNAMERecord": {
+      "singular": "privatednszonescnamerecord",
+      "plural": "privatednszonescnamerecords"
+    },
+    "network.azure.com/PrivateDnsZonesMXRecord": {
+      "singular": "privatednszonesmxrecord",
+      "plural": "privatednszonesmxrecords"
+    },
+    "network.azure.com/PrivateDnsZonesPTRRecord": {
+      "singular": "privatednszonesptrrecord",
+      "plural": "privatednszonesptrrecords"
+    },
+    "network.azure.com/PrivateDnsZonesSRVRecord": {
+      "singular": "privatednszonessrvrecord",
+      "plural": "privatednszonessrvrecords"
+    },
+    "network.azure.com/PrivateDnsZonesTXTRecord": {
+      "singular": "privatednszonestxtrecord",
+      "plural": "privatednszonestxtrecords"
+    },
+    "network.azure.com/PrivateDnsZonesVirtualNetworkLink": {
+      "singular": "privatednszonesvirtualnetworklink",
+      "plural": "privatednszonesvirtualnetworklinks"
+    },
+    "network.azure.com/PrivateEndpoint": {
+      "singular": "privateendpoint",
+      "plural": "privateendpoints"
+    },
+    "network.azure.com/PrivateEndpointsPrivateDnsZoneGroup": {
+      "singular": "privateendpointsprivatednszonegroup",
+      "plural": "privateendpointsprivatednszonegroups"
+    },
+    "network.azure.com/PrivateLinkService": {
+      "singular": "privatelinkservice",
+      "plural": "privatelinkservices"
+    },
+    "network.azure.com/PublicIPAddress": {
+      "singular": "publicipaddress",
+      "plural": "publicipaddresses"
+    },
+    "network.azure.com/PublicIPPrefix": {
+      "singular": "publicipprefix",
+      "plural": "publicipprefixes"
+    },
+    "network.azure.com/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "network.azure.com/RouteTablesRoute": {
+      "singular": "routetablesroute",
+      "plural": "routetablesroutes"
+    },
+    "network.azure.com/TrafficManagerProfile": {
+      "singular": "trafficmanagerprofile",
+      "plural": "trafficmanagerprofiles"
+    },
+    "network.azure.com/TrafficManagerProfilesAzureEndpoint": {
+      "singular": "trafficmanagerprofilesazureendpoint",
+      "plural": "trafficmanagerprofilesazureendpoints"
+    },
+    "network.azure.com/TrafficManagerProfilesExternalEndpoint": {
+      "singular": "trafficmanagerprofilesexternalendpoint",
+      "plural": "trafficmanagerprofilesexternalendpoints"
+    },
+    "network.azure.com/TrafficManagerProfilesNestedEndpoint": {
+      "singular": "trafficmanagerprofilesnestedendpoint",
+      "plural": "trafficmanagerprofilesnestedendpoints"
+    },
+    "network.azure.com/VirtualNetwork": {
+      "singular": "virtualnetwork",
+      "plural": "virtualnetworks"
+    },
+    "network.azure.com/VirtualNetworkGateway": {
+      "singular": "virtualnetworkgateway",
+      "plural": "virtualnetworkgateways"
+    },
+    "network.azure.com/VirtualNetworksSubnet": {
+      "singular": "virtualnetworkssubnet",
+      "plural": "virtualnetworkssubnets"
+    },
+    "network.azure.com/VirtualNetworksVirtualNetworkPeering": {
+      "singular": "virtualnetworksvirtualnetworkpeering",
+      "plural": "virtualnetworksvirtualnetworkpeerings"
+    },
+    "network.azure.com/WebApplicationFirewallPolicy": {
+      "singular": "webapplicationfirewallpolicy",
+      "plural": "webapplicationfirewallpolicies"
+    },
+    "network.frontdoor.azure.com/WebApplicationFirewallPolicy": {
+      "singular": "webapplicationfirewallpolicy",
+      "plural": "webapplicationfirewallpolicies"
+    },
+    "notificationhubs.azure.com/Namespace": {
+      "singular": "namespace",
+      "plural": "namespaces"
+    },
+    "notificationhubs.azure.com/NamespacesAuthorizationRule": {
+      "singular": "namespacesauthorizationrule",
+      "plural": "namespacesauthorizationrules"
+    },
+    "notificationhubs.azure.com/NotificationHub": {
+      "singular": "notificationhub",
+      "plural": "notificationhubs"
+    },
+    "notificationhubs.azure.com/NotificationHubsAuthorizationRule": {
+      "singular": "notificationhubsauthorizationrule",
+      "plural": "notificationhubsauthorizationrules"
+    },
+    "operationalinsights.azure.com/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "quota.azure.com/Quota": {
+      "singular": "quota",
+      "plural": "quotas"
+    },
+    "redhatopenshift.azure.com/OpenShiftCluster": {
+      "singular": "openshiftcluster",
+      "plural": "openshiftclusters"
+    },
+    "resources.azure.com/ResourceGroup": {
+      "singular": "resourcegroup",
+      "plural": "resourcegroups"
+    },
+    "search.azure.com/SearchService": {
+      "singular": "searchservice",
+      "plural": "searchservices"
+    },
+    "servicebus.azure.com/Namespace": {
+      "singular": "namespace",
+      "plural": "namespaces"
+    },
+    "servicebus.azure.com/NamespacesAuthorizationRule": {
+      "singular": "namespacesauthorizationrule",
+      "plural": "namespacesauthorizationrules"
+    },
+    "servicebus.azure.com/NamespacesQueue": {
+      "singular": "namespacesqueue",
+      "plural": "namespacesqueues"
+    },
+    "servicebus.azure.com/NamespacesTopic": {
+      "singular": "namespacestopic",
+      "plural": "namespacestopics"
+    },
+    "servicebus.azure.com/NamespacesTopicsSubscription": {
+      "singular": "namespacestopicssubscription",
+      "plural": "namespacestopicssubscriptions"
+    },
+    "servicebus.azure.com/NamespacesTopicsSubscriptionsRule": {
+      "singular": "namespacestopicssubscriptionsrule",
+      "plural": "namespacestopicssubscriptionsrules"
+    },
+    "servicebus.azure.com/TopicAuthorizationRule": {
+      "singular": "topicauthorizationrule",
+      "plural": "topicauthorizationrules"
+    },
+    "signalrservice.azure.com/CustomCertificate": {
+      "singular": "customcertificate",
+      "plural": "customcertificates"
+    },
+    "signalrservice.azure.com/CustomDomain": {
+      "singular": "customdomain",
+      "plural": "customdomains"
+    },
+    "signalrservice.azure.com/Replica": {
+      "singular": "replica",
+      "plural": "replicas"
+    },
+    "signalrservice.azure.com/SignalR": {
+      "singular": "signalr",
+      "plural": "signalrs"
+    },
+    "sql.azure.com/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "sql.azure.com/ServersAdministrator": {
+      "singular": "serversadministrator",
+      "plural": "serversadministrators"
+    },
+    "sql.azure.com/ServersAdvancedThreatProtectionSetting": {
+      "singular": "serversadvancedthreatprotectionsetting",
+      "plural": "serversadvancedthreatprotectionsettings"
+    },
+    "sql.azure.com/ServersAuditingSetting": {
+      "singular": "serversauditingsetting",
+      "plural": "serversauditingsettings"
+    },
+    "sql.azure.com/ServersAzureADOnlyAuthentication": {
+      "singular": "serversazureadonlyauthentication",
+      "plural": "serversazureadonlyauthentications"
+    },
+    "sql.azure.com/ServersConnectionPolicy": {
+      "singular": "serversconnectionpolicy",
+      "plural": "serversconnectionpolicies"
+    },
+    "sql.azure.com/ServersDatabase": {
+      "singular": "serversdatabase",
+      "plural": "serversdatabases"
+    },
+    "sql.azure.com/ServersDatabasesAdvancedThreatProtectionSetting": {
+      "singular": "serversdatabasesadvancedthreatprotectionsetting",
+      "plural": "serversdatabasesadvancedthreatprotectionsettings"
+    },
+    "sql.azure.com/ServersDatabasesAuditingSetting": {
+      "singular": "serversdatabasesauditingsetting",
+      "plural": "serversdatabasesauditingsettings"
+    },
+    "sql.azure.com/ServersDatabasesBackupLongTermRetentionPolicy": {
+      "singular": "serversdatabasesbackuplongtermretentionpolicy",
+      "plural": "serversdatabasesbackuplongtermretentionpolicies"
+    },
+    "sql.azure.com/ServersDatabasesBackupShortTermRetentionPolicy": {
+      "singular": "serversdatabasesbackupshorttermretentionpolicy",
+      "plural": "serversdatabasesbackupshorttermretentionpolicies"
+    },
+    "sql.azure.com/ServersDatabasesSecurityAlertPolicy": {
+      "singular": "serversdatabasessecurityalertpolicy",
+      "plural": "serversdatabasessecurityalertpolicies"
+    },
+    "sql.azure.com/ServersDatabasesTransparentDataEncryption": {
+      "singular": "serversdatabasestransparentdataencryption",
+      "plural": "serversdatabasestransparentdataencryptions"
+    },
+    "sql.azure.com/ServersDatabasesVulnerabilityAssessment": {
+      "singular": "serversdatabasesvulnerabilityassessment",
+      "plural": "serversdatabasesvulnerabilityassessments"
+    },
+    "sql.azure.com/ServersElasticPool": {
+      "singular": "serverselasticpool",
+      "plural": "serverselasticpools"
+    },
+    "sql.azure.com/ServersFailoverGroup": {
+      "singular": "serversfailovergroup",
+      "plural": "serversfailovergroups"
+    },
+    "sql.azure.com/ServersFirewallRule": {
+      "singular": "serversfirewallrule",
+      "plural": "serversfirewallrules"
+    },
+    "sql.azure.com/ServersIPV6FirewallRule": {
+      "singular": "serversipv6firewallrule",
+      "plural": "serversipv6firewallrules"
+    },
+    "sql.azure.com/ServersOutboundFirewallRule": {
+      "singular": "serversoutboundfirewallrule",
+      "plural": "serversoutboundfirewallrules"
+    },
+    "sql.azure.com/ServersSecurityAlertPolicy": {
+      "singular": "serverssecurityalertpolicy",
+      "plural": "serverssecurityalertpolicies"
+    },
+    "sql.azure.com/ServersVirtualNetworkRule": {
+      "singular": "serversvirtualnetworkrule",
+      "plural": "serversvirtualnetworkrules"
+    },
+    "sql.azure.com/ServersVulnerabilityAssessment": {
+      "singular": "serversvulnerabilityassessment",
+      "plural": "serversvulnerabilityassessments"
+    },
+    "sql.azure.com/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "storage.azure.com/StorageAccount": {
+      "singular": "storageaccount",
+      "plural": "storageaccounts"
+    },
+    "storage.azure.com/StorageAccountsBlobService": {
+      "singular": "storageaccountsblobservice",
+      "plural": "storageaccountsblobservices"
+    },
+    "storage.azure.com/StorageAccountsBlobServicesContainer": {
+      "singular": "storageaccountsblobservicescontainer",
+      "plural": "storageaccountsblobservicescontainers"
+    },
+    "storage.azure.com/StorageAccountsFileService": {
+      "singular": "storageaccountsfileservice",
+      "plural": "storageaccountsfileservices"
+    },
+    "storage.azure.com/StorageAccountsFileServicesShare": {
+      "singular": "storageaccountsfileservicesshare",
+      "plural": "storageaccountsfileservicesshares"
+    },
+    "storage.azure.com/StorageAccountsManagementPolicy": {
+      "singular": "storageaccountsmanagementpolicy",
+      "plural": "storageaccountsmanagementpolicies"
+    },
+    "storage.azure.com/StorageAccountsQueueService": {
+      "singular": "storageaccountsqueueservice",
+      "plural": "storageaccountsqueueservices"
+    },
+    "storage.azure.com/StorageAccountsQueueServicesQueue": {
+      "singular": "storageaccountsqueueservicesqueue",
+      "plural": "storageaccountsqueueservicesqueues"
+    },
+    "storage.azure.com/StorageAccountsTableService": {
+      "singular": "storageaccountstableservice",
+      "plural": "storageaccountstableservices"
+    },
+    "storage.azure.com/StorageAccountsTableServicesTable": {
+      "singular": "storageaccountstableservicestable",
+      "plural": "storageaccountstableservicestables"
+    },
+    "subscription.azure.com/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "synapse.azure.com/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "synapse.azure.com/WorkspacesBigDataPool": {
+      "singular": "workspacesbigdatapool",
+      "plural": "workspacesbigdatapools"
+    },
+    "web.azure.com/ServerFarm": {
+      "singular": "serverfarm",
+      "plural": "serverfarms"
+    },
+    "web.azure.com/Site": {
+      "singular": "site",
+      "plural": "sites"
+    },
+    "web.azure.com/SitesSourcecontrol": {
+      "singular": "sitessourcecontrol",
+      "plural": "sitessourcecontrols"
+    }
+  },
   "files": [
     "catalog/alertsmanagement.azure.com/prometheusrulegroup_v1api20230301.fields.txt",
     "catalog/alertsmanagement.azure.com/prometheusrulegroup_v1api20230301.json",

--- a/build/history/calico.json
+++ b/build/history/calico.json
@@ -2,7 +2,7 @@
   "name": "calico",
   "repo": "projectcalico/calico",
   "version": "v3.32.1",
-  "builtAt": "2026-07-05T18:51:31.178Z",
+  "builtAt": "2026-07-07T19:14:45.932Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "crd.projectcalico.org/BGPConfiguration",
@@ -28,6 +28,96 @@
     "crd.projectcalico.org/StagedNetworkPolicy",
     "crd.projectcalico.org/Tier"
   ],
+  "resources": {
+    "crd.projectcalico.org/BGPConfiguration": {
+      "singular": "bgpconfiguration",
+      "plural": "bgpconfigurations"
+    },
+    "crd.projectcalico.org/BGPFilter": {
+      "singular": "bgpfilter",
+      "plural": "bgpfilters"
+    },
+    "crd.projectcalico.org/BGPPeer": {
+      "singular": "bgppeer",
+      "plural": "bgppeers"
+    },
+    "crd.projectcalico.org/BlockAffinity": {
+      "singular": "blockaffinity",
+      "plural": "blockaffinities"
+    },
+    "crd.projectcalico.org/CalicoNodeStatus": {
+      "singular": "caliconodestatus",
+      "plural": "caliconodestatuses"
+    },
+    "crd.projectcalico.org/ClusterInformation": {
+      "singular": "clusterinformation",
+      "plural": "clusterinformations"
+    },
+    "crd.projectcalico.org/FelixConfiguration": {
+      "singular": "felixconfiguration",
+      "plural": "felixconfigurations"
+    },
+    "crd.projectcalico.org/GlobalNetworkPolicy": {
+      "singular": "globalnetworkpolicy",
+      "plural": "globalnetworkpolicies"
+    },
+    "crd.projectcalico.org/GlobalNetworkSet": {
+      "singular": "globalnetworkset",
+      "plural": "globalnetworksets"
+    },
+    "crd.projectcalico.org/HostEndpoint": {
+      "singular": "hostendpoint",
+      "plural": "hostendpoints"
+    },
+    "crd.projectcalico.org/IPAMBlock": {
+      "singular": "ipamblock",
+      "plural": "ipamblocks"
+    },
+    "crd.projectcalico.org/IPAMConfig": {
+      "singular": "ipamconfig",
+      "plural": "ipamconfigs"
+    },
+    "crd.projectcalico.org/IPAMHandle": {
+      "singular": "ipamhandle",
+      "plural": "ipamhandles"
+    },
+    "crd.projectcalico.org/IPPool": {
+      "singular": "ippool",
+      "plural": "ippools"
+    },
+    "crd.projectcalico.org/IPReservation": {
+      "singular": "ipreservation",
+      "plural": "ipreservations"
+    },
+    "crd.projectcalico.org/KubeControllersConfiguration": {
+      "singular": "kubecontrollersconfiguration",
+      "plural": "kubecontrollersconfigurations"
+    },
+    "crd.projectcalico.org/NetworkPolicy": {
+      "singular": "networkpolicy",
+      "plural": "networkpolicies"
+    },
+    "crd.projectcalico.org/NetworkSet": {
+      "singular": "networkset",
+      "plural": "networksets"
+    },
+    "crd.projectcalico.org/StagedGlobalNetworkPolicy": {
+      "singular": "stagedglobalnetworkpolicy",
+      "plural": "stagedglobalnetworkpolicies"
+    },
+    "crd.projectcalico.org/StagedKubernetesNetworkPolicy": {
+      "singular": "stagedkubernetesnetworkpolicy",
+      "plural": "stagedkubernetesnetworkpolicies"
+    },
+    "crd.projectcalico.org/StagedNetworkPolicy": {
+      "singular": "stagednetworkpolicy",
+      "plural": "stagednetworkpolicies"
+    },
+    "crd.projectcalico.org/Tier": {
+      "singular": "tier",
+      "plural": "tiers"
+    }
+  },
   "files": [
     "catalog/crd.projectcalico.org/bgpconfiguration_v1.fields.txt",
     "catalog/crd.projectcalico.org/bgpconfiguration_v1.json",

--- a/build/history/capsule.json
+++ b/build/history/capsule.json
@@ -2,7 +2,7 @@
   "name": "capsule",
   "repo": "projectcapsule/capsule",
   "version": "v0.13.9",
-  "builtAt": "2026-07-07T07:24:41.569Z",
+  "builtAt": "2026-07-07T19:12:16.386Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "capsule.clastix.io/CapsuleConfiguration",
@@ -17,6 +17,73 @@
     "capsule.clastix.io/TenantOwner",
     "capsule.clastix.io/TenantResource"
   ],
+  "resources": {
+    "capsule.clastix.io/CapsuleConfiguration": {
+      "singular": "capsuleconfiguration",
+      "plural": "capsuleconfigurations"
+    },
+    "capsule.clastix.io/CustomQuota": {
+      "singular": "customquota",
+      "plural": "customquotas",
+      "shortNames": [
+        "cq"
+      ]
+    },
+    "capsule.clastix.io/GlobalCustomQuota": {
+      "singular": "globalcustomquota",
+      "plural": "globalcustomquotas",
+      "shortNames": [
+        "gcq"
+      ]
+    },
+    "capsule.clastix.io/GlobalTenantResource": {
+      "singular": "globaltenantresource",
+      "plural": "globaltenantresources",
+      "shortNames": [
+        "gtr"
+      ]
+    },
+    "capsule.clastix.io/QuantityLedger": {
+      "singular": "quantityledger",
+      "plural": "quantityledgers",
+      "shortNames": [
+        "ql"
+      ]
+    },
+    "capsule.clastix.io/ResourcePool": {
+      "singular": "resourcepool",
+      "plural": "resourcepools",
+      "shortNames": [
+        "quotapool"
+      ]
+    },
+    "capsule.clastix.io/ResourcePoolClaim": {
+      "singular": "resourcepoolclaim",
+      "plural": "resourcepoolclaims"
+    },
+    "capsule.clastix.io/RuleStatus": {
+      "singular": "rulestatus",
+      "plural": "rulestatuses"
+    },
+    "capsule.clastix.io/Tenant": {
+      "singular": "tenant",
+      "plural": "tenants",
+      "shortNames": [
+        "tnt"
+      ]
+    },
+    "capsule.clastix.io/TenantOwner": {
+      "singular": "tenantowner",
+      "plural": "tenantowners",
+      "shortNames": [
+        "to"
+      ]
+    },
+    "capsule.clastix.io/TenantResource": {
+      "singular": "tenantresource",
+      "plural": "tenantresources"
+    }
+  },
   "files": [
     "catalog/capsule.clastix.io/capsuleconfiguration_v1beta2.fields.txt",
     "catalog/capsule.clastix.io/capsuleconfiguration_v1beta2.json",

--- a/build/history/cert-manager.json
+++ b/build/history/cert-manager.json
@@ -2,8 +2,8 @@
   "name": "cert-manager",
   "repo": "cert-manager/cert-manager",
   "version": "v1.20.3",
-  "builtAt": "2026-07-05T09:08:56.825Z",
-  "fluxSchemaVersion": "0.7.0",
+  "builtAt": "2026-07-07T19:05:09.309Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "acme.cert-manager.io/Challenge",
     "acme.cert-manager.io/Order",
@@ -12,6 +12,46 @@
     "cert-manager.io/ClusterIssuer",
     "cert-manager.io/Issuer"
   ],
+  "resources": {
+    "acme.cert-manager.io/Challenge": {
+      "singular": "challenge",
+      "plural": "challenges"
+    },
+    "acme.cert-manager.io/Order": {
+      "singular": "order",
+      "plural": "orders"
+    },
+    "cert-manager.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates",
+      "shortNames": [
+        "cert",
+        "certs"
+      ]
+    },
+    "cert-manager.io/CertificateRequest": {
+      "singular": "certificaterequest",
+      "plural": "certificaterequests",
+      "shortNames": [
+        "cr",
+        "crs"
+      ]
+    },
+    "cert-manager.io/ClusterIssuer": {
+      "singular": "clusterissuer",
+      "plural": "clusterissuers",
+      "shortNames": [
+        "ciss"
+      ]
+    },
+    "cert-manager.io/Issuer": {
+      "singular": "issuer",
+      "plural": "issuers",
+      "shortNames": [
+        "iss"
+      ]
+    }
+  },
   "files": [
     "catalog/acme.cert-manager.io/challenge_v1.fields.txt",
     "catalog/acme.cert-manager.io/challenge_v1.json",

--- a/build/history/cilium.json
+++ b/build/history/cilium.json
@@ -2,8 +2,8 @@
   "name": "cilium",
   "repo": "cilium/cilium",
   "version": "v1.19.5",
-  "builtAt": "2026-07-05T10:34:38.957Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:05:30.549Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "cilium.io/CiliumBGPAdvertisement",
     "cilium.io/CiliumBGPClusterConfig",
@@ -27,6 +27,158 @@
     "cilium.io/CiliumNodeConfig",
     "cilium.io/CiliumPodIPPool"
   ],
+  "resources": {
+    "cilium.io/CiliumBGPAdvertisement": {
+      "singular": "ciliumbgpadvertisement",
+      "plural": "ciliumbgpadvertisements",
+      "shortNames": [
+        "cbgpadvert"
+      ]
+    },
+    "cilium.io/CiliumBGPClusterConfig": {
+      "singular": "ciliumbgpclusterconfig",
+      "plural": "ciliumbgpclusterconfigs",
+      "shortNames": [
+        "cbgpcluster"
+      ]
+    },
+    "cilium.io/CiliumBGPNodeConfig": {
+      "singular": "ciliumbgpnodeconfig",
+      "plural": "ciliumbgpnodeconfigs",
+      "shortNames": [
+        "cbgpnode"
+      ]
+    },
+    "cilium.io/CiliumBGPNodeConfigOverride": {
+      "singular": "ciliumbgpnodeconfigoverride",
+      "plural": "ciliumbgpnodeconfigoverrides",
+      "shortNames": [
+        "cbgpnodeoverride"
+      ]
+    },
+    "cilium.io/CiliumBGPPeerConfig": {
+      "singular": "ciliumbgppeerconfig",
+      "plural": "ciliumbgppeerconfigs",
+      "shortNames": [
+        "cbgppeer"
+      ]
+    },
+    "cilium.io/CiliumCIDRGroup": {
+      "singular": "ciliumcidrgroup",
+      "plural": "ciliumcidrgroups",
+      "shortNames": [
+        "ccg"
+      ]
+    },
+    "cilium.io/CiliumClusterwideEnvoyConfig": {
+      "singular": "ciliumclusterwideenvoyconfig",
+      "plural": "ciliumclusterwideenvoyconfigs",
+      "shortNames": [
+        "ccec"
+      ]
+    },
+    "cilium.io/CiliumClusterwideNetworkPolicy": {
+      "singular": "ciliumclusterwidenetworkpolicy",
+      "plural": "ciliumclusterwidenetworkpolicies",
+      "shortNames": [
+        "ccnp"
+      ]
+    },
+    "cilium.io/CiliumEgressGatewayPolicy": {
+      "singular": "ciliumegressgatewaypolicy",
+      "plural": "ciliumegressgatewaypolicies",
+      "shortNames": [
+        "cegp"
+      ]
+    },
+    "cilium.io/CiliumEndpoint": {
+      "singular": "ciliumendpoint",
+      "plural": "ciliumendpoints",
+      "shortNames": [
+        "cep",
+        "ciliumep"
+      ]
+    },
+    "cilium.io/CiliumEndpointSlice": {
+      "singular": "ciliumendpointslice",
+      "plural": "ciliumendpointslices",
+      "shortNames": [
+        "ces"
+      ]
+    },
+    "cilium.io/CiliumEnvoyConfig": {
+      "singular": "ciliumenvoyconfig",
+      "plural": "ciliumenvoyconfigs",
+      "shortNames": [
+        "cec"
+      ]
+    },
+    "cilium.io/CiliumGatewayClassConfig": {
+      "singular": "ciliumgatewayclassconfig",
+      "plural": "ciliumgatewayclassconfigs",
+      "shortNames": [
+        "cgcc"
+      ]
+    },
+    "cilium.io/CiliumIdentity": {
+      "singular": "ciliumidentity",
+      "plural": "ciliumidentities",
+      "shortNames": [
+        "ciliumid"
+      ]
+    },
+    "cilium.io/CiliumL2AnnouncementPolicy": {
+      "singular": "ciliuml2announcementpolicy",
+      "plural": "ciliuml2announcementpolicies",
+      "shortNames": [
+        "l2announcement"
+      ]
+    },
+    "cilium.io/CiliumLoadBalancerIPPool": {
+      "singular": "ciliumloadbalancerippool",
+      "plural": "ciliumloadbalancerippools",
+      "shortNames": [
+        "ippools",
+        "ippool",
+        "lbippool",
+        "lbippools"
+      ]
+    },
+    "cilium.io/CiliumLocalRedirectPolicy": {
+      "singular": "ciliumlocalredirectpolicy",
+      "plural": "ciliumlocalredirectpolicies",
+      "shortNames": [
+        "clrp"
+      ]
+    },
+    "cilium.io/CiliumNetworkPolicy": {
+      "singular": "ciliumnetworkpolicy",
+      "plural": "ciliumnetworkpolicies",
+      "shortNames": [
+        "cnp",
+        "ciliumnp"
+      ]
+    },
+    "cilium.io/CiliumNode": {
+      "singular": "ciliumnode",
+      "plural": "ciliumnodes",
+      "shortNames": [
+        "cn",
+        "ciliumn"
+      ]
+    },
+    "cilium.io/CiliumNodeConfig": {
+      "singular": "ciliumnodeconfig",
+      "plural": "ciliumnodeconfigs"
+    },
+    "cilium.io/CiliumPodIPPool": {
+      "singular": "ciliumpodippool",
+      "plural": "ciliumpodippools",
+      "shortNames": [
+        "cpip"
+      ]
+    }
+  },
   "files": [
     "catalog/cilium.io/ciliumbgpadvertisement_v2.fields.txt",
     "catalog/cilium.io/ciliumbgpadvertisement_v2.json",

--- a/build/history/cloudnative-pg.json
+++ b/build/history/cloudnative-pg.json
@@ -2,8 +2,8 @@
   "name": "cloudnative-pg",
   "repo": "cloudnative-pg/cloudnative-pg",
   "version": "v1.30.0",
-  "builtAt": "2026-07-05T13:14:42.352Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:20.509Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "postgresql.cnpg.io/Backup",
     "postgresql.cnpg.io/Cluster",
@@ -17,6 +17,52 @@
     "postgresql.cnpg.io/ScheduledBackup",
     "postgresql.cnpg.io/Subscription"
   ],
+  "resources": {
+    "postgresql.cnpg.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "postgresql.cnpg.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "postgresql.cnpg.io/ClusterImageCatalog": {
+      "singular": "clusterimagecatalog",
+      "plural": "clusterimagecatalogs"
+    },
+    "postgresql.cnpg.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "postgresql.cnpg.io/DatabaseRole": {
+      "singular": "databaserole",
+      "plural": "databaseroles"
+    },
+    "postgresql.cnpg.io/FailoverQuorum": {
+      "singular": "failoverquorum",
+      "plural": "failoverquorums"
+    },
+    "postgresql.cnpg.io/ImageCatalog": {
+      "singular": "imagecatalog",
+      "plural": "imagecatalogs"
+    },
+    "postgresql.cnpg.io/Pooler": {
+      "singular": "pooler",
+      "plural": "poolers"
+    },
+    "postgresql.cnpg.io/Publication": {
+      "singular": "publication",
+      "plural": "publications"
+    },
+    "postgresql.cnpg.io/ScheduledBackup": {
+      "singular": "scheduledbackup",
+      "plural": "scheduledbackups"
+    },
+    "postgresql.cnpg.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    }
+  },
   "files": [
     "catalog/postgresql.cnpg.io/backup_v1.fields.txt",
     "catalog/postgresql.cnpg.io/backup_v1.json",

--- a/build/history/cluster-api-addon-provider-helm.json
+++ b/build/history/cluster-api-addon-provider-helm.json
@@ -2,12 +2,28 @@
   "name": "cluster-api-addon-provider-helm",
   "repo": "kubernetes-sigs/cluster-api-addon-provider-helm",
   "version": "v0.6.4",
-  "builtAt": "2026-07-05T18:03:04.119Z",
+  "builtAt": "2026-07-07T19:05:03.086Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "addons.cluster.x-k8s.io/HelmChartProxy",
     "addons.cluster.x-k8s.io/HelmReleaseProxy"
   ],
+  "resources": {
+    "addons.cluster.x-k8s.io/HelmChartProxy": {
+      "singular": "helmchartproxy",
+      "plural": "helmchartproxies",
+      "shortNames": [
+        "hcp"
+      ]
+    },
+    "addons.cluster.x-k8s.io/HelmReleaseProxy": {
+      "singular": "helmreleaseproxy",
+      "plural": "helmreleaseproxies",
+      "shortNames": [
+        "hrp"
+      ]
+    }
+  },
   "files": [
     "catalog/addons.cluster.x-k8s.io/helmchartproxy_v1alpha1.fields.txt",
     "catalog/addons.cluster.x-k8s.io/helmchartproxy_v1alpha1.json",

--- a/build/history/cluster-api-operator.json
+++ b/build/history/cluster-api-operator.json
@@ -2,7 +2,7 @@
   "name": "cluster-api-operator",
   "repo": "kubernetes-sigs/cluster-api-operator",
   "version": "v0.27.0",
-  "builtAt": "2026-07-05T18:02:14.597Z",
+  "builtAt": "2026-07-07T19:05:02.033Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "operator.cluster.x-k8s.io/AddonProvider",
@@ -13,6 +13,57 @@
     "operator.cluster.x-k8s.io/InfrastructureProvider",
     "operator.cluster.x-k8s.io/RuntimeExtensionProvider"
   ],
+  "resources": {
+    "operator.cluster.x-k8s.io/AddonProvider": {
+      "singular": "addonprovider",
+      "plural": "addonproviders",
+      "shortNames": [
+        "caap"
+      ]
+    },
+    "operator.cluster.x-k8s.io/BootstrapProvider": {
+      "singular": "bootstrapprovider",
+      "plural": "bootstrapproviders",
+      "shortNames": [
+        "cabp"
+      ]
+    },
+    "operator.cluster.x-k8s.io/ControlPlaneProvider": {
+      "singular": "controlplaneprovider",
+      "plural": "controlplaneproviders",
+      "shortNames": [
+        "cacpp"
+      ]
+    },
+    "operator.cluster.x-k8s.io/CoreProvider": {
+      "singular": "coreprovider",
+      "plural": "coreproviders",
+      "shortNames": [
+        "cacp"
+      ]
+    },
+    "operator.cluster.x-k8s.io/IPAMProvider": {
+      "singular": "ipamprovider",
+      "plural": "ipamproviders",
+      "shortNames": [
+        "caipamp"
+      ]
+    },
+    "operator.cluster.x-k8s.io/InfrastructureProvider": {
+      "singular": "infrastructureprovider",
+      "plural": "infrastructureproviders",
+      "shortNames": [
+        "caip"
+      ]
+    },
+    "operator.cluster.x-k8s.io/RuntimeExtensionProvider": {
+      "singular": "runtimeextensionprovider",
+      "plural": "runtimeextensionproviders",
+      "shortNames": [
+        "carep"
+      ]
+    }
+  },
   "files": [
     "catalog/operator.cluster.x-k8s.io/addonprovider_v1alpha2.fields.txt",
     "catalog/operator.cluster.x-k8s.io/addonprovider_v1alpha2.json",

--- a/build/history/cluster-api-provider-openstack.json
+++ b/build/history/cluster-api-provider-openstack.json
@@ -2,7 +2,7 @@
   "name": "cluster-api-provider-openstack",
   "repo": "kubernetes-sigs/cluster-api-provider-openstack",
   "version": "v0.14.6",
-  "builtAt": "2026-07-06T23:58:25.032Z",
+  "builtAt": "2026-07-07T19:05:05.017Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "infrastructure.cluster.x-k8s.io/OpenStackCluster",
@@ -13,6 +13,54 @@
     "infrastructure.cluster.x-k8s.io/OpenStackMachineTemplate",
     "infrastructure.cluster.x-k8s.io/OpenStackServer"
   ],
+  "resources": {
+    "infrastructure.cluster.x-k8s.io/OpenStackCluster": {
+      "singular": "openstackcluster",
+      "plural": "openstackclusters",
+      "shortNames": [
+        "osc"
+      ]
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackClusterIdentity": {
+      "singular": "openstackclusteridentity",
+      "plural": "openstackclusteridentities",
+      "shortNames": [
+        "osci"
+      ]
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackClusterTemplate": {
+      "singular": "openstackclustertemplate",
+      "plural": "openstackclustertemplates",
+      "shortNames": [
+        "osct"
+      ]
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackFloatingIPPool": {
+      "singular": "openstackfloatingippool",
+      "plural": "openstackfloatingippools"
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackMachine": {
+      "singular": "openstackmachine",
+      "plural": "openstackmachines",
+      "shortNames": [
+        "osm"
+      ]
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackMachineTemplate": {
+      "singular": "openstackmachinetemplate",
+      "plural": "openstackmachinetemplates",
+      "shortNames": [
+        "osmt"
+      ]
+    },
+    "infrastructure.cluster.x-k8s.io/OpenStackServer": {
+      "singular": "openstackserver",
+      "plural": "openstackservers",
+      "shortNames": [
+        "oss"
+      ]
+    }
+  },
   "files": [
     "catalog/infrastructure.cluster.x-k8s.io/openstackcluster_v1beta1.fields.txt",
     "catalog/infrastructure.cluster.x-k8s.io/openstackcluster_v1beta1.json",

--- a/build/history/cluster-api-provider-vsphere.json
+++ b/build/history/cluster-api-provider-vsphere.json
@@ -2,7 +2,7 @@
   "name": "cluster-api-provider-vsphere",
   "repo": "kubernetes-sigs/cluster-api-provider-vsphere",
   "version": "v1.16.1",
-  "builtAt": "2026-07-06T23:58:23.463Z",
+  "builtAt": "2026-07-07T19:05:03.972Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "infrastructure.cluster.x-k8s.io/VSphereCluster",
@@ -14,6 +14,40 @@
     "infrastructure.cluster.x-k8s.io/VSphereMachineTemplate",
     "infrastructure.cluster.x-k8s.io/VSphereVM"
   ],
+  "resources": {
+    "infrastructure.cluster.x-k8s.io/VSphereCluster": {
+      "singular": "vspherecluster",
+      "plural": "vsphereclusters"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereClusterIdentity": {
+      "singular": "vsphereclusteridentity",
+      "plural": "vsphereclusteridentities"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereClusterTemplate": {
+      "singular": "vsphereclustertemplate",
+      "plural": "vsphereclustertemplates"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereDeploymentZone": {
+      "singular": "vspheredeploymentzone",
+      "plural": "vspheredeploymentzones"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereFailureDomain": {
+      "singular": "vspherefailuredomain",
+      "plural": "vspherefailuredomains"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereMachine": {
+      "singular": "vspheremachine",
+      "plural": "vspheremachines"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereMachineTemplate": {
+      "singular": "vspheremachinetemplate",
+      "plural": "vspheremachinetemplates"
+    },
+    "infrastructure.cluster.x-k8s.io/VSphereVM": {
+      "singular": "vspherevm",
+      "plural": "vspherevms"
+    }
+  },
   "files": [
     "catalog/infrastructure.cluster.x-k8s.io/vspherecluster_v1beta1.fields.txt",
     "catalog/infrastructure.cluster.x-k8s.io/vspherecluster_v1beta1.json",

--- a/build/history/cluster-api.json
+++ b/build/history/cluster-api.json
@@ -2,8 +2,8 @@
   "name": "cluster-api",
   "repo": "kubernetes-sigs/cluster-api",
   "version": "v1.13.3",
-  "builtAt": "2026-07-05T09:08:53.018Z",
-  "fluxSchemaVersion": "0.7.0",
+  "builtAt": "2026-07-07T19:05:00.780Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "addons.cluster.x-k8s.io/ClusterResourceSet",
     "addons.cluster.x-k8s.io/ClusterResourceSetBinding",
@@ -23,6 +23,104 @@
     "ipam.cluster.x-k8s.io/IPAddressClaim",
     "runtime.cluster.x-k8s.io/ExtensionConfig"
   ],
+  "resources": {
+    "addons.cluster.x-k8s.io/ClusterResourceSet": {
+      "singular": "clusterresourceset",
+      "plural": "clusterresourcesets"
+    },
+    "addons.cluster.x-k8s.io/ClusterResourceSetBinding": {
+      "singular": "clusterresourcesetbinding",
+      "plural": "clusterresourcesetbindings"
+    },
+    "bootstrap.cluster.x-k8s.io/KubeadmConfig": {
+      "singular": "kubeadmconfig",
+      "plural": "kubeadmconfigs"
+    },
+    "bootstrap.cluster.x-k8s.io/KubeadmConfigTemplate": {
+      "singular": "kubeadmconfigtemplate",
+      "plural": "kubeadmconfigtemplates"
+    },
+    "cluster.x-k8s.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters",
+      "shortNames": [
+        "cl"
+      ]
+    },
+    "cluster.x-k8s.io/ClusterClass": {
+      "singular": "clusterclass",
+      "plural": "clusterclasses",
+      "shortNames": [
+        "cc"
+      ]
+    },
+    "cluster.x-k8s.io/Machine": {
+      "singular": "machine",
+      "plural": "machines",
+      "shortNames": [
+        "ma"
+      ]
+    },
+    "cluster.x-k8s.io/MachineDeployment": {
+      "singular": "machinedeployment",
+      "plural": "machinedeployments",
+      "shortNames": [
+        "md"
+      ]
+    },
+    "cluster.x-k8s.io/MachineDrainRule": {
+      "singular": "machinedrainrule",
+      "plural": "machinedrainrules"
+    },
+    "cluster.x-k8s.io/MachineHealthCheck": {
+      "singular": "machinehealthcheck",
+      "plural": "machinehealthchecks",
+      "shortNames": [
+        "mhc",
+        "mhcs"
+      ]
+    },
+    "cluster.x-k8s.io/MachinePool": {
+      "singular": "machinepool",
+      "plural": "machinepools",
+      "shortNames": [
+        "mp"
+      ]
+    },
+    "cluster.x-k8s.io/MachineSet": {
+      "singular": "machineset",
+      "plural": "machinesets",
+      "shortNames": [
+        "ms"
+      ]
+    },
+    "controlplane.cluster.x-k8s.io/KubeadmControlPlane": {
+      "singular": "kubeadmcontrolplane",
+      "plural": "kubeadmcontrolplanes",
+      "shortNames": [
+        "kcp"
+      ]
+    },
+    "controlplane.cluster.x-k8s.io/KubeadmControlPlaneTemplate": {
+      "singular": "kubeadmcontrolplanetemplate",
+      "plural": "kubeadmcontrolplanetemplates"
+    },
+    "ipam.cluster.x-k8s.io/IPAddress": {
+      "singular": "ipaddress",
+      "plural": "ipaddresses"
+    },
+    "ipam.cluster.x-k8s.io/IPAddressClaim": {
+      "singular": "ipaddressclaim",
+      "plural": "ipaddressclaims"
+    },
+    "runtime.cluster.x-k8s.io/ExtensionConfig": {
+      "singular": "extensionconfig",
+      "plural": "extensionconfigs",
+      "shortNames": [
+        "ext"
+      ]
+    }
+  },
   "files": [
     "catalog/addons.cluster.x-k8s.io/clusterresourceset_v1beta1.fields.txt",
     "catalog/addons.cluster.x-k8s.io/clusterresourceset_v1beta1.json",

--- a/build/history/config-connector.json
+++ b/build/history/config-connector.json
@@ -2,7 +2,7 @@
   "name": "config-connector",
   "repo": "GoogleCloudPlatform/k8s-config-connector",
   "version": "v1.153.0",
-  "builtAt": "2026-07-07T07:24:37.571Z",
+  "builtAt": "2026-07-07T19:10:07.014Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerAccessLevel",
@@ -516,6 +516,4086 @@
     "workstations.cnrm.cloud.google.com/WorkstationCluster",
     "workstations.cnrm.cloud.google.com/WorkstationConfig"
   ],
+  "resources": {
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerAccessLevel": {
+      "singular": "accesscontextmanageraccesslevel",
+      "plural": "accesscontextmanageraccesslevels",
+      "shortNames": [
+        "gcpaccesscontextmanageraccesslevel",
+        "gcpaccesscontextmanageraccesslevels"
+      ]
+    },
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerAccessLevelCondition": {
+      "singular": "accesscontextmanageraccesslevelcondition",
+      "plural": "accesscontextmanageraccesslevelconditions",
+      "shortNames": [
+        "gcpaccesscontextmanageraccesslevelcondition",
+        "gcpaccesscontextmanageraccesslevelconditions"
+      ]
+    },
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerAccessPolicy": {
+      "singular": "accesscontextmanageraccesspolicy",
+      "plural": "accesscontextmanageraccesspolicies",
+      "shortNames": [
+        "gcpaccesscontextmanageraccesspolicy",
+        "gcpaccesscontextmanageraccesspolicies"
+      ]
+    },
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerGCPUserAccessBinding": {
+      "singular": "accesscontextmanagergcpuseraccessbinding",
+      "plural": "accesscontextmanagergcpuseraccessbindings",
+      "shortNames": [
+        "gcpaccesscontextmanagergcpuseraccessbinding",
+        "gcpaccesscontextmanagergcpuseraccessbindings"
+      ]
+    },
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerServicePerimeter": {
+      "singular": "accesscontextmanagerserviceperimeter",
+      "plural": "accesscontextmanagerserviceperimeters",
+      "shortNames": [
+        "gcpaccesscontextmanagerserviceperimeter",
+        "gcpaccesscontextmanagerserviceperimeters"
+      ]
+    },
+    "accesscontextmanager.cnrm.cloud.google.com/AccessContextManagerServicePerimeterResource": {
+      "singular": "accesscontextmanagerserviceperimeterresource",
+      "plural": "accesscontextmanagerserviceperimeterresources",
+      "shortNames": [
+        "gcpaccesscontextmanagerserviceperimeterresource",
+        "gcpaccesscontextmanagerserviceperimeterresources"
+      ]
+    },
+    "aiplatform.cnrm.cloud.google.com/AIPlatformModel": {
+      "singular": "aiplatformmodel",
+      "plural": "aiplatformmodels",
+      "shortNames": [
+        "gcpaiplatformmodel",
+        "gcpaiplatformmodels"
+      ]
+    },
+    "aistreams.cnrm.cloud.google.com/AIStreamsCluster": {
+      "singular": "aistreamscluster",
+      "plural": "aistreamsclusters",
+      "shortNames": [
+        "gcpaistreamscluster",
+        "gcpaistreamsclusters"
+      ]
+    },
+    "alloydb.cnrm.cloud.google.com/AlloyDBBackup": {
+      "singular": "alloydbbackup",
+      "plural": "alloydbbackups",
+      "shortNames": [
+        "gcpalloydbbackup",
+        "gcpalloydbbackups"
+      ]
+    },
+    "alloydb.cnrm.cloud.google.com/AlloyDBCluster": {
+      "singular": "alloydbcluster",
+      "plural": "alloydbclusters",
+      "shortNames": [
+        "gcpalloydbcluster",
+        "gcpalloydbclusters"
+      ]
+    },
+    "alloydb.cnrm.cloud.google.com/AlloyDBInstance": {
+      "singular": "alloydbinstance",
+      "plural": "alloydbinstances",
+      "shortNames": [
+        "gcpalloydbinstance",
+        "gcpalloydbinstances"
+      ]
+    },
+    "alloydb.cnrm.cloud.google.com/AlloyDBUser": {
+      "singular": "alloydbuser",
+      "plural": "alloydbusers",
+      "shortNames": [
+        "gcpalloydbuser",
+        "gcpalloydbusers"
+      ]
+    },
+    "analytics.cnrm.cloud.google.com/AnalyticsAccount": {
+      "singular": "analyticsaccount",
+      "plural": "analyticsaccounts",
+      "shortNames": [
+        "gcpanalyticsaccount",
+        "gcpanalyticsaccounts"
+      ]
+    },
+    "apigateway.cnrm.cloud.google.com/APIGatewayAPI": {
+      "singular": "apigatewayapi",
+      "plural": "apigatewayapis",
+      "shortNames": [
+        "gcpapigatewayapi",
+        "gcpapigatewayapis"
+      ]
+    },
+    "apigateway.cnrm.cloud.google.com/APIGatewayAPIConfig": {
+      "singular": "apigatewayapiconfig",
+      "plural": "apigatewayapiconfigs",
+      "shortNames": [
+        "gcpapigatewayapiconfig",
+        "gcpapigatewayapiconfigs"
+      ]
+    },
+    "apigateway.cnrm.cloud.google.com/APIGatewayGateway": {
+      "singular": "apigatewaygateway",
+      "plural": "apigatewaygateways",
+      "shortNames": [
+        "gcpapigatewaygateway",
+        "gcpapigatewaygateways"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeAddonsConfig": {
+      "singular": "apigeeaddonsconfig",
+      "plural": "apigeeaddonsconfigs",
+      "shortNames": [
+        "gcpapigeeaddonsconfig",
+        "gcpapigeeaddonsconfigs"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeEndpointAttachment": {
+      "singular": "apigeeendpointattachment",
+      "plural": "apigeeendpointattachments",
+      "shortNames": [
+        "gcpapigeeendpointattachment",
+        "gcpapigeeendpointattachments"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeEnvgroup": {
+      "singular": "apigeeenvgroup",
+      "plural": "apigeeenvgroups",
+      "shortNames": [
+        "gcpapigeeenvgroup",
+        "gcpapigeeenvgroups"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeEnvgroupAttachment": {
+      "singular": "apigeeenvgroupattachment",
+      "plural": "apigeeenvgroupattachments",
+      "shortNames": [
+        "gcpapigeeenvgroupattachment",
+        "gcpapigeeenvgroupattachments"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeEnvironment": {
+      "singular": "apigeeenvironment",
+      "plural": "apigeeenvironments",
+      "shortNames": [
+        "gcpapigeeenvironment",
+        "gcpapigeeenvironments"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeInstance": {
+      "singular": "apigeeinstance",
+      "plural": "apigeeinstances",
+      "shortNames": [
+        "gcpapigeeinstance",
+        "gcpapigeeinstances"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeInstanceAttachment": {
+      "singular": "apigeeinstanceattachment",
+      "plural": "apigeeinstanceattachments",
+      "shortNames": [
+        "gcpapigeeinstanceattachment",
+        "gcpapigeeinstanceattachments"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeNATAddress": {
+      "singular": "apigeenataddress",
+      "plural": "apigeenataddresses",
+      "shortNames": [
+        "gcpapigeenataddress",
+        "gcpapigeenataddresses"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeOrganization": {
+      "singular": "apigeeorganization",
+      "plural": "apigeeorganizations",
+      "shortNames": [
+        "gcpapigeeorganization",
+        "gcpapigeeorganizations"
+      ]
+    },
+    "apigee.cnrm.cloud.google.com/ApigeeSyncAuthorization": {
+      "singular": "apigeesyncauthorization",
+      "plural": "apigeesyncauthorizations",
+      "shortNames": [
+        "gcpapigeesyncauthorization",
+        "gcpapigeesyncauthorizations"
+      ]
+    },
+    "apigeeregistry.cnrm.cloud.google.com/ApigeeRegistryInstance": {
+      "singular": "apigeeregistryinstance",
+      "plural": "apigeeregistryinstances",
+      "shortNames": [
+        "gcpapigeeregistryinstance",
+        "gcpapigeeregistryinstances"
+      ]
+    },
+    "apihub.cnrm.cloud.google.com/APIHubAPI": {
+      "singular": "apihubapi",
+      "plural": "apihubapis",
+      "shortNames": [
+        "gcpapihubapi",
+        "gcpapihubapis"
+      ]
+    },
+    "apihub.cnrm.cloud.google.com/APIHubDeployment": {
+      "singular": "apihubdeployment",
+      "plural": "apihubdeployments",
+      "shortNames": [
+        "gcpapihubdeployment",
+        "gcpapihubdeployments"
+      ]
+    },
+    "apihub.cnrm.cloud.google.com/APIHubPlugin": {
+      "singular": "apihubplugin",
+      "plural": "apihubplugins",
+      "shortNames": [
+        "gcpapihubplugin",
+        "gcpapihubplugins"
+      ]
+    },
+    "apihub.cnrm.cloud.google.com/APIHubRuntimeProjectAttachment": {
+      "singular": "apihubruntimeprojectattachment",
+      "plural": "apihubruntimeprojectattachments",
+      "shortNames": [
+        "gcpapihubruntimeprojectattachment",
+        "gcpapihubruntimeprojectattachments"
+      ]
+    },
+    "apikeys.cnrm.cloud.google.com/APIKeysKey": {
+      "singular": "apikeyskey",
+      "plural": "apikeyskeys",
+      "shortNames": [
+        "gcpapikeyskey",
+        "gcpapikeyskeys"
+      ]
+    },
+    "appengine.cnrm.cloud.google.com/AppEngineDomainMapping": {
+      "singular": "appenginedomainmapping",
+      "plural": "appenginedomainmappings",
+      "shortNames": [
+        "gcpappenginedomainmapping",
+        "gcpappenginedomainmappings"
+      ]
+    },
+    "appengine.cnrm.cloud.google.com/AppEngineFirewallRule": {
+      "singular": "appenginefirewallrule",
+      "plural": "appenginefirewallrules",
+      "shortNames": [
+        "gcpappenginefirewallrule",
+        "gcpappenginefirewallrules"
+      ]
+    },
+    "appengine.cnrm.cloud.google.com/AppEngineFlexibleAppVersion": {
+      "singular": "appengineflexibleappversion",
+      "plural": "appengineflexibleappversions",
+      "shortNames": [
+        "gcpappengineflexibleappversion",
+        "gcpappengineflexibleappversions"
+      ]
+    },
+    "appengine.cnrm.cloud.google.com/AppEngineServiceSplitTraffic": {
+      "singular": "appengineservicesplittraffic",
+      "plural": "appengineservicesplittraffics",
+      "shortNames": [
+        "gcpappengineservicesplittraffic",
+        "gcpappengineservicesplittraffics"
+      ]
+    },
+    "appengine.cnrm.cloud.google.com/AppEngineStandardAppVersion": {
+      "singular": "appenginestandardappversion",
+      "plural": "appenginestandardappversions",
+      "shortNames": [
+        "gcpappenginestandardappversion",
+        "gcpappenginestandardappversions"
+      ]
+    },
+    "apphub.cnrm.cloud.google.com/AppHubApplication": {
+      "singular": "apphubapplication",
+      "plural": "apphubapplications",
+      "shortNames": [
+        "gcpapphubapplication",
+        "gcpapphubapplications"
+      ]
+    },
+    "apphub.cnrm.cloud.google.com/AppHubDiscoveredService": {
+      "singular": "apphubdiscoveredservice",
+      "plural": "apphubdiscoveredservices",
+      "shortNames": [
+        "gcpapphubdiscoveredservice",
+        "gcpapphubdiscoveredservices"
+      ]
+    },
+    "apphub.cnrm.cloud.google.com/AppHubDiscoveredWorkload": {
+      "singular": "apphubdiscoveredworkload",
+      "plural": "apphubdiscoveredworkloads",
+      "shortNames": [
+        "gcpapphubdiscoveredworkload",
+        "gcpapphubdiscoveredworkloads"
+      ]
+    },
+    "apphub.cnrm.cloud.google.com/AppHubServiceProjectAttachment": {
+      "singular": "apphubserviceprojectattachment",
+      "plural": "apphubserviceprojectattachments",
+      "shortNames": [
+        "gcpapphubserviceprojectattachment",
+        "gcpapphubserviceprojectattachments"
+      ]
+    },
+    "artifactregistry.cnrm.cloud.google.com/ArtifactRegistryRepository": {
+      "singular": "artifactregistryrepository",
+      "plural": "artifactregistryrepositories",
+      "shortNames": [
+        "gcpartifactregistryrepository",
+        "gcpartifactregistryrepositories"
+      ]
+    },
+    "asset.cnrm.cloud.google.com/AssetFeed": {
+      "singular": "assetfeed",
+      "plural": "assetfeeds",
+      "shortNames": [
+        "gcpassetfeed",
+        "gcpassetfeeds"
+      ]
+    },
+    "asset.cnrm.cloud.google.com/AssetSavedQuery": {
+      "singular": "assetsavedquery",
+      "plural": "assetsavedqueries",
+      "shortNames": [
+        "gcpassetsavedquery",
+        "gcpassetsavedqueries"
+      ]
+    },
+    "assuredworkloads.cnrm.cloud.google.com/AssuredWorkloadsWorkload": {
+      "singular": "assuredworkloadsworkload",
+      "plural": "assuredworkloadsworkloads",
+      "shortNames": [
+        "gcpassuredworkloadsworkload",
+        "gcpassuredworkloadsworkloads"
+      ]
+    },
+    "automl.cnrm.cloud.google.com/AutoMLDataset": {
+      "singular": "automldataset",
+      "plural": "automldatasets",
+      "shortNames": [
+        "gcpautomldataset",
+        "gcpautomldatasets"
+      ]
+    },
+    "backupdr.cnrm.cloud.google.com/BackupDRBackupPlan": {
+      "singular": "backupdrbackupplan",
+      "plural": "backupdrbackupplans",
+      "shortNames": [
+        "gcpbackupdrbackupplan",
+        "gcpbackupdrbackupplans"
+      ]
+    },
+    "backupdr.cnrm.cloud.google.com/BackupDRBackupPlanAssociation": {
+      "singular": "backupdrbackupplanassociation",
+      "plural": "backupdrbackupplanassociations",
+      "shortNames": [
+        "gcpbackupdrbackupplanassociation",
+        "gcpbackupdrbackupplanassociations"
+      ]
+    },
+    "backupdr.cnrm.cloud.google.com/BackupDRBackupVault": {
+      "singular": "backupdrbackupvault",
+      "plural": "backupdrbackupvaults",
+      "shortNames": [
+        "gcpbackupdrbackupvault",
+        "gcpbackupdrbackupvaults"
+      ]
+    },
+    "backupdr.cnrm.cloud.google.com/BackupDRManagementServer": {
+      "singular": "backupdrmanagementserver",
+      "plural": "backupdrmanagementservers",
+      "shortNames": [
+        "gcpbackupdrmanagementserver",
+        "gcpbackupdrmanagementservers"
+      ]
+    },
+    "batch.cnrm.cloud.google.com/BatchJob": {
+      "singular": "batchjob",
+      "plural": "batchjobs",
+      "shortNames": [
+        "gcpbatchjob",
+        "gcpbatchjobs"
+      ]
+    },
+    "batch.cnrm.cloud.google.com/BatchTask": {
+      "singular": "batchtask",
+      "plural": "batchtasks",
+      "shortNames": [
+        "gcpbatchtask",
+        "gcpbatchtasks"
+      ]
+    },
+    "batch.cnrm.cloud.google.com/CloudBatchResourceAllowance": {
+      "singular": "cloudbatchresourceallowance",
+      "plural": "cloudbatchresourceallowances",
+      "shortNames": [
+        "gcpcloudbatchresourceallowance",
+        "gcpcloudbatchresourceallowances"
+      ]
+    },
+    "beyondcorp.cnrm.cloud.google.com/BeyondCorpAppConnection": {
+      "singular": "beyondcorpappconnection",
+      "plural": "beyondcorpappconnections",
+      "shortNames": [
+        "gcpbeyondcorpappconnection",
+        "gcpbeyondcorpappconnections"
+      ]
+    },
+    "beyondcorp.cnrm.cloud.google.com/BeyondCorpAppConnector": {
+      "singular": "beyondcorpappconnector",
+      "plural": "beyondcorpappconnectors",
+      "shortNames": [
+        "gcpbeyondcorpappconnector",
+        "gcpbeyondcorpappconnectors"
+      ]
+    },
+    "beyondcorp.cnrm.cloud.google.com/BeyondCorpAppGateway": {
+      "singular": "beyondcorpappgateway",
+      "plural": "beyondcorpappgateways",
+      "shortNames": [
+        "gcpbeyondcorpappgateway",
+        "gcpbeyondcorpappgateways"
+      ]
+    },
+    "beyondcorp.cnrm.cloud.google.com/BeyondCorpClientConnectorService": {
+      "singular": "beyondcorpclientconnectorservice",
+      "plural": "beyondcorpclientconnectorservices",
+      "shortNames": [
+        "gcpbeyondcorpclientconnectorservice",
+        "gcpbeyondcorpclientconnectorservices"
+      ]
+    },
+    "beyondcorp.cnrm.cloud.google.com/BeyondCorpClientGateway": {
+      "singular": "beyondcorpclientgateway",
+      "plural": "beyondcorpclientgateways",
+      "shortNames": [
+        "gcpbeyondcorpclientgateway",
+        "gcpbeyondcorpclientgateways"
+      ]
+    },
+    "bigquery.cnrm.cloud.google.com/BigQueryDataset": {
+      "singular": "bigquerydataset",
+      "plural": "bigquerydatasets",
+      "shortNames": [
+        "gcpbigquerydataset",
+        "gcpbigquerydatasets"
+      ]
+    },
+    "bigquery.cnrm.cloud.google.com/BigQueryDatasetAccess": {
+      "singular": "bigquerydatasetaccess",
+      "plural": "bigquerydatasetaccesses",
+      "shortNames": [
+        "gcpbigquerydatasetaccess",
+        "gcpbigquerydatasetaccesses"
+      ]
+    },
+    "bigquery.cnrm.cloud.google.com/BigQueryJob": {
+      "singular": "bigqueryjob",
+      "plural": "bigqueryjobs",
+      "shortNames": [
+        "gcpbigqueryjob",
+        "gcpbigqueryjobs"
+      ]
+    },
+    "bigquery.cnrm.cloud.google.com/BigQueryRoutine": {
+      "singular": "bigqueryroutine",
+      "plural": "bigqueryroutines",
+      "shortNames": [
+        "gcpbigqueryroutine",
+        "gcpbigqueryroutines"
+      ]
+    },
+    "bigquery.cnrm.cloud.google.com/BigQueryTable": {
+      "singular": "bigquerytable",
+      "plural": "bigquerytables",
+      "shortNames": [
+        "gcpbigquerytable",
+        "gcpbigquerytables"
+      ]
+    },
+    "bigqueryanalyticshub.cnrm.cloud.google.com/BigQueryAnalyticsHubDataExchange": {
+      "singular": "bigqueryanalyticshubdataexchange",
+      "plural": "bigqueryanalyticshubdataexchanges",
+      "shortNames": [
+        "gcpbigqueryanalyticshubdataexchange",
+        "gcpbigqueryanalyticshubdataexchanges"
+      ]
+    },
+    "bigqueryanalyticshub.cnrm.cloud.google.com/BigQueryAnalyticsHubListing": {
+      "singular": "bigqueryanalyticshublisting",
+      "plural": "bigqueryanalyticshublistings",
+      "shortNames": [
+        "gcpbigqueryanalyticshublisting",
+        "gcpbigqueryanalyticshublistings"
+      ]
+    },
+    "bigquerybiglake.cnrm.cloud.google.com/BigLakeCatalog": {
+      "singular": "biglakecatalog",
+      "plural": "biglakecatalogs",
+      "shortNames": [
+        "gcpbiglakecatalog",
+        "gcpbiglakecatalogs"
+      ]
+    },
+    "bigquerybiglake.cnrm.cloud.google.com/BigLakeDatabase": {
+      "singular": "biglakedatabase",
+      "plural": "biglakedatabases",
+      "shortNames": [
+        "gcpbiglakedatabase",
+        "gcpbiglakedatabases"
+      ]
+    },
+    "bigquerybiglake.cnrm.cloud.google.com/BigLakeTable": {
+      "singular": "biglaketable",
+      "plural": "biglaketables",
+      "shortNames": [
+        "gcpbiglaketable",
+        "gcpbiglaketables"
+      ]
+    },
+    "bigqueryconnection.cnrm.cloud.google.com/BigQueryConnectionConnection": {
+      "singular": "bigqueryconnectionconnection",
+      "plural": "bigqueryconnectionconnections",
+      "shortNames": [
+        "gcpbigqueryconnectionconnection",
+        "gcpbigqueryconnectionconnections"
+      ]
+    },
+    "bigquerydatapolicy.cnrm.cloud.google.com/BigQueryDataPolicy": {
+      "singular": "bigquerydatapolicy",
+      "plural": "bigquerydatapolicies",
+      "shortNames": [
+        "gcpbigquerydatapolicy",
+        "gcpbigquerydatapolicies"
+      ]
+    },
+    "bigquerydatapolicy.cnrm.cloud.google.com/BigQueryDataPolicyDataPolicy": {
+      "singular": "bigquerydatapolicydatapolicy",
+      "plural": "bigquerydatapolicydatapolicies",
+      "shortNames": [
+        "gcpbigquerydatapolicydatapolicy",
+        "gcpbigquerydatapolicydatapolicies"
+      ]
+    },
+    "bigquerydatatransfer.cnrm.cloud.google.com/BigQueryDataTransferConfig": {
+      "singular": "bigquerydatatransferconfig",
+      "plural": "bigquerydatatransferconfigs",
+      "shortNames": [
+        "gcpbigquerydatatransferconfig",
+        "gcpbigquerydatatransferconfigs"
+      ]
+    },
+    "bigqueryreservation.cnrm.cloud.google.com/BigQueryReservationAssignment": {
+      "singular": "bigqueryreservationassignment",
+      "plural": "bigqueryreservationassignments",
+      "shortNames": [
+        "gcpbigqueryreservationassignment",
+        "gcpbigqueryreservationassignments"
+      ]
+    },
+    "bigqueryreservation.cnrm.cloud.google.com/BigQueryReservationCapacityCommitment": {
+      "singular": "bigqueryreservationcapacitycommitment",
+      "plural": "bigqueryreservationcapacitycommitments",
+      "shortNames": [
+        "gcpbigqueryreservationcapacitycommitment",
+        "gcpbigqueryreservationcapacitycommitments"
+      ]
+    },
+    "bigqueryreservation.cnrm.cloud.google.com/BigQueryReservationReservation": {
+      "singular": "bigqueryreservationreservation",
+      "plural": "bigqueryreservationreservations",
+      "shortNames": [
+        "gcpbigqueryreservationreservation",
+        "gcpbigqueryreservationreservations"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableAppProfile": {
+      "singular": "bigtableappprofile",
+      "plural": "bigtableappprofiles",
+      "shortNames": [
+        "gcpbigtableappprofile",
+        "gcpbigtableappprofiles"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableAuthorizedView": {
+      "singular": "bigtableauthorizedview",
+      "plural": "bigtableauthorizedviews",
+      "shortNames": [
+        "gcpbigtableauthorizedview",
+        "gcpbigtableauthorizedviews"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableBackup": {
+      "singular": "bigtablebackup",
+      "plural": "bigtablebackups",
+      "shortNames": [
+        "gcpbigtablebackup",
+        "gcpbigtablebackups"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableCluster": {
+      "singular": "bigtablecluster",
+      "plural": "bigtableclusters",
+      "shortNames": [
+        "gcpbigtablecluster",
+        "gcpbigtableclusters"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableGCPolicy": {
+      "singular": "bigtablegcpolicy",
+      "plural": "bigtablegcpolicies",
+      "shortNames": [
+        "gcpbigtablegcpolicy",
+        "gcpbigtablegcpolicies"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableInstance": {
+      "singular": "bigtableinstance",
+      "plural": "bigtableinstances",
+      "shortNames": [
+        "gcpbigtableinstance",
+        "gcpbigtableinstances"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableLogicalView": {
+      "singular": "bigtablelogicalview",
+      "plural": "bigtablelogicalviews",
+      "shortNames": [
+        "gcpbigtablelogicalview",
+        "gcpbigtablelogicalviews"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableMaterializedView": {
+      "singular": "bigtablematerializedview",
+      "plural": "bigtablematerializedviews",
+      "shortNames": [
+        "gcpbigtablematerializedview",
+        "gcpbigtablematerializedviews"
+      ]
+    },
+    "bigtable.cnrm.cloud.google.com/BigtableTable": {
+      "singular": "bigtabletable",
+      "plural": "bigtabletables",
+      "shortNames": [
+        "gcpbigtabletable",
+        "gcpbigtabletables"
+      ]
+    },
+    "billing.cnrm.cloud.google.com/BillingAccount": {
+      "singular": "billingaccount",
+      "plural": "billingaccounts",
+      "shortNames": [
+        "gcpbillingaccount",
+        "gcpbillingaccounts"
+      ]
+    },
+    "billingbudgets.cnrm.cloud.google.com/BillingBudgetsBudget": {
+      "singular": "billingbudgetsbudget",
+      "plural": "billingbudgetsbudgets",
+      "shortNames": [
+        "gcpbillingbudgetsbudget",
+        "gcpbillingbudgetsbudgets"
+      ]
+    },
+    "binaryauthorization.cnrm.cloud.google.com/BinaryAuthorizationAttestor": {
+      "singular": "binaryauthorizationattestor",
+      "plural": "binaryauthorizationattestors",
+      "shortNames": [
+        "gcpbinaryauthorizationattestor",
+        "gcpbinaryauthorizationattestors"
+      ]
+    },
+    "binaryauthorization.cnrm.cloud.google.com/BinaryAuthorizationPlatformPolicy": {
+      "singular": "binaryauthorizationplatformpolicy",
+      "plural": "binaryauthorizationplatformpolicies",
+      "shortNames": [
+        "gcpbinaryauthorizationplatformpolicy",
+        "gcpbinaryauthorizationplatformpolicies"
+      ]
+    },
+    "binaryauthorization.cnrm.cloud.google.com/BinaryAuthorizationPolicy": {
+      "singular": "binaryauthorizationpolicy",
+      "plural": "binaryauthorizationpolicies",
+      "shortNames": [
+        "gcpbinaryauthorizationpolicy",
+        "gcpbinaryauthorizationpolicies"
+      ]
+    },
+    "certificatemanager.cnrm.cloud.google.com/CertificateManagerCertificate": {
+      "singular": "certificatemanagercertificate",
+      "plural": "certificatemanagercertificates",
+      "shortNames": [
+        "gcpcertificatemanagercertificate",
+        "gcpcertificatemanagercertificates"
+      ]
+    },
+    "certificatemanager.cnrm.cloud.google.com/CertificateManagerCertificateIssuanceConfig": {
+      "singular": "certificatemanagercertificateissuanceconfig",
+      "plural": "certificatemanagercertificateissuanceconfigs",
+      "shortNames": [
+        "gcpcertificatemanagercertificateissuanceconfig",
+        "gcpcertificatemanagercertificateissuanceconfigs"
+      ]
+    },
+    "certificatemanager.cnrm.cloud.google.com/CertificateManagerCertificateMap": {
+      "singular": "certificatemanagercertificatemap",
+      "plural": "certificatemanagercertificatemaps",
+      "shortNames": [
+        "gcpcertificatemanagercertificatemap",
+        "gcpcertificatemanagercertificatemaps"
+      ]
+    },
+    "certificatemanager.cnrm.cloud.google.com/CertificateManagerCertificateMapEntry": {
+      "singular": "certificatemanagercertificatemapentry",
+      "plural": "certificatemanagercertificatemapentries",
+      "shortNames": [
+        "gcpcertificatemanagercertificatemapentry",
+        "gcpcertificatemanagercertificatemapentries"
+      ]
+    },
+    "certificatemanager.cnrm.cloud.google.com/CertificateManagerDNSAuthorization": {
+      "singular": "certificatemanagerdnsauthorization",
+      "plural": "certificatemanagerdnsauthorizations",
+      "shortNames": [
+        "gcpcertificatemanagerdnsauthorization",
+        "gcpcertificatemanagerdnsauthorizations"
+      ]
+    },
+    "cloudasset.cnrm.cloud.google.com/CloudAssetFolderFeed": {
+      "singular": "cloudassetfolderfeed",
+      "plural": "cloudassetfolderfeeds",
+      "shortNames": [
+        "gcpcloudassetfolderfeed",
+        "gcpcloudassetfolderfeeds"
+      ]
+    },
+    "cloudasset.cnrm.cloud.google.com/CloudAssetOrganizationFeed": {
+      "singular": "cloudassetorganizationfeed",
+      "plural": "cloudassetorganizationfeeds",
+      "shortNames": [
+        "gcpcloudassetorganizationfeed",
+        "gcpcloudassetorganizationfeeds"
+      ]
+    },
+    "cloudasset.cnrm.cloud.google.com/CloudAssetProjectFeed": {
+      "singular": "cloudassetprojectfeed",
+      "plural": "cloudassetprojectfeeds",
+      "shortNames": [
+        "gcpcloudassetprojectfeed",
+        "gcpcloudassetprojectfeeds"
+      ]
+    },
+    "cloudbuild.cnrm.cloud.google.com/CloudBuildTrigger": {
+      "singular": "cloudbuildtrigger",
+      "plural": "cloudbuildtriggers",
+      "shortNames": [
+        "gcpcloudbuildtrigger",
+        "gcpcloudbuildtriggers"
+      ]
+    },
+    "cloudbuild.cnrm.cloud.google.com/CloudBuildWorkerPool": {
+      "singular": "cloudbuildworkerpool",
+      "plural": "cloudbuildworkerpools",
+      "shortNames": [
+        "gcpcloudbuildworkerpool",
+        "gcpcloudbuildworkerpools"
+      ]
+    },
+    "clouddeploy.cnrm.cloud.google.com/CloudDeployAutomation": {
+      "singular": "clouddeployautomation",
+      "plural": "clouddeployautomations",
+      "shortNames": [
+        "gcpclouddeployautomation",
+        "gcpclouddeployautomations"
+      ]
+    },
+    "clouddeploy.cnrm.cloud.google.com/CloudDeployCustomTargetType": {
+      "singular": "clouddeploycustomtargettype",
+      "plural": "clouddeploycustomtargettypes",
+      "shortNames": [
+        "gcpclouddeploycustomtargettype",
+        "gcpclouddeploycustomtargettypes"
+      ]
+    },
+    "clouddeploy.cnrm.cloud.google.com/CloudDeployDeliveryPipeline": {
+      "singular": "clouddeploydeliverypipeline",
+      "plural": "clouddeploydeliverypipelines",
+      "shortNames": [
+        "gcpdeploydeliverypipeline",
+        "gcpdeploydeliverypipelines"
+      ]
+    },
+    "clouddeploy.cnrm.cloud.google.com/CloudDeployDeployPolicy": {
+      "singular": "clouddeploydeploypolicy",
+      "plural": "clouddeploydeploypolicies",
+      "shortNames": [
+        "gcpcodedeploydeploypolicy",
+        "gcpcodedeploydeploypolicies"
+      ]
+    },
+    "clouddeploy.cnrm.cloud.google.com/CloudDeployTarget": {
+      "singular": "clouddeploytarget",
+      "plural": "clouddeploytargets",
+      "shortNames": [
+        "gcpclouddeploytarget",
+        "gcpclouddeploytargets"
+      ]
+    },
+    "clouddms.cnrm.cloud.google.com/CloudDMSConversionWorkspace": {
+      "singular": "clouddmsconversionworkspace",
+      "plural": "clouddmsconversionworkspaces",
+      "shortNames": [
+        "gcpclouddmsconversionworkspace",
+        "gcpclouddmsconversionworkspaces"
+      ]
+    },
+    "clouddms.cnrm.cloud.google.com/CloudDMSMigrationJob": {
+      "singular": "clouddmsmigrationjob",
+      "plural": "clouddmsmigrationjobs",
+      "shortNames": [
+        "gcpclouddmsmigrationjob",
+        "gcpclouddmsmigrationjobs"
+      ]
+    },
+    "clouddms.cnrm.cloud.google.com/CloudDMSPrivateConnection": {
+      "singular": "clouddmsprivateconnection",
+      "plural": "clouddmsprivateconnections",
+      "shortNames": [
+        "gcpclouddmsprivateconnection",
+        "gcpclouddmsprivateconnections"
+      ]
+    },
+    "cloudfunctions.cnrm.cloud.google.com/CloudFunctionsFunction": {
+      "singular": "cloudfunctionsfunction",
+      "plural": "cloudfunctionsfunctions",
+      "shortNames": [
+        "gcpcloudfunctionsfunction",
+        "gcpcloudfunctionsfunctions"
+      ]
+    },
+    "cloudfunctions2.cnrm.cloud.google.com/CloudFunctions2Function": {
+      "singular": "cloudfunctions2function",
+      "plural": "cloudfunctions2functions",
+      "shortNames": [
+        "gcpcloudfunctions2function",
+        "gcpcloudfunctions2functions"
+      ]
+    },
+    "cloudidentity.cnrm.cloud.google.com/CloudIdentityGroup": {
+      "singular": "cloudidentitygroup",
+      "plural": "cloudidentitygroups",
+      "shortNames": [
+        "gcpcloudidentitygroup",
+        "gcpcloudidentitygroups"
+      ]
+    },
+    "cloudidentity.cnrm.cloud.google.com/CloudIdentityMembership": {
+      "singular": "cloudidentitymembership",
+      "plural": "cloudidentitymemberships",
+      "shortNames": [
+        "gcpcloudidentitymembership",
+        "gcpcloudidentitymemberships"
+      ]
+    },
+    "cloudids.cnrm.cloud.google.com/CloudIDSEndpoint": {
+      "singular": "cloudidsendpoint",
+      "plural": "cloudidsendpoints",
+      "shortNames": [
+        "gcpcloudidsendpoint",
+        "gcpcloudidsendpoints"
+      ]
+    },
+    "cloudiot.cnrm.cloud.google.com/CloudIOTDevice": {
+      "singular": "cloudiotdevice",
+      "plural": "cloudiotdevices",
+      "shortNames": [
+        "gcpcloudiotdevice",
+        "gcpcloudiotdevices"
+      ]
+    },
+    "cloudiot.cnrm.cloud.google.com/CloudIOTDeviceRegistry": {
+      "singular": "cloudiotdeviceregistry",
+      "plural": "cloudiotdeviceregistries",
+      "shortNames": [
+        "gcpcloudiotdeviceregistry",
+        "gcpcloudiotdeviceregistries"
+      ]
+    },
+    "cloudquota.cnrm.cloud.google.com/APIQuotaAdjusterSettings": {
+      "singular": "apiquotaadjustersettings",
+      "plural": "apiquotaadjustersettings",
+      "shortNames": [
+        "gcpapiquotaadjustersettings"
+      ]
+    },
+    "cloudquota.cnrm.cloud.google.com/APIQuotaPreference": {
+      "singular": "apiquotapreference",
+      "plural": "apiquotapreferences",
+      "shortNames": [
+        "gcpapiquotapreference",
+        "gcpapiquotapreferences"
+      ]
+    },
+    "cloudscheduler.cnrm.cloud.google.com/CloudSchedulerJob": {
+      "singular": "cloudschedulerjob",
+      "plural": "cloudschedulerjobs",
+      "shortNames": [
+        "gcpcloudschedulerjob",
+        "gcpcloudschedulerjobs"
+      ]
+    },
+    "cloudsecuritycompliance.cnrm.cloud.google.com/CloudSecurityComplianceCloudControl": {
+      "singular": "cloudsecuritycompliancecloudcontrol",
+      "plural": "cloudsecuritycompliancecloudcontrols",
+      "shortNames": [
+        "gcpcloudsecuritycompliancecloudcontrol",
+        "gcpcloudsecuritycompliancecloudcontrols"
+      ]
+    },
+    "cloudsecuritycompliance.cnrm.cloud.google.com/CloudSecurityComplianceFramework": {
+      "singular": "cloudsecuritycomplianceframework",
+      "plural": "cloudsecuritycomplianceframeworks",
+      "shortNames": [
+        "gcpcloudsecuritycomplianceframework",
+        "gcpcloudsecuritycomplianceframeworks"
+      ]
+    },
+    "cloudtasks.cnrm.cloud.google.com/TasksQueue": {
+      "singular": "tasksqueue",
+      "plural": "tasksqueues",
+      "shortNames": [
+        "gcptasksqueue",
+        "gcptasksqueues"
+      ]
+    },
+    "colab.cnrm.cloud.google.com/ColabRuntime": {
+      "singular": "colabruntime",
+      "plural": "colabruntimes",
+      "shortNames": [
+        "gcpcolabruntime",
+        "gcpcolabruntimes"
+      ]
+    },
+    "colab.cnrm.cloud.google.com/ColabRuntimeTemplate": {
+      "singular": "colabruntimetemplate",
+      "plural": "colabruntimetemplates",
+      "shortNames": [
+        "gcpcolabruntimetemplate",
+        "gcpcolabruntimetemplates"
+      ]
+    },
+    "composer.cnrm.cloud.google.com/ComposerEnvironment": {
+      "singular": "composerenvironment",
+      "plural": "composerenvironments",
+      "shortNames": [
+        "gcpcomposerenvironment",
+        "gcpcomposerenvironments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeAddress": {
+      "singular": "computeaddress",
+      "plural": "computeaddresses",
+      "shortNames": [
+        "gcpcomputeaddress",
+        "gcpcomputeaddresses"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeAutoscaler": {
+      "singular": "computeautoscaler",
+      "plural": "computeautoscalers",
+      "shortNames": [
+        "gcpcomputeautoscaler",
+        "gcpcomputeautoscalers"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeBackendBucket": {
+      "singular": "computebackendbucket",
+      "plural": "computebackendbuckets",
+      "shortNames": [
+        "gcpcomputebackendbucket",
+        "gcpcomputebackendbuckets"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeBackendBucketSignedURLKey": {
+      "singular": "computebackendbucketsignedurlkey",
+      "plural": "computebackendbucketsignedurlkeys",
+      "shortNames": [
+        "gcpcomputebackendbucketsignedurlkey",
+        "gcpcomputebackendbucketsignedurlkeys"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeBackendService": {
+      "singular": "computebackendservice",
+      "plural": "computebackendservices",
+      "shortNames": [
+        "gcpcomputebackendservice",
+        "gcpcomputebackendservices"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeBackendServiceSignedURLKey": {
+      "singular": "computebackendservicesignedurlkey",
+      "plural": "computebackendservicesignedurlkeys",
+      "shortNames": [
+        "gcpcomputebackendservicesignedurlkey",
+        "gcpcomputebackendservicesignedurlkeys"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeDisk": {
+      "singular": "computedisk",
+      "plural": "computedisks",
+      "shortNames": [
+        "gcpcomputedisk",
+        "gcpcomputedisks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeDiskResourcePolicyAttachment": {
+      "singular": "computediskresourcepolicyattachment",
+      "plural": "computediskresourcepolicyattachments",
+      "shortNames": [
+        "gcpcomputediskresourcepolicyattachment",
+        "gcpcomputediskresourcepolicyattachments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeExternalVPNGateway": {
+      "singular": "computeexternalvpngateway",
+      "plural": "computeexternalvpngateways",
+      "shortNames": [
+        "gcpcomputeexternalvpngateway",
+        "gcpcomputeexternalvpngateways"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeFirewall": {
+      "singular": "computefirewall",
+      "plural": "computefirewalls",
+      "shortNames": [
+        "gcpcomputefirewall",
+        "gcpcomputefirewalls"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeFirewallPolicy": {
+      "singular": "computefirewallpolicy",
+      "plural": "computefirewallpolicies",
+      "shortNames": [
+        "gcpcomputefirewallpolicy",
+        "gcpcomputefirewallpolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeFirewallPolicyAssociation": {
+      "singular": "computefirewallpolicyassociation",
+      "plural": "computefirewallpolicyassociations",
+      "shortNames": [
+        "gcpcomputefirewallpolicyassociation",
+        "gcpcomputefirewallpolicyassociations"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeFirewallPolicyRule": {
+      "singular": "computefirewallpolicyrule",
+      "plural": "computefirewallpolicyrules",
+      "shortNames": [
+        "gcpcomputefirewallpolicyrule",
+        "gcpcomputefirewallpolicyrules"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeForwardingRule": {
+      "singular": "computeforwardingrule",
+      "plural": "computeforwardingrules",
+      "shortNames": [
+        "gcpcomputeforwardingrule",
+        "gcpcomputeforwardingrules"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeFutureReservation": {
+      "singular": "computefuturereservation",
+      "plural": "computefuturereservations",
+      "shortNames": [
+        "gcpcomputefuturereservation",
+        "gcpcomputefuturereservations"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeGlobalNetworkEndpoint": {
+      "singular": "computeglobalnetworkendpoint",
+      "plural": "computeglobalnetworkendpoints",
+      "shortNames": [
+        "gcpcomputeglobalnetworkendpoint",
+        "gcpcomputeglobalnetworkendpoints"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeGlobalNetworkEndpointGroup": {
+      "singular": "computeglobalnetworkendpointgroup",
+      "plural": "computeglobalnetworkendpointgroups",
+      "shortNames": [
+        "gcpcomputeglobalnetworkendpointgroup",
+        "gcpcomputeglobalnetworkendpointgroups"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeHTTPHealthCheck": {
+      "singular": "computehttphealthcheck",
+      "plural": "computehttphealthchecks",
+      "shortNames": [
+        "gcpcomputehttphealthcheck",
+        "gcpcomputehttphealthchecks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeHTTPSHealthCheck": {
+      "singular": "computehttpshealthcheck",
+      "plural": "computehttpshealthchecks",
+      "shortNames": [
+        "gcpcomputehttpshealthcheck",
+        "gcpcomputehttpshealthchecks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeHealthCheck": {
+      "singular": "computehealthcheck",
+      "plural": "computehealthchecks",
+      "shortNames": [
+        "gcpcomputehealthcheck",
+        "gcpcomputehealthchecks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeImage": {
+      "singular": "computeimage",
+      "plural": "computeimages",
+      "shortNames": [
+        "gcpcomputeimage",
+        "gcpcomputeimages"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInstance": {
+      "singular": "computeinstance",
+      "plural": "computeinstances",
+      "shortNames": [
+        "gcpcomputeinstance",
+        "gcpcomputeinstances"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInstanceGroup": {
+      "singular": "computeinstancegroup",
+      "plural": "computeinstancegroups",
+      "shortNames": [
+        "gcpcomputeinstancegroup",
+        "gcpcomputeinstancegroups"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInstanceGroupManager": {
+      "singular": "computeinstancegroupmanager",
+      "plural": "computeinstancegroupmanagers",
+      "shortNames": [
+        "gcpcomputeinstancegroupmanager",
+        "gcpcomputeinstancegroupmanagers"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInstanceGroupNamedPort": {
+      "singular": "computeinstancegroupnamedport",
+      "plural": "computeinstancegroupnamedports",
+      "shortNames": [
+        "gcpcomputeinstancegroupnamedport",
+        "gcpcomputeinstancegroupnamedports"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInstanceTemplate": {
+      "singular": "computeinstancetemplate",
+      "plural": "computeinstancetemplates",
+      "shortNames": [
+        "gcpcomputeinstancetemplate",
+        "gcpcomputeinstancetemplates"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInterconnect": {
+      "singular": "computeinterconnect",
+      "plural": "computeinterconnects",
+      "shortNames": [
+        "gcpcomputeinterconnect",
+        "gcpcomputeinterconnects"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeInterconnectAttachment": {
+      "singular": "computeinterconnectattachment",
+      "plural": "computeinterconnectattachments",
+      "shortNames": [
+        "gcpcomputeinterconnectattachment",
+        "gcpcomputeinterconnectattachments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeMachineImage": {
+      "singular": "computemachineimage",
+      "plural": "computemachineimages",
+      "shortNames": [
+        "gcpcomputemachineimage",
+        "gcpcomputemachineimages"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeManagedSSLCertificate": {
+      "singular": "computemanagedsslcertificate",
+      "plural": "computemanagedsslcertificates",
+      "shortNames": [
+        "gcpcomputemanagedsslcertificate",
+        "gcpcomputemanagedsslcertificates"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetwork": {
+      "singular": "computenetwork",
+      "plural": "computenetworks",
+      "shortNames": [
+        "gcpcomputenetwork",
+        "gcpcomputenetworks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkAttachment": {
+      "singular": "computenetworkattachment",
+      "plural": "computenetworkattachments",
+      "shortNames": [
+        "gcpcomputenetworkattachment",
+        "gcpcomputenetworkattachments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkEdgeSecurityService": {
+      "singular": "computenetworkedgesecurityservice",
+      "plural": "computenetworkedgesecurityservices",
+      "shortNames": [
+        "gcpcomputenetworkedgesecurityservice",
+        "gcpcomputenetworkedgesecurityservices"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkEndpoint": {
+      "singular": "computenetworkendpoint",
+      "plural": "computenetworkendpoints",
+      "shortNames": [
+        "gcpcomputenetworkendpoint",
+        "gcpcomputenetworkendpoints"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkEndpointGroup": {
+      "singular": "computenetworkendpointgroup",
+      "plural": "computenetworkendpointgroups",
+      "shortNames": [
+        "gcpcomputenetworkendpointgroup",
+        "gcpcomputenetworkendpointgroups"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkFirewallPolicy": {
+      "singular": "computenetworkfirewallpolicy",
+      "plural": "computenetworkfirewallpolicies",
+      "shortNames": [
+        "gcpcomputenetworkfirewallpolicy",
+        "gcpcomputenetworkfirewallpolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkFirewallPolicyAssociation": {
+      "singular": "computenetworkfirewallpolicyassociation",
+      "plural": "computenetworkfirewallpolicyassociations",
+      "shortNames": [
+        "gcpcomputenetworkfirewallpolicyassociation",
+        "gcpcomputenetworkfirewallpolicyassociations"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkFirewallPolicyRule": {
+      "singular": "computenetworkfirewallpolicyrule",
+      "plural": "computenetworkfirewallpolicyrules",
+      "shortNames": [
+        "gcpcomputenetworkfirewallpolicyrule",
+        "gcpcomputenetworkfirewallpolicyrules"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkPeering": {
+      "singular": "computenetworkpeering",
+      "plural": "computenetworkpeerings",
+      "shortNames": [
+        "gcpcomputenetworkpeering",
+        "gcpcomputenetworkpeerings"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNetworkPeeringRoutesConfig": {
+      "singular": "computenetworkpeeringroutesconfig",
+      "plural": "computenetworkpeeringroutesconfigs",
+      "shortNames": [
+        "gcpcomputenetworkpeeringroutesconfig",
+        "gcpcomputenetworkpeeringroutesconfigs"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNodeGroup": {
+      "singular": "computenodegroup",
+      "plural": "computenodegroups",
+      "shortNames": [
+        "gcpcomputenodegroup",
+        "gcpcomputenodegroups"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeNodeTemplate": {
+      "singular": "computenodetemplate",
+      "plural": "computenodetemplates",
+      "shortNames": [
+        "gcpcomputenodetemplate",
+        "gcpcomputenodetemplates"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeOrganizationSecurityPolicy": {
+      "singular": "computeorganizationsecuritypolicy",
+      "plural": "computeorganizationsecuritypolicies",
+      "shortNames": [
+        "gcpcomputeorganizationsecuritypolicy",
+        "gcpcomputeorganizationsecuritypolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeOrganizationSecurityPolicyAssociation": {
+      "singular": "computeorganizationsecuritypolicyassociation",
+      "plural": "computeorganizationsecuritypolicyassociations",
+      "shortNames": [
+        "gcpcomputeorganizationsecuritypolicyassociation",
+        "gcpcomputeorganizationsecuritypolicyassociations"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeOrganizationSecurityPolicyRule": {
+      "singular": "computeorganizationsecuritypolicyrule",
+      "plural": "computeorganizationsecuritypolicyrules",
+      "shortNames": [
+        "gcpcomputeorganizationsecuritypolicyrule",
+        "gcpcomputeorganizationsecuritypolicyrules"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputePacketMirroring": {
+      "singular": "computepacketmirroring",
+      "plural": "computepacketmirrorings",
+      "shortNames": [
+        "gcpcomputepacketmirroring",
+        "gcpcomputepacketmirrorings"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputePerInstanceConfig": {
+      "singular": "computeperinstanceconfig",
+      "plural": "computeperinstanceconfigs",
+      "shortNames": [
+        "gcpcomputeperinstanceconfig",
+        "gcpcomputeperinstanceconfigs"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeProjectMetadata": {
+      "singular": "computeprojectmetadata",
+      "plural": "computeprojectmetadatas",
+      "shortNames": [
+        "gcpcomputeprojectmetadata",
+        "gcpcomputeprojectmetadatas"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRegionAutoscaler": {
+      "singular": "computeregionautoscaler",
+      "plural": "computeregionautoscalers",
+      "shortNames": [
+        "gcpcomputeregionautoscaler",
+        "gcpcomputeregionautoscalers"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRegionDiskResourcePolicyAttachment": {
+      "singular": "computeregiondiskresourcepolicyattachment",
+      "plural": "computeregiondiskresourcepolicyattachments",
+      "shortNames": [
+        "gcpcomputeregiondiskresourcepolicyattachment",
+        "gcpcomputeregiondiskresourcepolicyattachments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRegionNetworkEndpointGroup": {
+      "singular": "computeregionnetworkendpointgroup",
+      "plural": "computeregionnetworkendpointgroups",
+      "shortNames": [
+        "gcpcomputeregionnetworkendpointgroup",
+        "gcpcomputeregionnetworkendpointgroups"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRegionPerInstanceConfig": {
+      "singular": "computeregionperinstanceconfig",
+      "plural": "computeregionperinstanceconfigs",
+      "shortNames": [
+        "gcpcomputeregionperinstanceconfig",
+        "gcpcomputeregionperinstanceconfigs"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRegionSSLPolicy": {
+      "singular": "computeregionsslpolicy",
+      "plural": "computeregionsslpolicies",
+      "shortNames": [
+        "gcpcomputeregionsslpolicy",
+        "gcpcomputeregionsslpolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeReservation": {
+      "singular": "computereservation",
+      "plural": "computereservations",
+      "shortNames": [
+        "gcpcomputereservation",
+        "gcpcomputereservations"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeResourcePolicy": {
+      "singular": "computeresourcepolicy",
+      "plural": "computeresourcepolicies",
+      "shortNames": [
+        "gcpcomputeresourcepolicy",
+        "gcpcomputeresourcepolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRoute": {
+      "singular": "computeroute",
+      "plural": "computeroutes",
+      "shortNames": [
+        "gcpcomputeroute",
+        "gcpcomputeroutes"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRouter": {
+      "singular": "computerouter",
+      "plural": "computerouters",
+      "shortNames": [
+        "gcpcomputerouter",
+        "gcpcomputerouters"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRouterInterface": {
+      "singular": "computerouterinterface",
+      "plural": "computerouterinterfaces",
+      "shortNames": [
+        "gcpcomputerouterinterface",
+        "gcpcomputerouterinterfaces"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRouterNAT": {
+      "singular": "computerouternat",
+      "plural": "computerouternats",
+      "shortNames": [
+        "gcpcomputerouternat",
+        "gcpcomputerouternats"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeRouterPeer": {
+      "singular": "computerouterpeer",
+      "plural": "computerouterpeers",
+      "shortNames": [
+        "gcpcomputerouterpeer",
+        "gcpcomputerouterpeers"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSSLCertificate": {
+      "singular": "computesslcertificate",
+      "plural": "computesslcertificates",
+      "shortNames": [
+        "gcpcomputesslcertificate",
+        "gcpcomputesslcertificates"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSSLPolicy": {
+      "singular": "computesslpolicy",
+      "plural": "computesslpolicies",
+      "shortNames": [
+        "gcpcomputesslpolicy",
+        "gcpcomputesslpolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSecurityPolicy": {
+      "singular": "computesecuritypolicy",
+      "plural": "computesecuritypolicies",
+      "shortNames": [
+        "gcpcomputesecuritypolicy",
+        "gcpcomputesecuritypolicies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeServiceAttachment": {
+      "singular": "computeserviceattachment",
+      "plural": "computeserviceattachments",
+      "shortNames": [
+        "gcpcomputeserviceattachment",
+        "gcpcomputeserviceattachments"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSharedVPCHostProject": {
+      "singular": "computesharedvpchostproject",
+      "plural": "computesharedvpchostprojects",
+      "shortNames": [
+        "gcpcomputesharedvpchostproject",
+        "gcpcomputesharedvpchostprojects"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSharedVPCServiceProject": {
+      "singular": "computesharedvpcserviceproject",
+      "plural": "computesharedvpcserviceprojects",
+      "shortNames": [
+        "gcpcomputesharedvpcserviceproject",
+        "gcpcomputesharedvpcserviceprojects"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSnapshot": {
+      "singular": "computesnapshot",
+      "plural": "computesnapshots",
+      "shortNames": [
+        "gcpcomputesnapshot",
+        "gcpcomputesnapshots"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeSubnetwork": {
+      "singular": "computesubnetwork",
+      "plural": "computesubnetworks",
+      "shortNames": [
+        "gcpcomputesubnetwork",
+        "gcpcomputesubnetworks"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetGRPCProxy": {
+      "singular": "computetargetgrpcproxy",
+      "plural": "computetargetgrpcproxies",
+      "shortNames": [
+        "gcpcomputetargetgrpcproxy",
+        "gcpcomputetargetgrpcproxies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetHTTPProxy": {
+      "singular": "computetargethttpproxy",
+      "plural": "computetargethttpproxies",
+      "shortNames": [
+        "gcpcomputetargethttpproxy",
+        "gcpcomputetargethttpproxies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetHTTPSProxy": {
+      "singular": "computetargethttpsproxy",
+      "plural": "computetargethttpsproxies",
+      "shortNames": [
+        "gcpcomputetargethttpsproxy",
+        "gcpcomputetargethttpsproxies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetInstance": {
+      "singular": "computetargetinstance",
+      "plural": "computetargetinstances",
+      "shortNames": [
+        "gcpcomputetargetinstance",
+        "gcpcomputetargetinstances"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetPool": {
+      "singular": "computetargetpool",
+      "plural": "computetargetpools",
+      "shortNames": [
+        "gcpcomputetargetpool",
+        "gcpcomputetargetpools"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetSSLProxy": {
+      "singular": "computetargetsslproxy",
+      "plural": "computetargetsslproxies",
+      "shortNames": [
+        "gcpcomputetargetsslproxy",
+        "gcpcomputetargetsslproxies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetTCPProxy": {
+      "singular": "computetargettcpproxy",
+      "plural": "computetargettcpproxies",
+      "shortNames": [
+        "gcpcomputetargettcpproxy",
+        "gcpcomputetargettcpproxies"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeTargetVPNGateway": {
+      "singular": "computetargetvpngateway",
+      "plural": "computetargetvpngateways",
+      "shortNames": [
+        "gcpcomputetargetvpngateway",
+        "gcpcomputetargetvpngateways"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeURLMap": {
+      "singular": "computeurlmap",
+      "plural": "computeurlmaps",
+      "shortNames": [
+        "gcpcomputeurlmap",
+        "gcpcomputeurlmaps"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeVPNGateway": {
+      "singular": "computevpngateway",
+      "plural": "computevpngateways",
+      "shortNames": [
+        "gcpcomputevpngateway",
+        "gcpcomputevpngateways"
+      ]
+    },
+    "compute.cnrm.cloud.google.com/ComputeVPNTunnel": {
+      "singular": "computevpntunnel",
+      "plural": "computevpntunnels",
+      "shortNames": [
+        "gcpcomputevpntunnel",
+        "gcpcomputevpntunnels"
+      ]
+    },
+    "configcontroller.cnrm.cloud.google.com/ConfigControllerInstance": {
+      "singular": "configcontrollerinstance",
+      "plural": "configcontrollerinstances",
+      "shortNames": [
+        "gcpconfigcontrollerinstance",
+        "gcpconfigcontrollerinstances"
+      ]
+    },
+    "configdelivery.cnrm.cloud.google.com/ConfigDeliveryFleetPackage": {
+      "singular": "configdeliveryfleetpackage",
+      "plural": "configdeliveryfleetpackages",
+      "shortNames": [
+        "gcpconfigdeliveryfleetpackage",
+        "gcpconfigdeliveryfleetpackages"
+      ]
+    },
+    "configdelivery.cnrm.cloud.google.com/ConfigDeliveryResourceBundle": {
+      "singular": "configdeliveryresourcebundle",
+      "plural": "configdeliveryresourcebundles",
+      "shortNames": [
+        "gcpconfigdeliveryresourcebundle",
+        "gcpconfigdeliveryresourcebundles"
+      ]
+    },
+    "contactcenterinsights.cnrm.cloud.google.com/CCInsightsView": {
+      "singular": "ccinsightsview",
+      "plural": "ccinsightsviews",
+      "shortNames": [
+        "gcpccinsightsview",
+        "gcpccinsightsviews"
+      ]
+    },
+    "container.cnrm.cloud.google.com/ContainerCluster": {
+      "singular": "containercluster",
+      "plural": "containerclusters",
+      "shortNames": [
+        "gcpcontainercluster",
+        "gcpcontainerclusters"
+      ]
+    },
+    "container.cnrm.cloud.google.com/ContainerNodePool": {
+      "singular": "containernodepool",
+      "plural": "containernodepools",
+      "shortNames": [
+        "gcpcontainernodepool",
+        "gcpcontainernodepools"
+      ]
+    },
+    "containeranalysis.cnrm.cloud.google.com/ContainerAnalysisNote": {
+      "singular": "containeranalysisnote",
+      "plural": "containeranalysisnotes",
+      "shortNames": [
+        "gcpcontaineranalysisnote",
+        "gcpcontaineranalysisnotes"
+      ]
+    },
+    "containeranalysis.cnrm.cloud.google.com/ContainerAnalysisOccurrence": {
+      "singular": "containeranalysisoccurrence",
+      "plural": "containeranalysisoccurrences",
+      "shortNames": [
+        "gcpcontaineranalysisoccurrence",
+        "gcpcontaineranalysisoccurrences"
+      ]
+    },
+    "containerattached.cnrm.cloud.google.com/ContainerAttachedCluster": {
+      "singular": "containerattachedcluster",
+      "plural": "containerattachedclusters",
+      "shortNames": [
+        "gcpcontainerattachedcluster",
+        "gcpcontainerattachedclusters"
+      ]
+    },
+    "contentwarehouse.cnrm.cloud.google.com/ContentWarehouseSchema": {
+      "singular": "contentwarehouseschema",
+      "plural": "contentwarehouseschemas",
+      "shortNames": [
+        "gcpcontentwarehouseschema",
+        "gcpcontentwarehouseschemas"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogEntry": {
+      "singular": "datacatalogentry",
+      "plural": "datacatalogentries",
+      "shortNames": [
+        "gcpdatacatalogentry",
+        "gcpdatacatalogentries"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogEntryGroup": {
+      "singular": "datacatalogentrygroup",
+      "plural": "datacatalogentrygroups",
+      "shortNames": [
+        "gcpdatacatalogentrygroup",
+        "gcpdatacatalogentrygroups"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogPolicyTag": {
+      "singular": "datacatalogpolicytag",
+      "plural": "datacatalogpolicytags",
+      "shortNames": [
+        "gcpdatacatalogpolicytag",
+        "gcpdatacatalogpolicytags"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogTag": {
+      "singular": "datacatalogtag",
+      "plural": "datacatalogtags",
+      "shortNames": [
+        "gcpdatacatalogtag",
+        "gcpdatacatalogtags"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogTagTemplate": {
+      "singular": "datacatalogtagtemplate",
+      "plural": "datacatalogtagtemplates",
+      "shortNames": [
+        "gcpdatacatalogtagtemplate",
+        "gcpdatacatalogtagtemplates"
+      ]
+    },
+    "datacatalog.cnrm.cloud.google.com/DataCatalogTaxonomy": {
+      "singular": "datacatalogtaxonomy",
+      "plural": "datacatalogtaxonomies",
+      "shortNames": [
+        "gcpdatacatalogtaxonomy",
+        "gcpdatacatalogtaxonomies"
+      ]
+    },
+    "dataflow.cnrm.cloud.google.com/DataflowFlexTemplateJob": {
+      "singular": "dataflowflextemplatejob",
+      "plural": "dataflowflextemplatejobs",
+      "shortNames": [
+        "gcpdataflowflextemplatejob",
+        "gcpdataflowflextemplatejobs"
+      ]
+    },
+    "dataflow.cnrm.cloud.google.com/DataflowJob": {
+      "singular": "dataflowjob",
+      "plural": "dataflowjobs",
+      "shortNames": [
+        "gcpdataflowjob",
+        "gcpdataflowjobs"
+      ]
+    },
+    "dataform.cnrm.cloud.google.com/DataformRepository": {
+      "singular": "dataformrepository",
+      "plural": "dataformrepositories",
+      "shortNames": [
+        "gcpdataformrepository",
+        "gcpdataformrepositories"
+      ]
+    },
+    "datafusion.cnrm.cloud.google.com/DataFusionInstance": {
+      "singular": "datafusioninstance",
+      "plural": "datafusioninstances",
+      "shortNames": [
+        "gcpdatafusioninstance",
+        "gcpdatafusioninstances"
+      ]
+    },
+    "datalabeling.cnrm.cloud.google.com/DataLabelingAnnotationSpecSet": {
+      "singular": "datalabelingannotationspecset",
+      "plural": "datalabelingannotationspecsets",
+      "shortNames": [
+        "gcpdatalabelingannotationspecset",
+        "gcpdatalabelingannotationspecsets"
+      ]
+    },
+    "datalabeling.cnrm.cloud.google.com/DataLabelingInstruction": {
+      "singular": "datalabelinginstruction",
+      "plural": "datalabelinginstructions",
+      "shortNames": [
+        "gcpdatalabelinginstruction",
+        "gcpdatalabelinginstructions"
+      ]
+    },
+    "datamigration.cnrm.cloud.google.com/DatabaseMigrationConversionWorkspace": {
+      "singular": "databasemigrationconversionworkspace",
+      "plural": "databasemigrationconversionworkspaces",
+      "shortNames": [
+        "gcpdatabasemigrationconversionworkspace",
+        "gcpdatabasemigrationconversionworkspaces"
+      ]
+    },
+    "datamigration.cnrm.cloud.google.com/DatabaseMigrationMigrationJob": {
+      "singular": "databasemigrationmigrationjob",
+      "plural": "databasemigrationmigrationjobs",
+      "shortNames": [
+        "gcpdatabasemigrationmigrationjob",
+        "gcpdatabasemigrationmigrationjobs"
+      ]
+    },
+    "dataplex.cnrm.cloud.google.com/DataplexEntryGroup": {
+      "singular": "dataplexentrygroup",
+      "plural": "dataplexentrygroups",
+      "shortNames": [
+        "gcpdataplexentrygroup",
+        "gcpdataplexentrygroups"
+      ]
+    },
+    "dataplex.cnrm.cloud.google.com/DataplexEntryType": {
+      "singular": "dataplexentrytype",
+      "plural": "dataplexentrytypes",
+      "shortNames": [
+        "gcpdataplexentrytype",
+        "gcpdataplexentrytypes"
+      ]
+    },
+    "dataplex.cnrm.cloud.google.com/DataplexLake": {
+      "singular": "dataplexlake",
+      "plural": "dataplexlakes",
+      "shortNames": [
+        "gcpdataplexlake",
+        "gcpdataplexlakes"
+      ]
+    },
+    "dataplex.cnrm.cloud.google.com/DataplexTask": {
+      "singular": "dataplextask",
+      "plural": "dataplextasks",
+      "shortNames": [
+        "gcpdataplextask",
+        "gcpdataplextasks"
+      ]
+    },
+    "dataplex.cnrm.cloud.google.com/DataplexZone": {
+      "singular": "dataplexzone",
+      "plural": "dataplexzones",
+      "shortNames": [
+        "gcpdataplexzone",
+        "gcpdataplexzones"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocAutoscalingPolicy": {
+      "singular": "dataprocautoscalingpolicy",
+      "plural": "dataprocautoscalingpolicies",
+      "shortNames": [
+        "gcpdataprocautoscalingpolicy",
+        "gcpdataprocautoscalingpolicies"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocBatch": {
+      "singular": "dataprocbatch",
+      "plural": "dataprocbatches",
+      "shortNames": [
+        "gcpdataprocbatch",
+        "gcpdataprocbatches"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocCluster": {
+      "singular": "dataproccluster",
+      "plural": "dataprocclusters",
+      "shortNames": [
+        "gcpdataproccluster",
+        "gcpdataprocclusters"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocJob": {
+      "singular": "dataprocjob",
+      "plural": "dataprocjobs",
+      "shortNames": [
+        "gcpdataprocjob",
+        "gcpdataprocjobs"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocNodeGroup": {
+      "singular": "dataprocnodegroup",
+      "plural": "dataprocnodegroups",
+      "shortNames": [
+        "gcpdataprocnodegroup",
+        "gcpdataprocnodegroups"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocSession": {
+      "singular": "dataprocsession",
+      "plural": "dataprocsessions",
+      "shortNames": [
+        "gcpdataprocsession",
+        "gcpdataprocsessions"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocSessionTemplate": {
+      "singular": "dataprocsessiontemplate",
+      "plural": "dataprocsessiontemplates",
+      "shortNames": [
+        "gcpdataprocsessiontemplate",
+        "gcpdataprocsessiontemplates"
+      ]
+    },
+    "dataproc.cnrm.cloud.google.com/DataprocWorkflowTemplate": {
+      "singular": "dataprocworkflowtemplate",
+      "plural": "dataprocworkflowtemplates",
+      "shortNames": [
+        "gcpdataprocworkflowtemplate",
+        "gcpdataprocworkflowtemplates"
+      ]
+    },
+    "datastore.cnrm.cloud.google.com/DatastoreIndex": {
+      "singular": "datastoreindex",
+      "plural": "datastoreindexes",
+      "shortNames": [
+        "gcpdatastoreindex",
+        "gcpdatastoreindexes"
+      ]
+    },
+    "datastream.cnrm.cloud.google.com/DatastreamConnectionProfile": {
+      "singular": "datastreamconnectionprofile",
+      "plural": "datastreamconnectionprofiles",
+      "shortNames": [
+        "gcpdatastreamconnectionprofile",
+        "gcpdatastreamconnectionprofiles"
+      ]
+    },
+    "datastream.cnrm.cloud.google.com/DatastreamPrivateConnection": {
+      "singular": "datastreamprivateconnection",
+      "plural": "datastreamprivateconnections",
+      "shortNames": [
+        "gcpdatastreamprivateconnection",
+        "gcpdatastreamprivateconnections"
+      ]
+    },
+    "datastream.cnrm.cloud.google.com/DatastreamRoute": {
+      "singular": "datastreamroute",
+      "plural": "datastreamroutes",
+      "shortNames": [
+        "gcpdatastreamroute",
+        "gcpdatastreamroutes"
+      ]
+    },
+    "datastream.cnrm.cloud.google.com/DatastreamStream": {
+      "singular": "datastreamstream",
+      "plural": "datastreamstreams",
+      "shortNames": [
+        "gcpdatastreamstream",
+        "gcpdatastreamstreams"
+      ]
+    },
+    "deploymentmanager.cnrm.cloud.google.com/DeploymentManagerDeployment": {
+      "singular": "deploymentmanagerdeployment",
+      "plural": "deploymentmanagerdeployments",
+      "shortNames": [
+        "gcpdeploymentmanagerdeployment",
+        "gcpdeploymentmanagerdeployments"
+      ]
+    },
+    "developerconnect.cnrm.cloud.google.com/DevConnectAccountConnector": {
+      "singular": "devconnectaccountconnector",
+      "plural": "devconnectaccountconnectors",
+      "shortNames": [
+        "gcpdevconnectaccountconnector",
+        "gcpdevconnectaccountconnectors"
+      ]
+    },
+    "developerconnect.cnrm.cloud.google.com/DevConnectInsightsConfig": {
+      "singular": "devconnectinsightsconfig",
+      "plural": "devconnectinsightsconfigs",
+      "shortNames": [
+        "gcpdevconnectinsightsconfig",
+        "gcpdevconnectinsightsconfigs"
+      ]
+    },
+    "devicestreaming.cnrm.cloud.google.com/DeviceStreamingSession": {
+      "singular": "devicestreamingsession",
+      "plural": "devicestreamingsessions",
+      "shortNames": [
+        "gcpdevicestreamingsession",
+        "gcpdevicestreamingsessions"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowAgent": {
+      "singular": "dialogflowagent",
+      "plural": "dialogflowagents",
+      "shortNames": [
+        "gcpdialogflowagent",
+        "gcpdialogflowagents"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowEntityType": {
+      "singular": "dialogflowentitytype",
+      "plural": "dialogflowentitytypes",
+      "shortNames": [
+        "gcpdialogflowentitytype",
+        "gcpdialogflowentitytypes"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowFulfillment": {
+      "singular": "dialogflowfulfillment",
+      "plural": "dialogflowfulfillments",
+      "shortNames": [
+        "gcpdialogflowfulfillment",
+        "gcpdialogflowfulfillments"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowGenerator": {
+      "singular": "dialogflowgenerator",
+      "plural": "dialogflowgenerators",
+      "shortNames": [
+        "gcpdialogflowgenerator",
+        "gcpdialogflowgenerators"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowIntent": {
+      "singular": "dialogflowintent",
+      "plural": "dialogflowintents",
+      "shortNames": [
+        "gcpdialogflowintent",
+        "gcpdialogflowintents"
+      ]
+    },
+    "dialogflow.cnrm.cloud.google.com/DialogflowKnowledgeBase": {
+      "singular": "dialogflowknowledgebase",
+      "plural": "dialogflowknowledgebases",
+      "shortNames": [
+        "gcpdialogflowknowledgebase",
+        "gcpdialogflowknowledgebases"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXAgent": {
+      "singular": "dialogflowcxagent",
+      "plural": "dialogflowcxagents",
+      "shortNames": [
+        "gcpdialogflowcxagent",
+        "gcpdialogflowcxagents"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXEntityType": {
+      "singular": "dialogflowcxentitytype",
+      "plural": "dialogflowcxentitytypes",
+      "shortNames": [
+        "gcpdialogflowcxentitytype",
+        "gcpdialogflowcxentitytypes"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXFlow": {
+      "singular": "dialogflowcxflow",
+      "plural": "dialogflowcxflows",
+      "shortNames": [
+        "gcpdialogflowcxflow",
+        "gcpdialogflowcxflows"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXIntent": {
+      "singular": "dialogflowcxintent",
+      "plural": "dialogflowcxintents",
+      "shortNames": [
+        "gcpdialogflowcxintent",
+        "gcpdialogflowcxintents"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXPage": {
+      "singular": "dialogflowcxpage",
+      "plural": "dialogflowcxpages",
+      "shortNames": [
+        "gcpdialogflowcxpage",
+        "gcpdialogflowcxpages"
+      ]
+    },
+    "dialogflowcx.cnrm.cloud.google.com/DialogflowCXWebhook": {
+      "singular": "dialogflowcxwebhook",
+      "plural": "dialogflowcxwebhooks",
+      "shortNames": [
+        "gcpdialogflowcxwebhook",
+        "gcpdialogflowcxwebhooks"
+      ]
+    },
+    "discoveryengine.cnrm.cloud.google.com/DiscoveryEngineConversation": {
+      "singular": "discoveryengineconversation",
+      "plural": "discoveryengineconversations",
+      "shortNames": [
+        "gcpdiscoveryengineconversation",
+        "gcpdiscoveryengineconversations"
+      ]
+    },
+    "discoveryengine.cnrm.cloud.google.com/DiscoveryEngineDataStore": {
+      "singular": "discoveryenginedatastore",
+      "plural": "discoveryenginedatastores",
+      "shortNames": [
+        "gcpdiscoveryenginedatastore",
+        "gcpdiscoveryenginedatastores"
+      ]
+    },
+    "discoveryengine.cnrm.cloud.google.com/DiscoveryEngineDataStoreTargetSite": {
+      "singular": "discoveryenginedatastoretargetsite",
+      "plural": "discoveryenginedatastoretargetsites",
+      "shortNames": [
+        "gcpdiscoveryenginedatastoretargetsite",
+        "gcpdiscoveryenginedatastoretargetsites"
+      ]
+    },
+    "discoveryengine.cnrm.cloud.google.com/DiscoveryEngineEngine": {
+      "singular": "discoveryengineengine",
+      "plural": "discoveryengineengines",
+      "shortNames": [
+        "gcpdiscoveryengineengine",
+        "gcpdiscoveryengineengines"
+      ]
+    },
+    "discoveryengine.cnrm.cloud.google.com/DiscoveryEngineIdentityMappingStore": {
+      "singular": "discoveryengineidentitymappingstore",
+      "plural": "discoveryengineidentitymappingstores",
+      "shortNames": [
+        "gcpdiscoveryengineidentitymappingstore",
+        "gcpdiscoveryengineidentitymappingstores"
+      ]
+    },
+    "dlp.cnrm.cloud.google.com/DLPDeidentifyTemplate": {
+      "singular": "dlpdeidentifytemplate",
+      "plural": "dlpdeidentifytemplates",
+      "shortNames": [
+        "gcpdlpdeidentifytemplate",
+        "gcpdlpdeidentifytemplates"
+      ]
+    },
+    "dlp.cnrm.cloud.google.com/DLPInspectTemplate": {
+      "singular": "dlpinspecttemplate",
+      "plural": "dlpinspecttemplates",
+      "shortNames": [
+        "gcpdlpinspecttemplate",
+        "gcpdlpinspecttemplates"
+      ]
+    },
+    "dlp.cnrm.cloud.google.com/DLPJobTrigger": {
+      "singular": "dlpjobtrigger",
+      "plural": "dlpjobtriggers",
+      "shortNames": [
+        "gcpdlpjobtrigger",
+        "gcpdlpjobtriggers"
+      ]
+    },
+    "dlp.cnrm.cloud.google.com/DLPStoredInfoType": {
+      "singular": "dlpstoredinfotype",
+      "plural": "dlpstoredinfotypes",
+      "shortNames": [
+        "gcpdlpstoredinfotype",
+        "gcpdlpstoredinfotypes"
+      ]
+    },
+    "dns.cnrm.cloud.google.com/DNSManagedZone": {
+      "singular": "dnsmanagedzone",
+      "plural": "dnsmanagedzones",
+      "shortNames": [
+        "gcpdnsmanagedzone",
+        "gcpdnsmanagedzones"
+      ]
+    },
+    "dns.cnrm.cloud.google.com/DNSPolicy": {
+      "singular": "dnspolicy",
+      "plural": "dnspolicies",
+      "shortNames": [
+        "gcpdnspolicy",
+        "gcpdnspolicies"
+      ]
+    },
+    "dns.cnrm.cloud.google.com/DNSRecordSet": {
+      "singular": "dnsrecordset",
+      "plural": "dnsrecordsets",
+      "shortNames": [
+        "gcpdnsrecordset",
+        "gcpdnsrecordsets"
+      ]
+    },
+    "dns.cnrm.cloud.google.com/DNSResponsePolicy": {
+      "singular": "dnsresponsepolicy",
+      "plural": "dnsresponsepolicies",
+      "shortNames": [
+        "gcpdnsresponsepolicy",
+        "gcpdnsresponsepolicies"
+      ]
+    },
+    "dns.cnrm.cloud.google.com/DNSResponsePolicyRule": {
+      "singular": "dnsresponsepolicyrule",
+      "plural": "dnsresponsepolicyrules",
+      "shortNames": [
+        "gcpdnsresponsepolicyrule",
+        "gcpdnsresponsepolicyrules"
+      ]
+    },
+    "documentai.cnrm.cloud.google.com/DocumentAIProcessor": {
+      "singular": "documentaiprocessor",
+      "plural": "documentaiprocessors",
+      "shortNames": [
+        "gcpdocumentaiprocessor",
+        "gcpdocumentaiprocessors"
+      ]
+    },
+    "documentai.cnrm.cloud.google.com/DocumentAIProcessorDefaultVersion": {
+      "singular": "documentaiprocessordefaultversion",
+      "plural": "documentaiprocessordefaultversions",
+      "shortNames": [
+        "gcpdocumentaiprocessordefaultversion",
+        "gcpdocumentaiprocessordefaultversions"
+      ]
+    },
+    "documentai.cnrm.cloud.google.com/DocumentAIProcessorVersion": {
+      "singular": "documentaiprocessorversion",
+      "plural": "documentaiprocessorversions",
+      "shortNames": [
+        "gcpdocumentaiprocessorversion",
+        "gcpdocumentaiprocessorversions"
+      ]
+    },
+    "edgecontainer.cnrm.cloud.google.com/EdgeContainerCluster": {
+      "singular": "edgecontainercluster",
+      "plural": "edgecontainerclusters",
+      "shortNames": [
+        "gcpedgecontainercluster",
+        "gcpedgecontainerclusters"
+      ]
+    },
+    "edgecontainer.cnrm.cloud.google.com/EdgeContainerMachine": {
+      "singular": "edgecontainermachine",
+      "plural": "edgecontainermachines",
+      "shortNames": [
+        "gcpedgecontainermachine",
+        "gcpedgecontainermachines"
+      ]
+    },
+    "edgecontainer.cnrm.cloud.google.com/EdgeContainerNodePool": {
+      "singular": "edgecontainernodepool",
+      "plural": "edgecontainernodepools",
+      "shortNames": [
+        "gcpedgecontainernodepool",
+        "gcpedgecontainernodepools"
+      ]
+    },
+    "edgecontainer.cnrm.cloud.google.com/EdgeContainerVpnConnection": {
+      "singular": "edgecontainervpnconnection",
+      "plural": "edgecontainervpnconnections",
+      "shortNames": [
+        "gcpedgecontainervpnconnection",
+        "gcpedgecontainervpnconnections"
+      ]
+    },
+    "edgenetwork.cnrm.cloud.google.com/EdgeNetworkNetwork": {
+      "singular": "edgenetworknetwork",
+      "plural": "edgenetworknetworks",
+      "shortNames": [
+        "gcpedgenetworknetwork",
+        "gcpedgenetworknetworks"
+      ]
+    },
+    "edgenetwork.cnrm.cloud.google.com/EdgeNetworkSubnet": {
+      "singular": "edgenetworksubnet",
+      "plural": "edgenetworksubnets",
+      "shortNames": [
+        "gcpedgenetworksubnet",
+        "gcpedgenetworksubnets"
+      ]
+    },
+    "essentialcontacts.cnrm.cloud.google.com/EssentialContactsContact": {
+      "singular": "essentialcontactscontact",
+      "plural": "essentialcontactscontacts",
+      "shortNames": [
+        "gcpessentialcontactscontact",
+        "gcpessentialcontactscontacts"
+      ]
+    },
+    "eventarc.cnrm.cloud.google.com/EventarcChannel": {
+      "singular": "eventarcchannel",
+      "plural": "eventarcchannels",
+      "shortNames": [
+        "gcpeventarcchannel",
+        "gcpeventarcchannels"
+      ]
+    },
+    "eventarc.cnrm.cloud.google.com/EventarcChannelConnection": {
+      "singular": "eventarcchannelconnection",
+      "plural": "eventarcchannelconnections",
+      "shortNames": [
+        "gcpeventarcchannelconnection",
+        "gcpeventarcchannelconnections"
+      ]
+    },
+    "eventarc.cnrm.cloud.google.com/EventarcEnrollment": {
+      "singular": "eventarcenrollment",
+      "plural": "eventarcenrollments",
+      "shortNames": [
+        "gcpeventarcenrollment",
+        "gcpeventarcenrollments"
+      ]
+    },
+    "eventarc.cnrm.cloud.google.com/EventarcGoogleChannelConfig": {
+      "singular": "eventarcgooglechannelconfig",
+      "plural": "eventarcgooglechannelconfigs",
+      "shortNames": [
+        "gcpeventarcgooglechannelconfig",
+        "gcpeventarcgooglechannelconfigs"
+      ]
+    },
+    "eventarc.cnrm.cloud.google.com/EventarcTrigger": {
+      "singular": "eventarctrigger",
+      "plural": "eventarctriggers",
+      "shortNames": [
+        "gcpeventarctrigger",
+        "gcpeventarctriggers"
+      ]
+    },
+    "filestore.cnrm.cloud.google.com/FilestoreBackup": {
+      "singular": "filestorebackup",
+      "plural": "filestorebackups",
+      "shortNames": [
+        "gcpfilestorebackup",
+        "gcpfilestorebackups"
+      ]
+    },
+    "filestore.cnrm.cloud.google.com/FilestoreInstance": {
+      "singular": "filestoreinstance",
+      "plural": "filestoreinstances",
+      "shortNames": [
+        "gcpfilestoreinstance",
+        "gcpfilestoreinstances"
+      ]
+    },
+    "filestore.cnrm.cloud.google.com/FilestoreSnapshot": {
+      "singular": "filestoresnapshot",
+      "plural": "filestoresnapshots",
+      "shortNames": [
+        "gcpfilestoresnapshot",
+        "gcpfilestoresnapshots"
+      ]
+    },
+    "firebase.cnrm.cloud.google.com/FirebaseAndroidApp": {
+      "singular": "firebaseandroidapp",
+      "plural": "firebaseandroidapps",
+      "shortNames": [
+        "gcpfirebaseandroidapp",
+        "gcpfirebaseandroidapps"
+      ]
+    },
+    "firebase.cnrm.cloud.google.com/FirebaseProject": {
+      "singular": "firebaseproject",
+      "plural": "firebaseprojects",
+      "shortNames": [
+        "gcpfirebaseproject",
+        "gcpfirebaseprojects"
+      ]
+    },
+    "firebase.cnrm.cloud.google.com/FirebaseWebApp": {
+      "singular": "firebasewebapp",
+      "plural": "firebasewebapps",
+      "shortNames": [
+        "gcpfirebasewebapp",
+        "gcpfirebasewebapps"
+      ]
+    },
+    "firebasedatabase.cnrm.cloud.google.com/FirebaseDatabaseInstance": {
+      "singular": "firebasedatabaseinstance",
+      "plural": "firebasedatabaseinstances",
+      "shortNames": [
+        "gcpfirebasedatabaseinstance",
+        "gcpfirebasedatabaseinstances"
+      ]
+    },
+    "firebasehosting.cnrm.cloud.google.com/FirebaseHostingChannel": {
+      "singular": "firebasehostingchannel",
+      "plural": "firebasehostingchannels",
+      "shortNames": [
+        "gcpfirebasehostingchannel",
+        "gcpfirebasehostingchannels"
+      ]
+    },
+    "firebasehosting.cnrm.cloud.google.com/FirebaseHostingSite": {
+      "singular": "firebasehostingsite",
+      "plural": "firebasehostingsites",
+      "shortNames": [
+        "gcpfirebasehostingsite",
+        "gcpfirebasehostingsites"
+      ]
+    },
+    "firebasestorage.cnrm.cloud.google.com/FirebaseStorageBucket": {
+      "singular": "firebasestoragebucket",
+      "plural": "firebasestoragebuckets",
+      "shortNames": [
+        "gcpfirebasestoragebucket",
+        "gcpfirebasestoragebuckets"
+      ]
+    },
+    "firestore.cnrm.cloud.google.com/FirestoreBackupSchedule": {
+      "singular": "firestorebackupschedule",
+      "plural": "firestorebackupschedules",
+      "shortNames": [
+        "gcpfirestorebackupschedule",
+        "gcpfirestorebackupschedules"
+      ]
+    },
+    "firestore.cnrm.cloud.google.com/FirestoreDatabase": {
+      "singular": "firestoredatabase",
+      "plural": "firestoredatabases",
+      "shortNames": [
+        "gcpfirestoredatabase",
+        "gcpfirestoredatabases"
+      ]
+    },
+    "firestore.cnrm.cloud.google.com/FirestoreDocument": {
+      "singular": "firestoredocument",
+      "plural": "firestoredocuments",
+      "shortNames": [
+        "gcpfirestoredocument",
+        "gcpfirestoredocuments"
+      ]
+    },
+    "firestore.cnrm.cloud.google.com/FirestoreField": {
+      "singular": "firestorefield",
+      "plural": "firestorefields",
+      "shortNames": [
+        "gcpfirestorefield",
+        "gcpfirestorefields"
+      ]
+    },
+    "firestore.cnrm.cloud.google.com/FirestoreIndex": {
+      "singular": "firestoreindex",
+      "plural": "firestoreindexes",
+      "shortNames": [
+        "gcpfirestoreindex",
+        "gcpfirestoreindexes"
+      ]
+    },
+    "gkebackup.cnrm.cloud.google.com/GKEBackupBackup": {
+      "singular": "gkebackupbackup",
+      "plural": "gkebackupbackups",
+      "shortNames": [
+        "gcpgkebackupbackup",
+        "gcpgkebackupbackups"
+      ]
+    },
+    "gkebackup.cnrm.cloud.google.com/GKEBackupBackupPlan": {
+      "singular": "gkebackupbackupplan",
+      "plural": "gkebackupbackupplans",
+      "shortNames": [
+        "gcpgkebackupbackupplan",
+        "gcpgkebackupbackupplans"
+      ]
+    },
+    "gkebackup.cnrm.cloud.google.com/GKEBackupRestore": {
+      "singular": "gkebackuprestore",
+      "plural": "gkebackuprestores",
+      "shortNames": [
+        "gcpgkebackuprestore",
+        "gcpgkebackuprestores"
+      ]
+    },
+    "gkebackup.cnrm.cloud.google.com/GKEBackupRestorePlan": {
+      "singular": "gkebackuprestoreplan",
+      "plural": "gkebackuprestoreplans",
+      "shortNames": [
+        "gcpgkebackuprestoreplan",
+        "gcpgkebackuprestoreplans"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubFeature": {
+      "singular": "gkehubfeature",
+      "plural": "gkehubfeatures",
+      "shortNames": [
+        "gcpgkehubfeature",
+        "gcpgkehubfeatures"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubFeatureMembership": {
+      "singular": "gkehubfeaturemembership",
+      "plural": "gkehubfeaturememberships",
+      "shortNames": [
+        "gcpgkehubfeaturemembership",
+        "gcpgkehubfeaturememberships"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubMembership": {
+      "singular": "gkehubmembership",
+      "plural": "gkehubmemberships",
+      "shortNames": [
+        "gcpgkehubmembership",
+        "gcpgkehubmemberships"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubMembershipBinding": {
+      "singular": "gkehubmembershipbinding",
+      "plural": "gkehubmembershipbindings",
+      "shortNames": [
+        "gcpgkehubmembershipbinding",
+        "gcpgkehubmembershipbindings"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubNamespace": {
+      "singular": "gkehubnamespace",
+      "plural": "gkehubnamespaces",
+      "shortNames": [
+        "gcpgkehubnamespace",
+        "gcpgkehubnamespaces"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubScope": {
+      "singular": "gkehubscope",
+      "plural": "gkehubscopes",
+      "shortNames": [
+        "gcpgkehubscope",
+        "gcpgkehubscopes"
+      ]
+    },
+    "gkehub.cnrm.cloud.google.com/GKEHubScopeRBACRoleBinding": {
+      "singular": "gkehubscoperbacrolebinding",
+      "plural": "gkehubscoperbacrolebindings",
+      "shortNames": [
+        "gcpgkehubscoperbacrolebinding",
+        "gcpgkehubscoperbacrolebindings"
+      ]
+    },
+    "healthcare.cnrm.cloud.google.com/HealthcareConsentStore": {
+      "singular": "healthcareconsentstore",
+      "plural": "healthcareconsentstores",
+      "shortNames": [
+        "gcphealthcareconsentstore",
+        "gcphealthcareconsentstores"
+      ]
+    },
+    "healthcare.cnrm.cloud.google.com/HealthcareDICOMStore": {
+      "singular": "healthcaredicomstore",
+      "plural": "healthcaredicomstores",
+      "shortNames": [
+        "gcphealthcaredicomstore",
+        "gcphealthcaredicomstores"
+      ]
+    },
+    "healthcare.cnrm.cloud.google.com/HealthcareDataset": {
+      "singular": "healthcaredataset",
+      "plural": "healthcaredatasets",
+      "shortNames": [
+        "gcphealthcaredataset",
+        "gcphealthcaredatasets"
+      ]
+    },
+    "healthcare.cnrm.cloud.google.com/HealthcareFHIRStore": {
+      "singular": "healthcarefhirstore",
+      "plural": "healthcarefhirstores",
+      "shortNames": [
+        "gcphealthcarefhirstore",
+        "gcphealthcarefhirstores"
+      ]
+    },
+    "healthcare.cnrm.cloud.google.com/HealthcareHL7V2Store": {
+      "singular": "healthcarehl7v2store",
+      "plural": "healthcarehl7v2stores",
+      "shortNames": [
+        "gcphealthcarehl7v2store",
+        "gcphealthcarehl7v2stores"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMAccessBoundaryPolicy": {
+      "singular": "iamaccessboundarypolicy",
+      "plural": "iamaccessboundarypolicies",
+      "shortNames": [
+        "gcpiamaccessboundarypolicy",
+        "gcpiamaccessboundarypolicies"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMAuditConfig": {
+      "singular": "iamauditconfig",
+      "plural": "iamauditconfigs",
+      "shortNames": [
+        "gcpiamauditconfig",
+        "gcpiamauditconfigs"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMCustomRole": {
+      "singular": "iamcustomrole",
+      "plural": "iamcustomroles",
+      "shortNames": [
+        "gcpiamcustomrole",
+        "gcpiamcustomroles"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMDenyPolicy": {
+      "singular": "iamdenypolicy",
+      "plural": "iamdenypolicies",
+      "shortNames": [
+        "gcpiamdenypolicy",
+        "gcpiamdenypolicies"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMPartialPolicy": {
+      "singular": "iampartialpolicy",
+      "plural": "iampartialpolicies",
+      "shortNames": [
+        "gcpiampartialpolicy",
+        "gcpiampartialpolicies"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMPolicy": {
+      "singular": "iampolicy",
+      "plural": "iampolicies",
+      "shortNames": [
+        "gcpiampolicy",
+        "gcpiampolicies"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMPolicyMember": {
+      "singular": "iampolicymember",
+      "plural": "iampolicymembers",
+      "shortNames": [
+        "gcpiampolicymember",
+        "gcpiampolicymembers"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMServiceAccount": {
+      "singular": "iamserviceaccount",
+      "plural": "iamserviceaccounts",
+      "shortNames": [
+        "gcpiamserviceaccount",
+        "gcpiamserviceaccounts"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMServiceAccountKey": {
+      "singular": "iamserviceaccountkey",
+      "plural": "iamserviceaccountkeys",
+      "shortNames": [
+        "gcpiamserviceaccountkey",
+        "gcpiamserviceaccountkeys"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMWorkforcePool": {
+      "singular": "iamworkforcepool",
+      "plural": "iamworkforcepools",
+      "shortNames": [
+        "gcpiamworkforcepool",
+        "gcpiamworkforcepools"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMWorkforcePoolProvider": {
+      "singular": "iamworkforcepoolprovider",
+      "plural": "iamworkforcepoolproviders",
+      "shortNames": [
+        "gcpiamworkforcepoolprovider",
+        "gcpiamworkforcepoolproviders"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMWorkloadIdentityPool": {
+      "singular": "iamworkloadidentitypool",
+      "plural": "iamworkloadidentitypools",
+      "shortNames": [
+        "gcpiamworkloadidentitypool",
+        "gcpiamworkloadidentitypools"
+      ]
+    },
+    "iam.cnrm.cloud.google.com/IAMWorkloadIdentityPoolProvider": {
+      "singular": "iamworkloadidentitypoolprovider",
+      "plural": "iamworkloadidentitypoolproviders",
+      "shortNames": [
+        "gcpiamworkloadidentitypoolprovider",
+        "gcpiamworkloadidentitypoolproviders"
+      ]
+    },
+    "iap.cnrm.cloud.google.com/IAPBrand": {
+      "singular": "iapbrand",
+      "plural": "iapbrands",
+      "shortNames": [
+        "gcpiapbrand",
+        "gcpiapbrands"
+      ]
+    },
+    "iap.cnrm.cloud.google.com/IAPIdentityAwareProxyClient": {
+      "singular": "iapidentityawareproxyclient",
+      "plural": "iapidentityawareproxyclients",
+      "shortNames": [
+        "gcpiapidentityawareproxyclient",
+        "gcpiapidentityawareproxyclients"
+      ]
+    },
+    "iap.cnrm.cloud.google.com/IAPSettings": {
+      "singular": "iapsettings",
+      "plural": "iapsettings",
+      "shortNames": [
+        "gcpiapsettings"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformConfig": {
+      "singular": "identityplatformconfig",
+      "plural": "identityplatformconfigs",
+      "shortNames": [
+        "gcpidentityplatformconfig",
+        "gcpidentityplatformconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformDefaultSupportedIDPConfig": {
+      "singular": "identityplatformdefaultsupportedidpconfig",
+      "plural": "identityplatformdefaultsupportedidpconfigs",
+      "shortNames": [
+        "gcpidentityplatformdefaultsupportedidpconfig",
+        "gcpidentityplatformdefaultsupportedidpconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformInboundSAMLConfig": {
+      "singular": "identityplatforminboundsamlconfig",
+      "plural": "identityplatforminboundsamlconfigs",
+      "shortNames": [
+        "gcpidentityplatforminboundsamlconfig",
+        "gcpidentityplatforminboundsamlconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformOAuthIDPConfig": {
+      "singular": "identityplatformoauthidpconfig",
+      "plural": "identityplatformoauthidpconfigs",
+      "shortNames": [
+        "gcpidentityplatformoauthidpconfig",
+        "gcpidentityplatformoauthidpconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformProjectDefaultConfig": {
+      "singular": "identityplatformprojectdefaultconfig",
+      "plural": "identityplatformprojectdefaultconfigs",
+      "shortNames": [
+        "gcpidentityplatformprojectdefaultconfig",
+        "gcpidentityplatformprojectdefaultconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformTenant": {
+      "singular": "identityplatformtenant",
+      "plural": "identityplatformtenants",
+      "shortNames": [
+        "gcpidentityplatformtenant",
+        "gcpidentityplatformtenants"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformTenantDefaultSupportedIDPConfig": {
+      "singular": "identityplatformtenantdefaultsupportedidpconfig",
+      "plural": "identityplatformtenantdefaultsupportedidpconfigs",
+      "shortNames": [
+        "gcpidentityplatformtenantdefaultsupportedidpconfig",
+        "gcpidentityplatformtenantdefaultsupportedidpconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformTenantInboundSAMLConfig": {
+      "singular": "identityplatformtenantinboundsamlconfig",
+      "plural": "identityplatformtenantinboundsamlconfigs",
+      "shortNames": [
+        "gcpidentityplatformtenantinboundsamlconfig",
+        "gcpidentityplatformtenantinboundsamlconfigs"
+      ]
+    },
+    "identityplatform.cnrm.cloud.google.com/IdentityPlatformTenantOAuthIDPConfig": {
+      "singular": "identityplatformtenantoauthidpconfig",
+      "plural": "identityplatformtenantoauthidpconfigs",
+      "shortNames": [
+        "gcpidentityplatformtenantoauthidpconfig",
+        "gcpidentityplatformtenantoauthidpconfigs"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSAutokeyConfig": {
+      "singular": "kmsautokeyconfig",
+      "plural": "kmsautokeyconfigs",
+      "shortNames": [
+        "gcpkmsautokeyconfig",
+        "gcpkmsautokeyconfigs"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSCryptoKey": {
+      "singular": "kmscryptokey",
+      "plural": "kmscryptokeys",
+      "shortNames": [
+        "gcpkmscryptokey",
+        "gcpkmscryptokeys"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSCryptoKeyVersion": {
+      "singular": "kmscryptokeyversion",
+      "plural": "kmscryptokeyversions",
+      "shortNames": [
+        "gcpkmscryptokeyversion",
+        "gcpkmscryptokeyversions"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSImportJob": {
+      "singular": "kmsimportjob",
+      "plural": "kmsimportjobs",
+      "shortNames": [
+        "gcpkmsimportjob",
+        "gcpkmsimportjobs"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSKeyHandle": {
+      "singular": "kmskeyhandle",
+      "plural": "kmskeyhandles",
+      "shortNames": [
+        "gcpkmskeyhandle",
+        "gcpkmskeyhandles"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSKeyRing": {
+      "singular": "kmskeyring",
+      "plural": "kmskeyrings",
+      "shortNames": [
+        "gcpkmskeyring",
+        "gcpkmskeyrings"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSKeyRingImportJob": {
+      "singular": "kmskeyringimportjob",
+      "plural": "kmskeyringimportjobs",
+      "shortNames": [
+        "gcpkmskeyringimportjob",
+        "gcpkmskeyringimportjobs"
+      ]
+    },
+    "kms.cnrm.cloud.google.com/KMSSecretCiphertext": {
+      "singular": "kmssecretciphertext",
+      "plural": "kmssecretciphertexts",
+      "shortNames": [
+        "gcpkmssecretciphertext",
+        "gcpkmssecretciphertexts"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLink": {
+      "singular": "logginglink",
+      "plural": "logginglinks",
+      "shortNames": [
+        "gcplogginglink",
+        "gcplogginglinks"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLogBucket": {
+      "singular": "logginglogbucket",
+      "plural": "logginglogbuckets",
+      "shortNames": [
+        "gcplogginglogbucket",
+        "gcplogginglogbuckets"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLogExclusion": {
+      "singular": "logginglogexclusion",
+      "plural": "logginglogexclusions",
+      "shortNames": [
+        "gcplogginglogexclusion",
+        "gcplogginglogexclusions"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLogMetric": {
+      "singular": "logginglogmetric",
+      "plural": "logginglogmetrics",
+      "shortNames": [
+        "gcplogginglogmetric",
+        "gcplogginglogmetrics"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLogSink": {
+      "singular": "logginglogsink",
+      "plural": "logginglogsinks",
+      "shortNames": [
+        "gcplogginglogsink",
+        "gcplogginglogsinks"
+      ]
+    },
+    "logging.cnrm.cloud.google.com/LoggingLogView": {
+      "singular": "logginglogview",
+      "plural": "logginglogviews",
+      "shortNames": [
+        "gcplogginglogview",
+        "gcplogginglogviews"
+      ]
+    },
+    "managedkafka.cnrm.cloud.google.com/ManagedKafkaCluster": {
+      "singular": "managedkafkacluster",
+      "plural": "managedkafkaclusters",
+      "shortNames": [
+        "gcpmanagedkafkacluster",
+        "gcpmanagedkafkaclusters"
+      ]
+    },
+    "managedkafka.cnrm.cloud.google.com/ManagedKafkaConsumerGroup": {
+      "singular": "managedkafkaconsumergroup",
+      "plural": "managedkafkaconsumergroups",
+      "shortNames": [
+        "gcpmanagedkafkaconsumergroup",
+        "gcpmanagedkafkaconsumergroups"
+      ]
+    },
+    "managedkafka.cnrm.cloud.google.com/ManagedKafkaTopic": {
+      "singular": "managedkafkatopic",
+      "plural": "managedkafkatopics",
+      "shortNames": [
+        "gcpmanagedkafkatopic",
+        "gcpmanagedkafkatopics"
+      ]
+    },
+    "memcache.cnrm.cloud.google.com/MemcacheInstance": {
+      "singular": "memcacheinstance",
+      "plural": "memcacheinstances",
+      "shortNames": [
+        "gcpmemcacheinstance",
+        "gcpmemcacheinstances"
+      ]
+    },
+    "memorystore.cnrm.cloud.google.com/MemorystoreInstance": {
+      "singular": "memorystoreinstance",
+      "plural": "memorystoreinstances",
+      "shortNames": [
+        "gcpmemorystoreinstance",
+        "gcpmemorystoreinstances"
+      ]
+    },
+    "memorystore.cnrm.cloud.google.com/MemorystoreInstanceEndpoint": {
+      "singular": "memorystoreinstanceendpoint",
+      "plural": "memorystoreinstanceendpoints",
+      "shortNames": [
+        "gcpmemorystoreinstanceendpoint",
+        "gcpmemorystoreinstanceendpoints"
+      ]
+    },
+    "metastore.cnrm.cloud.google.com/MetastoreBackup": {
+      "singular": "metastorebackup",
+      "plural": "metastorebackups",
+      "shortNames": [
+        "gcpmetastorebackup",
+        "gcpmetastorebackups"
+      ]
+    },
+    "metastore.cnrm.cloud.google.com/MetastoreFederation": {
+      "singular": "metastorefederation",
+      "plural": "metastorefederations",
+      "shortNames": [
+        "gcpmetastorefederation",
+        "gcpmetastorefederations"
+      ]
+    },
+    "metastore.cnrm.cloud.google.com/MetastoreService": {
+      "singular": "metastoreservice",
+      "plural": "metastoreservices",
+      "shortNames": [
+        "gcpmetastoreservice",
+        "gcpmetastoreservices"
+      ]
+    },
+    "mlengine.cnrm.cloud.google.com/MLEngineModel": {
+      "singular": "mlenginemodel",
+      "plural": "mlenginemodels",
+      "shortNames": [
+        "gcpmlenginemodel",
+        "gcpmlenginemodels"
+      ]
+    },
+    "modelarmor.cnrm.cloud.google.com/ModelArmorTemplate": {
+      "singular": "modelarmortemplate",
+      "plural": "modelarmortemplates",
+      "shortNames": [
+        "gcpmodelarmortemplate",
+        "gcpmodelarmortemplates"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringAlertPolicy": {
+      "singular": "monitoringalertpolicy",
+      "plural": "monitoringalertpolicies",
+      "shortNames": [
+        "gcpmonitoringalertpolicy",
+        "gcpmonitoringalertpolicies"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringDashboard": {
+      "singular": "monitoringdashboard",
+      "plural": "monitoringdashboards",
+      "shortNames": [
+        "gcpmonitoringdashboard",
+        "gcpmonitoringdashboards"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringGroup": {
+      "singular": "monitoringgroup",
+      "plural": "monitoringgroups",
+      "shortNames": [
+        "gcpmonitoringgroup",
+        "gcpmonitoringgroups"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringMetricDescriptor": {
+      "singular": "monitoringmetricdescriptor",
+      "plural": "monitoringmetricdescriptors",
+      "shortNames": [
+        "gcpmonitoringmetricdescriptor",
+        "gcpmonitoringmetricdescriptors"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringMonitoredProject": {
+      "singular": "monitoringmonitoredproject",
+      "plural": "monitoringmonitoredprojects",
+      "shortNames": [
+        "gcpmonitoringmonitoredproject",
+        "gcpmonitoringmonitoredprojects"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringNotificationChannel": {
+      "singular": "monitoringnotificationchannel",
+      "plural": "monitoringnotificationchannels",
+      "shortNames": [
+        "gcpmonitoringnotificationchannel",
+        "gcpmonitoringnotificationchannels"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringService": {
+      "singular": "monitoringservice",
+      "plural": "monitoringservices",
+      "shortNames": [
+        "gcpmonitoringservice",
+        "gcpmonitoringservices"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringServiceLevelObjective": {
+      "singular": "monitoringservicelevelobjective",
+      "plural": "monitoringservicelevelobjectives",
+      "shortNames": [
+        "gcpmonitoringservicelevelobjective",
+        "gcpmonitoringservicelevelobjectives"
+      ]
+    },
+    "monitoring.cnrm.cloud.google.com/MonitoringUptimeCheckConfig": {
+      "singular": "monitoringuptimecheckconfig",
+      "plural": "monitoringuptimecheckconfigs",
+      "shortNames": [
+        "gcpmonitoringuptimecheckconfig",
+        "gcpmonitoringuptimecheckconfigs"
+      ]
+    },
+    "netapp.cnrm.cloud.google.com/NetAppBackupPolicy": {
+      "singular": "netappbackuppolicy",
+      "plural": "netappbackuppolicies",
+      "shortNames": [
+        "gcpnetappbackuppolicy",
+        "gcpnetappbackuppolicies"
+      ]
+    },
+    "netapp.cnrm.cloud.google.com/NetAppBackupVault": {
+      "singular": "netappbackupvault",
+      "plural": "netappbackupvaults",
+      "shortNames": [
+        "gcpnetappbackupvault",
+        "gcpnetappbackupvaults"
+      ]
+    },
+    "networkconnectivity.cnrm.cloud.google.com/NetworkConnectivityHub": {
+      "singular": "networkconnectivityhub",
+      "plural": "networkconnectivityhubs",
+      "shortNames": [
+        "gcpnetworkconnectivityhub",
+        "gcpnetworkconnectivityhubs"
+      ]
+    },
+    "networkconnectivity.cnrm.cloud.google.com/NetworkConnectivityInternalRange": {
+      "singular": "networkconnectivityinternalrange",
+      "plural": "networkconnectivityinternalranges",
+      "shortNames": [
+        "gcpnetworkconnectivityinternalrange",
+        "gcpnetworkconnectivityinternalranges"
+      ]
+    },
+    "networkconnectivity.cnrm.cloud.google.com/NetworkConnectivityRegionalEndpoint": {
+      "singular": "networkconnectivityregionalendpoint",
+      "plural": "networkconnectivityregionalendpoints",
+      "shortNames": [
+        "gcpnetworkconnectivityregionalendpoint",
+        "gcpnetworkconnectivityregionalendpoints"
+      ]
+    },
+    "networkconnectivity.cnrm.cloud.google.com/NetworkConnectivityServiceConnectionPolicy": {
+      "singular": "networkconnectivityserviceconnectionpolicy",
+      "plural": "networkconnectivityserviceconnectionpolicies",
+      "shortNames": [
+        "gcpnetworkconnectivityserviceconnectionpolicy",
+        "gcpnetworkconnectivityserviceconnectionpolicies"
+      ]
+    },
+    "networkconnectivity.cnrm.cloud.google.com/NetworkConnectivitySpoke": {
+      "singular": "networkconnectivityspoke",
+      "plural": "networkconnectivityspokes",
+      "shortNames": [
+        "gcpnetworkconnectivityspoke",
+        "gcpnetworkconnectivityspokes"
+      ]
+    },
+    "networkmanagement.cnrm.cloud.google.com/NetworkManagementConnectivityTest": {
+      "singular": "networkmanagementconnectivitytest",
+      "plural": "networkmanagementconnectivitytests",
+      "shortNames": [
+        "gcpnetworkmanagementconnectivitytest",
+        "gcpnetworkmanagementconnectivitytests"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityAuthorizationPolicy": {
+      "singular": "networksecurityauthorizationpolicy",
+      "plural": "networksecurityauthorizationpolicies",
+      "shortNames": [
+        "gcpnetworksecurityauthorizationpolicy",
+        "gcpnetworksecurityauthorizationpolicies"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityBackendAuthenticationConfig": {
+      "singular": "networksecuritybackendauthenticationconfig",
+      "plural": "networksecuritybackendauthenticationconfigs",
+      "shortNames": [
+        "gcpnetworksecuritybackendauthenticationconfig",
+        "gcpnetworksecuritybackendauthenticationconfigs"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityClientTLSPolicy": {
+      "singular": "networksecurityclienttlspolicy",
+      "plural": "networksecurityclienttlspolicies",
+      "shortNames": [
+        "gcpnetworksecurityclienttlspolicy",
+        "gcpnetworksecurityclienttlspolicies"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityInterceptDeployment": {
+      "singular": "networksecurityinterceptdeployment",
+      "plural": "networksecurityinterceptdeployments",
+      "shortNames": [
+        "gcpnetworksecurityinterceptdeployment",
+        "gcpnetworksecurityinterceptdeployments"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityInterceptEndpointGroup": {
+      "singular": "networksecurityinterceptendpointgroup",
+      "plural": "networksecurityinterceptendpointgroups",
+      "shortNames": [
+        "gcpnetworksecurityinterceptendpointgroup",
+        "gcpnetworksecurityinterceptendpointgroups"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityMirroringDeployment": {
+      "singular": "networksecuritymirroringdeployment",
+      "plural": "networksecuritymirroringdeployments",
+      "shortNames": [
+        "gcpnetworksecuritymirroringdeployment",
+        "gcpnetworksecuritymirroringdeployments"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityMirroringEndpointGroup": {
+      "singular": "networksecuritymirroringendpointgroup",
+      "plural": "networksecuritymirroringendpointgroups",
+      "shortNames": [
+        "gcpnetworksecuritymirroringendpointgroup",
+        "gcpnetworksecuritymirroringendpointgroups"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecuritySACRealm": {
+      "singular": "networksecuritysacrealm",
+      "plural": "networksecuritysacrealms",
+      "shortNames": [
+        "gcpnetworksecuritysacrealm",
+        "gcpnetworksecuritysacrealms"
+      ]
+    },
+    "networksecurity.cnrm.cloud.google.com/NetworkSecurityServerTLSPolicy": {
+      "singular": "networksecurityservertlspolicy",
+      "plural": "networksecurityservertlspolicies",
+      "shortNames": [
+        "gcpnetworksecurityservertlspolicy",
+        "gcpnetworksecurityservertlspolicies"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesEdgeCacheKeyset": {
+      "singular": "networkservicesedgecachekeyset",
+      "plural": "networkservicesedgecachekeysets",
+      "shortNames": [
+        "gcpnetworkservicesedgecachekeyset",
+        "gcpnetworkservicesedgecachekeysets"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesEdgeCacheOrigin": {
+      "singular": "networkservicesedgecacheorigin",
+      "plural": "networkservicesedgecacheorigins",
+      "shortNames": [
+        "gcpnetworkservicesedgecacheorigin",
+        "gcpnetworkservicesedgecacheorigins"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesEdgeCacheService": {
+      "singular": "networkservicesedgecacheservice",
+      "plural": "networkservicesedgecacheservices",
+      "shortNames": [
+        "gcpnetworkservicesedgecacheservice",
+        "gcpnetworkservicesedgecacheservices"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesEndpointPolicy": {
+      "singular": "networkservicesendpointpolicy",
+      "plural": "networkservicesendpointpolicies",
+      "shortNames": [
+        "gcpnetworkservicesendpointpolicy",
+        "gcpnetworkservicesendpointpolicies"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesGRPCRoute": {
+      "singular": "networkservicesgrpcroute",
+      "plural": "networkservicesgrpcroutes",
+      "shortNames": [
+        "gcpnetworkservicesgrpcroute",
+        "gcpnetworkservicesgrpcroutes"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesGateway": {
+      "singular": "networkservicesgateway",
+      "plural": "networkservicesgateways",
+      "shortNames": [
+        "gcpnetworkservicesgateway",
+        "gcpnetworkservicesgateways"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesHTTPRoute": {
+      "singular": "networkserviceshttproute",
+      "plural": "networkserviceshttproutes",
+      "shortNames": [
+        "gcpnetworkserviceshttproute",
+        "gcpnetworkserviceshttproutes"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesLBRouteExtension": {
+      "singular": "networkserviceslbrouteextension",
+      "plural": "networkserviceslbrouteextensions",
+      "shortNames": [
+        "gcpnetworkserviceslbrouteextension",
+        "gcpnetworkserviceslbrouteextensions"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesMesh": {
+      "singular": "networkservicesmesh",
+      "plural": "networkservicesmeshes",
+      "shortNames": [
+        "gcpnetworkservicesmesh",
+        "gcpnetworkservicesmeshes"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesServiceBinding": {
+      "singular": "networkservicesservicebinding",
+      "plural": "networkservicesservicebindings",
+      "shortNames": [
+        "gcpnetworkservicesservicebinding",
+        "gcpnetworkservicesservicebindings"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesTCPRoute": {
+      "singular": "networkservicestcproute",
+      "plural": "networkservicestcproutes",
+      "shortNames": [
+        "gcpnetworkservicestcproute",
+        "gcpnetworkservicestcproutes"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesTLSRoute": {
+      "singular": "networkservicestlsroute",
+      "plural": "networkservicestlsroutes",
+      "shortNames": [
+        "gcpnetworkservicestlsroute",
+        "gcpnetworkservicestlsroutes"
+      ]
+    },
+    "networkservices.cnrm.cloud.google.com/NetworkServicesWasmPlugin": {
+      "singular": "networkserviceswasmplugin",
+      "plural": "networkserviceswasmplugins",
+      "shortNames": [
+        "gcpnetworkserviceswasmplugin",
+        "gcpnetworkserviceswasmplugins"
+      ]
+    },
+    "notebooks.cnrm.cloud.google.com/NotebookInstance": {
+      "singular": "notebookinstance",
+      "plural": "notebookinstances",
+      "shortNames": [
+        "gcpnotebookinstance",
+        "gcpnotebookinstances"
+      ]
+    },
+    "notebooks.cnrm.cloud.google.com/NotebooksEnvironment": {
+      "singular": "notebooksenvironment",
+      "plural": "notebooksenvironments",
+      "shortNames": [
+        "gcpnotebooksenvironment",
+        "gcpnotebooksenvironments"
+      ]
+    },
+    "notebooks.cnrm.cloud.google.com/NotebooksExecution": {
+      "singular": "notebooksexecution",
+      "plural": "notebooksexecutions",
+      "shortNames": [
+        "gcpnotebooksexecution",
+        "gcpnotebooksexecutions"
+      ]
+    },
+    "orgpolicy.cnrm.cloud.google.com/OrgPolicyCustomConstraint": {
+      "singular": "orgpolicycustomconstraint",
+      "plural": "orgpolicycustomconstraints",
+      "shortNames": [
+        "gcporgpolicycustomconstraint",
+        "gcporgpolicycustomconstraints"
+      ]
+    },
+    "orgpolicy.cnrm.cloud.google.com/OrgPolicyPolicy": {
+      "singular": "orgpolicypolicy",
+      "plural": "orgpolicypolicies",
+      "shortNames": [
+        "gcporgpolicypolicy",
+        "gcporgpolicypolicies"
+      ]
+    },
+    "osconfig.cnrm.cloud.google.com/OSConfigGuestPolicy": {
+      "singular": "osconfigguestpolicy",
+      "plural": "osconfigguestpolicies",
+      "shortNames": [
+        "gcposconfigguestpolicy",
+        "gcposconfigguestpolicies"
+      ]
+    },
+    "osconfig.cnrm.cloud.google.com/OSConfigOSPolicyAssignment": {
+      "singular": "osconfigospolicyassignment",
+      "plural": "osconfigospolicyassignments",
+      "shortNames": [
+        "gcposconfigospolicyassignment",
+        "gcposconfigospolicyassignments"
+      ]
+    },
+    "osconfig.cnrm.cloud.google.com/OSConfigPatchDeployment": {
+      "singular": "osconfigpatchdeployment",
+      "plural": "osconfigpatchdeployments",
+      "shortNames": [
+        "gcposconfigpatchdeployment",
+        "gcposconfigpatchdeployments"
+      ]
+    },
+    "oslogin.cnrm.cloud.google.com/OSLoginSSHPublicKey": {
+      "singular": "osloginsshpublickey",
+      "plural": "osloginsshpublickeys",
+      "shortNames": [
+        "gcposloginsshpublickey",
+        "gcposloginsshpublickeys"
+      ]
+    },
+    "parametermanager.cnrm.cloud.google.com/ParameterManagerParameter": {
+      "singular": "parametermanagerparameter",
+      "plural": "parametermanagerparameters",
+      "shortNames": [
+        "gcpparametermanagerparameter",
+        "gcpparametermanagerparameters"
+      ]
+    },
+    "parametermanager.cnrm.cloud.google.com/ParameterManagerParameterVersion": {
+      "singular": "parametermanagerparameterversion",
+      "plural": "parametermanagerparameterversions",
+      "shortNames": [
+        "gcpparametermanagerparameterversion",
+        "gcpparametermanagerparameterversions"
+      ]
+    },
+    "privateca.cnrm.cloud.google.com/PrivateCACAPool": {
+      "singular": "privatecacapool",
+      "plural": "privatecacapools",
+      "shortNames": [
+        "gcpprivatecacapool",
+        "gcpprivatecacapools"
+      ]
+    },
+    "privateca.cnrm.cloud.google.com/PrivateCACertificate": {
+      "singular": "privatecacertificate",
+      "plural": "privatecacertificates",
+      "shortNames": [
+        "gcpprivatecacertificate",
+        "gcpprivatecacertificates"
+      ]
+    },
+    "privateca.cnrm.cloud.google.com/PrivateCACertificateAuthority": {
+      "singular": "privatecacertificateauthority",
+      "plural": "privatecacertificateauthorities",
+      "shortNames": [
+        "gcpprivatecacertificateauthority",
+        "gcpprivatecacertificateauthorities"
+      ]
+    },
+    "privateca.cnrm.cloud.google.com/PrivateCACertificateTemplate": {
+      "singular": "privatecacertificatetemplate",
+      "plural": "privatecacertificatetemplates",
+      "shortNames": [
+        "gcpprivatecacertificatetemplate",
+        "gcpprivatecacertificatetemplates"
+      ]
+    },
+    "privilegedaccessmanager.cnrm.cloud.google.com/PrivilegedAccessManagerEntitlement": {
+      "singular": "privilegedaccessmanagerentitlement",
+      "plural": "privilegedaccessmanagerentitlements",
+      "shortNames": [
+        "gcpprivilegedaccessmanagerentitlement",
+        "gcpprivilegedaccessmanagerentitlements"
+      ]
+    },
+    "pubsub.cnrm.cloud.google.com/PubSubSchema": {
+      "singular": "pubsubschema",
+      "plural": "pubsubschemas",
+      "shortNames": [
+        "gcppubsubschema",
+        "gcppubsubschemas"
+      ]
+    },
+    "pubsub.cnrm.cloud.google.com/PubSubSnapshot": {
+      "singular": "pubsubsnapshot",
+      "plural": "pubsubsnapshots",
+      "shortNames": [
+        "gcppubsubsnapshot",
+        "gcppubsubsnapshots"
+      ]
+    },
+    "pubsub.cnrm.cloud.google.com/PubSubSubscription": {
+      "singular": "pubsubsubscription",
+      "plural": "pubsubsubscriptions",
+      "shortNames": [
+        "gcppubsubsubscription",
+        "gcppubsubsubscriptions"
+      ]
+    },
+    "pubsub.cnrm.cloud.google.com/PubSubTopic": {
+      "singular": "pubsubtopic",
+      "plural": "pubsubtopics",
+      "shortNames": [
+        "gcppubsubtopic",
+        "gcppubsubtopics"
+      ]
+    },
+    "pubsublite.cnrm.cloud.google.com/PubSubLiteReservation": {
+      "singular": "pubsublitereservation",
+      "plural": "pubsublitereservations",
+      "shortNames": [
+        "gcppubsublitereservation",
+        "gcppubsublitereservations"
+      ]
+    },
+    "pubsublite.cnrm.cloud.google.com/PubSubLiteSubscription": {
+      "singular": "pubsublitesubscription",
+      "plural": "pubsublitesubscriptions",
+      "shortNames": [
+        "gcppubsublitesubscription",
+        "gcppubsublitesubscriptions"
+      ]
+    },
+    "pubsublite.cnrm.cloud.google.com/PubSubLiteTopic": {
+      "singular": "pubsublitetopic",
+      "plural": "pubsublitetopics",
+      "shortNames": [
+        "gcppubsublitetopic",
+        "gcppubsublitetopics"
+      ]
+    },
+    "recaptchaenterprise.cnrm.cloud.google.com/ReCAPTCHAEnterpriseFirewallPolicy": {
+      "singular": "recaptchaenterprisefirewallpolicy",
+      "plural": "recaptchaenterprisefirewallpolicies",
+      "shortNames": [
+        "gcprecaptchaenterprisefirewallpolicy",
+        "gcprecaptchaenterprisefirewallpolicies"
+      ]
+    },
+    "recaptchaenterprise.cnrm.cloud.google.com/RecaptchaEnterpriseKey": {
+      "singular": "recaptchaenterprisekey",
+      "plural": "recaptchaenterprisekeys",
+      "shortNames": [
+        "gcprecaptchaenterprisekey",
+        "gcprecaptchaenterprisekeys"
+      ]
+    },
+    "redis.cnrm.cloud.google.com/RedisCluster": {
+      "singular": "rediscluster",
+      "plural": "redisclusters",
+      "shortNames": [
+        "gcprediscluster",
+        "gcpredisclusters"
+      ]
+    },
+    "redis.cnrm.cloud.google.com/RedisInstance": {
+      "singular": "redisinstance",
+      "plural": "redisinstances",
+      "shortNames": [
+        "gcpredisinstance",
+        "gcpredisinstances"
+      ]
+    },
+    "resourcemanager.cnrm.cloud.google.com/Folder": {
+      "singular": "folder",
+      "plural": "folders",
+      "shortNames": [
+        "gcpfolder",
+        "gcpfolders"
+      ]
+    },
+    "resourcemanager.cnrm.cloud.google.com/Project": {
+      "singular": "project",
+      "plural": "projects",
+      "shortNames": [
+        "gcpproject",
+        "gcpprojects"
+      ]
+    },
+    "resourcemanager.cnrm.cloud.google.com/ResourceManagerLien": {
+      "singular": "resourcemanagerlien",
+      "plural": "resourcemanagerliens",
+      "shortNames": [
+        "gcpresourcemanagerlien",
+        "gcpresourcemanagerliens"
+      ]
+    },
+    "resourcemanager.cnrm.cloud.google.com/ResourceManagerPolicy": {
+      "singular": "resourcemanagerpolicy",
+      "plural": "resourcemanagerpolicies",
+      "shortNames": [
+        "gcpresourcemanagerpolicy",
+        "gcpresourcemanagerpolicies"
+      ]
+    },
+    "run.cnrm.cloud.google.com/RunJob": {
+      "singular": "runjob",
+      "plural": "runjobs",
+      "shortNames": [
+        "gcprunjob",
+        "gcprunjobs"
+      ]
+    },
+    "run.cnrm.cloud.google.com/RunService": {
+      "singular": "runservice",
+      "plural": "runservices",
+      "shortNames": [
+        "gcprunservice",
+        "gcprunservices"
+      ]
+    },
+    "secretmanager.cnrm.cloud.google.com/SecretManagerSecret": {
+      "singular": "secretmanagersecret",
+      "plural": "secretmanagersecrets",
+      "shortNames": [
+        "gcpsecretmanagersecret",
+        "gcpsecretmanagersecrets"
+      ]
+    },
+    "secretmanager.cnrm.cloud.google.com/SecretManagerSecretVersion": {
+      "singular": "secretmanagersecretversion",
+      "plural": "secretmanagersecretversions",
+      "shortNames": [
+        "gcpsecretmanagersecretversion",
+        "gcpsecretmanagersecretversions"
+      ]
+    },
+    "securesourcemanager.cnrm.cloud.google.com/SecureSourceManagerInstance": {
+      "singular": "securesourcemanagerinstance",
+      "plural": "securesourcemanagerinstances",
+      "shortNames": [
+        "gcpsecuresourcemanagerinstance",
+        "gcpsecuresourcemanagerinstances"
+      ]
+    },
+    "securesourcemanager.cnrm.cloud.google.com/SecureSourceManagerRepository": {
+      "singular": "securesourcemanagerrepository",
+      "plural": "securesourcemanagerrepositories",
+      "shortNames": [
+        "gcpsecuresourcemanagerrepository",
+        "gcpsecuresourcemanagerrepositories"
+      ]
+    },
+    "securitycenter.cnrm.cloud.google.com/SecurityCenterBigQueryExport": {
+      "singular": "securitycenterbigqueryexport",
+      "plural": "securitycenterbigqueryexports",
+      "shortNames": [
+        "gcpsecuritycenterbigqueryexport",
+        "gcpsecuritycenterbigqueryexports"
+      ]
+    },
+    "securitycenter.cnrm.cloud.google.com/SecurityCenterMuteConfig": {
+      "singular": "securitycentermuteconfig",
+      "plural": "securitycentermuteconfigs",
+      "shortNames": [
+        "gcpsecuritycentermuteconfig",
+        "gcpsecuritycentermuteconfigs"
+      ]
+    },
+    "securitycenter.cnrm.cloud.google.com/SecurityCenterNotificationConfig": {
+      "singular": "securitycenternotificationconfig",
+      "plural": "securitycenternotificationconfigs",
+      "shortNames": [
+        "gcpsecuritycenternotificationconfig",
+        "gcpsecuritycenternotificationconfigs"
+      ]
+    },
+    "securitycenter.cnrm.cloud.google.com/SecurityCenterSource": {
+      "singular": "securitycentersource",
+      "plural": "securitycentersources",
+      "shortNames": [
+        "gcpsecuritycentersource",
+        "gcpsecuritycentersources"
+      ]
+    },
+    "servicedirectory.cnrm.cloud.google.com/ServiceDirectoryEndpoint": {
+      "singular": "servicedirectoryendpoint",
+      "plural": "servicedirectoryendpoints",
+      "shortNames": [
+        "gcpservicedirectoryendpoint",
+        "gcpservicedirectoryendpoints"
+      ]
+    },
+    "servicedirectory.cnrm.cloud.google.com/ServiceDirectoryNamespace": {
+      "singular": "servicedirectorynamespace",
+      "plural": "servicedirectorynamespaces",
+      "shortNames": [
+        "gcpservicedirectorynamespace",
+        "gcpservicedirectorynamespaces"
+      ]
+    },
+    "servicedirectory.cnrm.cloud.google.com/ServiceDirectoryService": {
+      "singular": "servicedirectoryservice",
+      "plural": "servicedirectoryservices",
+      "shortNames": [
+        "gcpservicedirectoryservice",
+        "gcpservicedirectoryservices"
+      ]
+    },
+    "servicenetworking.cnrm.cloud.google.com/ServiceNetworkingConnection": {
+      "singular": "servicenetworkingconnection",
+      "plural": "servicenetworkingconnections",
+      "shortNames": [
+        "gcpservicenetworkingconnection",
+        "gcpservicenetworkingconnections"
+      ]
+    },
+    "servicenetworking.cnrm.cloud.google.com/ServiceNetworkingPeeredDNSDomain": {
+      "singular": "servicenetworkingpeereddnsdomain",
+      "plural": "servicenetworkingpeereddnsdomains",
+      "shortNames": [
+        "gcpservicenetworkingpeereddnsdomain",
+        "gcpservicenetworkingpeereddnsdomains"
+      ]
+    },
+    "serviceusage.cnrm.cloud.google.com/Service": {
+      "singular": "service",
+      "plural": "services",
+      "shortNames": [
+        "gcpservice",
+        "gcpservices"
+      ]
+    },
+    "serviceusage.cnrm.cloud.google.com/ServiceIdentity": {
+      "singular": "serviceidentity",
+      "plural": "serviceidentities",
+      "shortNames": [
+        "gcpserviceidentity",
+        "gcpserviceidentities"
+      ]
+    },
+    "serviceusage.cnrm.cloud.google.com/ServiceUsageConsumerQuotaOverride": {
+      "singular": "serviceusageconsumerquotaoverride",
+      "plural": "serviceusageconsumerquotaoverrides",
+      "shortNames": [
+        "gcpserviceusageconsumerquotaoverride",
+        "gcpserviceusageconsumerquotaoverrides"
+      ]
+    },
+    "sourcerepo.cnrm.cloud.google.com/SourceRepoRepository": {
+      "singular": "sourcereporepository",
+      "plural": "sourcereporepositories",
+      "shortNames": [
+        "gcpsourcereporepository",
+        "gcpsourcereporepositories"
+      ]
+    },
+    "spanner.cnrm.cloud.google.com/SpannerBackupSchedule": {
+      "singular": "spannerbackupschedule",
+      "plural": "spannerbackupschedules",
+      "shortNames": [
+        "gcpspannerbackupschedule",
+        "gcpspannerbackupschedules"
+      ]
+    },
+    "spanner.cnrm.cloud.google.com/SpannerDatabase": {
+      "singular": "spannerdatabase",
+      "plural": "spannerdatabases",
+      "shortNames": [
+        "gcpspannerdatabase",
+        "gcpspannerdatabases"
+      ]
+    },
+    "spanner.cnrm.cloud.google.com/SpannerInstance": {
+      "singular": "spannerinstance",
+      "plural": "spannerinstances",
+      "shortNames": [
+        "gcpspannerinstance",
+        "gcpspannerinstances"
+      ]
+    },
+    "spanner.cnrm.cloud.google.com/SpannerInstanceConfig": {
+      "singular": "spannerinstanceconfig",
+      "plural": "spannerinstanceconfigs",
+      "shortNames": [
+        "gcpspannerinstanceconfig",
+        "gcpspannerinstanceconfigs"
+      ]
+    },
+    "speech.cnrm.cloud.google.com/SpeechCustomClass": {
+      "singular": "speechcustomclass",
+      "plural": "speechcustomclasses",
+      "shortNames": [
+        "gcpspeechcustomclass",
+        "gcpspeechcustomclasses"
+      ]
+    },
+    "speech.cnrm.cloud.google.com/SpeechPhraseSet": {
+      "singular": "speechphraseset",
+      "plural": "speechphrasesets",
+      "shortNames": [
+        "gcpspeechphraseset",
+        "gcpspeechphrasesets"
+      ]
+    },
+    "speech.cnrm.cloud.google.com/SpeechRecognizer": {
+      "singular": "speechrecognizer",
+      "plural": "speechrecognizers",
+      "shortNames": [
+        "gcpspeechrecognizer",
+        "gcpspeechrecognizers"
+      ]
+    },
+    "sql.cnrm.cloud.google.com/SQLDatabase": {
+      "singular": "sqldatabase",
+      "plural": "sqldatabases",
+      "shortNames": [
+        "gcpsqldatabase",
+        "gcpsqldatabases"
+      ]
+    },
+    "sql.cnrm.cloud.google.com/SQLInstance": {
+      "singular": "sqlinstance",
+      "plural": "sqlinstances",
+      "shortNames": [
+        "gcpsqlinstance",
+        "gcpsqlinstances"
+      ]
+    },
+    "sql.cnrm.cloud.google.com/SQLSSLCert": {
+      "singular": "sqlsslcert",
+      "plural": "sqlsslcerts",
+      "shortNames": [
+        "gcpsqlsslcert",
+        "gcpsqlsslcerts"
+      ]
+    },
+    "sql.cnrm.cloud.google.com/SQLUser": {
+      "singular": "sqluser",
+      "plural": "sqlusers",
+      "shortNames": [
+        "gcpsqluser",
+        "gcpsqlusers"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageAnywhereCache": {
+      "singular": "storageanywherecache",
+      "plural": "storageanywherecaches",
+      "shortNames": [
+        "gcpstorageanywherecache",
+        "gcpstorageanywherecaches"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageBucket": {
+      "singular": "storagebucket",
+      "plural": "storagebuckets",
+      "shortNames": [
+        "gcpstoragebucket",
+        "gcpstoragebuckets"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageBucketAccessControl": {
+      "singular": "storagebucketaccesscontrol",
+      "plural": "storagebucketaccesscontrols",
+      "shortNames": [
+        "gcpstoragebucketaccesscontrol",
+        "gcpstoragebucketaccesscontrols"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageDefaultObjectAccessControl": {
+      "singular": "storagedefaultobjectaccesscontrol",
+      "plural": "storagedefaultobjectaccesscontrols",
+      "shortNames": [
+        "gcpstoragedefaultobjectaccesscontrol",
+        "gcpstoragedefaultobjectaccesscontrols"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageFolder": {
+      "singular": "storagefolder",
+      "plural": "storagefolders",
+      "shortNames": [
+        "gcpstoragefolder",
+        "gcpstoragefolders"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageHMACKey": {
+      "singular": "storagehmackey",
+      "plural": "storagehmackeys",
+      "shortNames": [
+        "gcpstoragehmackey",
+        "gcpstoragehmackeys"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageManagedFolder": {
+      "singular": "storagemanagedfolder",
+      "plural": "storagemanagedfolders",
+      "shortNames": [
+        "gcpstoragemanagedfolder",
+        "gcpstoragemanagedfolders"
+      ]
+    },
+    "storage.cnrm.cloud.google.com/StorageNotification": {
+      "singular": "storagenotification",
+      "plural": "storagenotifications",
+      "shortNames": [
+        "gcpstoragenotification",
+        "gcpstoragenotifications"
+      ]
+    },
+    "storagetransfer.cnrm.cloud.google.com/StorageTransferAgentPool": {
+      "singular": "storagetransferagentpool",
+      "plural": "storagetransferagentpools",
+      "shortNames": [
+        "gcpstoragetransferagentpool",
+        "gcpstoragetransferagentpools"
+      ]
+    },
+    "storagetransfer.cnrm.cloud.google.com/StorageTransferJob": {
+      "singular": "storagetransferjob",
+      "plural": "storagetransferjobs",
+      "shortNames": [
+        "gcpstoragetransferjob",
+        "gcpstoragetransferjobs"
+      ]
+    },
+    "tags.cnrm.cloud.google.com/TagsLocationTagBinding": {
+      "singular": "tagslocationtagbinding",
+      "plural": "tagslocationtagbindings",
+      "shortNames": [
+        "gcptagslocationtagbinding",
+        "gcptagslocationtagbindings"
+      ]
+    },
+    "tags.cnrm.cloud.google.com/TagsTagBinding": {
+      "singular": "tagstagbinding",
+      "plural": "tagstagbindings",
+      "shortNames": [
+        "gcptagstagbinding",
+        "gcptagstagbindings"
+      ]
+    },
+    "tags.cnrm.cloud.google.com/TagsTagKey": {
+      "singular": "tagstagkey",
+      "plural": "tagstagkeys",
+      "shortNames": [
+        "gcptagstagkey",
+        "gcptagstagkeys"
+      ]
+    },
+    "tags.cnrm.cloud.google.com/TagsTagValue": {
+      "singular": "tagstagvalue",
+      "plural": "tagstagvalues",
+      "shortNames": [
+        "gcptagstagvalue",
+        "gcptagstagvalues"
+      ]
+    },
+    "tpu.cnrm.cloud.google.com/TPUNode": {
+      "singular": "tpunode",
+      "plural": "tpunodes",
+      "shortNames": [
+        "gcptpunode",
+        "gcptpunodes"
+      ]
+    },
+    "tpu.cnrm.cloud.google.com/TPUVirtualMachine": {
+      "singular": "tpuvirtualmachine",
+      "plural": "tpuvirtualmachines",
+      "shortNames": [
+        "gcptpuvirtualmachine",
+        "gcptpuvirtualmachines"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIDataLabelingJob": {
+      "singular": "vertexaidatalabelingjob",
+      "plural": "vertexaidatalabelingjobs",
+      "shortNames": [
+        "gcpvertexaidatalabelingjob",
+        "gcpvertexaidatalabelingjobs"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIDataset": {
+      "singular": "vertexaidataset",
+      "plural": "vertexaidatasets",
+      "shortNames": [
+        "gcpvertexaidataset",
+        "gcpvertexaidatasets"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIDeploymentResourcePool": {
+      "singular": "vertexaideploymentresourcepool",
+      "plural": "vertexaideploymentresourcepools",
+      "shortNames": [
+        "gcpvertexaideploymentresourcepool",
+        "gcpvertexaideploymentresourcepools"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIEndpoint": {
+      "singular": "vertexaiendpoint",
+      "plural": "vertexaiendpoints",
+      "shortNames": [
+        "gcpvertexaiendpoint",
+        "gcpvertexaiendpoints"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIExampleStore": {
+      "singular": "vertexaiexamplestore",
+      "plural": "vertexaiexamplestores",
+      "shortNames": [
+        "gcpvertexaiexamplestore",
+        "gcpvertexaiexamplestores"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIFeaturestore": {
+      "singular": "vertexaifeaturestore",
+      "plural": "vertexaifeaturestores",
+      "shortNames": [
+        "gcpvertexaifeaturestore",
+        "gcpvertexaifeaturestores"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIFeaturestoreEntityType": {
+      "singular": "vertexaifeaturestoreentitytype",
+      "plural": "vertexaifeaturestoreentitytypes",
+      "shortNames": [
+        "gcpvertexaifeaturestoreentitytype",
+        "gcpvertexaifeaturestoreentitytypes"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIFeaturestoreEntityTypeFeature": {
+      "singular": "vertexaifeaturestoreentitytypefeature",
+      "plural": "vertexaifeaturestoreentitytypefeatures",
+      "shortNames": [
+        "gcpvertexaifeaturestoreentitytypefeature",
+        "gcpvertexaifeaturestoreentitytypefeatures"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIIndex": {
+      "singular": "vertexaiindex",
+      "plural": "vertexaiindexes",
+      "shortNames": [
+        "gcpvertexaiindex",
+        "gcpvertexaiindexes"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIIndexEndpoint": {
+      "singular": "vertexaiindexendpoint",
+      "plural": "vertexaiindexendpoints",
+      "shortNames": [
+        "gcpvertexaiindexendpoint",
+        "gcpvertexaiindexendpoints"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAIMetadataStore": {
+      "singular": "vertexaimetadatastore",
+      "plural": "vertexaimetadatastores",
+      "shortNames": [
+        "gcpvertexaimetadatastore",
+        "gcpvertexaimetadatastores"
+      ]
+    },
+    "vertexai.cnrm.cloud.google.com/VertexAITensorboard": {
+      "singular": "vertexaitensorboard",
+      "plural": "vertexaitensorboards",
+      "shortNames": [
+        "gcpvertexaitensorboard",
+        "gcpvertexaitensorboards"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEngineExternalAccessRule": {
+      "singular": "vmwareengineexternalaccessrule",
+      "plural": "vmwareengineexternalaccessrules",
+      "shortNames": [
+        "gcpvmwareengineexternalaccessrule",
+        "gcpvmwareengineexternalaccessrules"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEngineExternalAddress": {
+      "singular": "vmwareengineexternaladdress",
+      "plural": "vmwareengineexternaladdresses",
+      "shortNames": [
+        "gcpvmwareengineexternaladdress",
+        "gcpvmwareengineexternaladdresses"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEngineNetwork": {
+      "singular": "vmwareenginenetwork",
+      "plural": "vmwareenginenetworks",
+      "shortNames": [
+        "gcpvmwareenginenetwork",
+        "gcpvmwareenginenetworks"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEngineNetworkPeering": {
+      "singular": "vmwareenginenetworkpeering",
+      "plural": "vmwareenginenetworkpeerings",
+      "shortNames": [
+        "gcpvmwareenginenetworkpeering",
+        "gcpvmwareenginenetworkpeerings"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEngineNetworkPolicy": {
+      "singular": "vmwareenginenetworkpolicy",
+      "plural": "vmwareenginenetworkpolicies",
+      "shortNames": [
+        "gcpvmwareenginenetworkpolicy",
+        "gcpvmwareenginenetworkpolicies"
+      ]
+    },
+    "vmwareengine.cnrm.cloud.google.com/VMwareEnginePrivateCloud": {
+      "singular": "vmwareengineprivatecloud",
+      "plural": "vmwareengineprivateclouds",
+      "shortNames": [
+        "gcpvmwareengineprivatecloud",
+        "gcpvmwareengineprivateclouds"
+      ]
+    },
+    "vpcaccess.cnrm.cloud.google.com/VPCAccessConnector": {
+      "singular": "vpcaccessconnector",
+      "plural": "vpcaccessconnectors",
+      "shortNames": [
+        "gcpvpcaccessconnector",
+        "gcpvpcaccessconnectors"
+      ]
+    },
+    "workflowexecutions.cnrm.cloud.google.com/WorkflowsExecution": {
+      "singular": "workflowsexecution",
+      "plural": "workflowsexecutions",
+      "shortNames": [
+        "gcpworkflowsexecution",
+        "gcpworkflowsexecutions"
+      ]
+    },
+    "workflows.cnrm.cloud.google.com/WorkflowsWorkflow": {
+      "singular": "workflowsworkflow",
+      "plural": "workflowsworkflows",
+      "shortNames": [
+        "gcpworkflowsworkflow",
+        "gcpworkflowsworkflows"
+      ]
+    },
+    "workstations.cnrm.cloud.google.com/Workstation": {
+      "singular": "workstation",
+      "plural": "workstations",
+      "shortNames": [
+        "gcpworkstation",
+        "gcpworkstations"
+      ]
+    },
+    "workstations.cnrm.cloud.google.com/WorkstationCluster": {
+      "singular": "workstationcluster",
+      "plural": "workstationclusters",
+      "shortNames": [
+        "gcpworkstationcluster",
+        "gcpworkstationclusters"
+      ]
+    },
+    "workstations.cnrm.cloud.google.com/WorkstationConfig": {
+      "singular": "workstationconfig",
+      "plural": "workstationconfigs",
+      "shortNames": [
+        "gcpworkstationconfig",
+        "gcpworkstationconfigs"
+      ]
+    }
+  },
   "files": [
     "catalog/accesscontextmanager.cnrm.cloud.google.com/accesscontextmanageraccesslevel_v1beta1.fields.txt",
     "catalog/accesscontextmanager.cnrm.cloud.google.com/accesscontextmanageraccesslevel_v1beta1.json",

--- a/build/history/cosi.json
+++ b/build/history/cosi.json
@@ -2,7 +2,7 @@
   "name": "cosi",
   "repo": "kubernetes-sigs/container-object-storage-interface",
   "version": "v0.2.2",
-  "builtAt": "2026-07-05T17:59:24.891Z",
+  "builtAt": "2026-07-07T19:13:02.716Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "objectstorage.k8s.io/Bucket",
@@ -11,6 +11,28 @@
     "objectstorage.k8s.io/BucketClaim",
     "objectstorage.k8s.io/BucketClass"
   ],
+  "resources": {
+    "objectstorage.k8s.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "objectstorage.k8s.io/BucketAccess": {
+      "singular": "bucketaccess",
+      "plural": "bucketaccesses"
+    },
+    "objectstorage.k8s.io/BucketAccessClass": {
+      "singular": "bucketaccessclass",
+      "plural": "bucketaccessclasses"
+    },
+    "objectstorage.k8s.io/BucketClaim": {
+      "singular": "bucketclaim",
+      "plural": "bucketclaims"
+    },
+    "objectstorage.k8s.io/BucketClass": {
+      "singular": "bucketclass",
+      "plural": "bucketclasses"
+    }
+  },
   "files": [
     "catalog/objectstorage.k8s.io/bucket_v1alpha1.fields.txt",
     "catalog/objectstorage.k8s.io/bucket_v1alpha1.json",

--- a/build/history/crossplane.json
+++ b/build/history/crossplane.json
@@ -2,8 +2,8 @@
   "name": "crossplane",
   "repo": "crossplane/crossplane",
   "version": "v2.3.3",
-  "builtAt": "2026-07-05T13:24:53.158Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:59.385Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "apiextensions.crossplane.io/CompositeResourceDefinition",
     "apiextensions.crossplane.io/Composition",
@@ -27,6 +27,121 @@
     "protection.crossplane.io/ClusterUsage",
     "protection.crossplane.io/Usage"
   ],
+  "resources": {
+    "apiextensions.crossplane.io/CompositeResourceDefinition": {
+      "singular": "compositeresourcedefinition",
+      "plural": "compositeresourcedefinitions",
+      "shortNames": [
+        "xrd",
+        "xrds"
+      ]
+    },
+    "apiextensions.crossplane.io/Composition": {
+      "singular": "composition",
+      "plural": "compositions",
+      "shortNames": [
+        "comp"
+      ]
+    },
+    "apiextensions.crossplane.io/CompositionRevision": {
+      "singular": "compositionrevision",
+      "plural": "compositionrevisions",
+      "shortNames": [
+        "comprev"
+      ]
+    },
+    "apiextensions.crossplane.io/EnvironmentConfig": {
+      "singular": "environmentconfig",
+      "plural": "environmentconfigs",
+      "shortNames": [
+        "envcfg"
+      ]
+    },
+    "apiextensions.crossplane.io/ManagedResourceActivationPolicy": {
+      "singular": "managedresourceactivationpolicy",
+      "plural": "managedresourceactivationpolicies",
+      "shortNames": [
+        "mrap"
+      ]
+    },
+    "apiextensions.crossplane.io/ManagedResourceDefinition": {
+      "singular": "managedresourcedefinition",
+      "plural": "managedresourcedefinitions",
+      "shortNames": [
+        "mrd",
+        "mrds"
+      ]
+    },
+    "apiextensions.crossplane.io/Usage": {
+      "singular": "usage",
+      "plural": "usages"
+    },
+    "ops.crossplane.io/CronOperation": {
+      "singular": "cronoperation",
+      "plural": "cronoperations",
+      "shortNames": [
+        "cronops"
+      ]
+    },
+    "ops.crossplane.io/Operation": {
+      "singular": "operation",
+      "plural": "operations",
+      "shortNames": [
+        "ops"
+      ]
+    },
+    "ops.crossplane.io/WatchOperation": {
+      "singular": "watchoperation",
+      "plural": "watchoperations",
+      "shortNames": [
+        "watchops"
+      ]
+    },
+    "pkg.crossplane.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "pkg.crossplane.io/ConfigurationRevision": {
+      "singular": "configurationrevision",
+      "plural": "configurationrevisions"
+    },
+    "pkg.crossplane.io/DeploymentRuntimeConfig": {
+      "singular": "deploymentruntimeconfig",
+      "plural": "deploymentruntimeconfigs"
+    },
+    "pkg.crossplane.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "pkg.crossplane.io/FunctionRevision": {
+      "singular": "functionrevision",
+      "plural": "functionrevisions"
+    },
+    "pkg.crossplane.io/ImageConfig": {
+      "singular": "imageconfig",
+      "plural": "imageconfigs"
+    },
+    "pkg.crossplane.io/Lock": {
+      "singular": "lock",
+      "plural": "locks"
+    },
+    "pkg.crossplane.io/Provider": {
+      "singular": "provider",
+      "plural": "providers"
+    },
+    "pkg.crossplane.io/ProviderRevision": {
+      "singular": "providerrevision",
+      "plural": "providerrevisions"
+    },
+    "protection.crossplane.io/ClusterUsage": {
+      "singular": "clusterusage",
+      "plural": "clusterusages"
+    },
+    "protection.crossplane.io/Usage": {
+      "singular": "usage",
+      "plural": "usages"
+    }
+  },
   "files": [
     "catalog/apiextensions.crossplane.io/compositeresourcedefinition_v1.fields.txt",
     "catalog/apiextensions.crossplane.io/compositeresourcedefinition_v1.json",

--- a/build/history/dapr.json
+++ b/build/history/dapr.json
@@ -2,7 +2,7 @@
   "name": "dapr",
   "repo": "dapr/dapr",
   "version": "v1.18.1",
-  "builtAt": "2026-07-05T16:56:09.883Z",
+  "builtAt": "2026-07-07T19:11:16.028Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "dapr.io/Component",
@@ -13,6 +13,36 @@
     "dapr.io/Subscription",
     "dapr.io/WorkflowAccessPolicy"
   ],
+  "resources": {
+    "dapr.io/Component": {
+      "singular": "component",
+      "plural": "components"
+    },
+    "dapr.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "dapr.io/HTTPEndpoint": {
+      "singular": "httpendpoint",
+      "plural": "httpendpoints"
+    },
+    "dapr.io/MCPServer": {
+      "singular": "mcpserver",
+      "plural": "mcpservers"
+    },
+    "dapr.io/Resiliency": {
+      "singular": "resiliency",
+      "plural": "resiliencies"
+    },
+    "dapr.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "dapr.io/WorkflowAccessPolicy": {
+      "singular": "workflowaccesspolicy",
+      "plural": "workflowaccesspolicies"
+    }
+  },
   "files": [
     "catalog/dapr.io/component_v1alpha1.fields.txt",
     "catalog/dapr.io/component_v1alpha1.json",

--- a/build/history/eck-operator.json
+++ b/build/history/eck-operator.json
@@ -2,7 +2,7 @@
   "name": "eck-operator",
   "repo": "elastic/cloud-on-k8s",
   "version": "v3.4.1",
-  "builtAt": "2026-07-06T22:16:45.838Z",
+  "builtAt": "2026-07-07T19:14:40.959Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "agent.k8s.elastic.co/Agent",
@@ -18,6 +18,92 @@
     "packageregistry.k8s.elastic.co/PackageRegistry",
     "stackconfigpolicy.k8s.elastic.co/StackConfigPolicy"
   ],
+  "resources": {
+    "agent.k8s.elastic.co/Agent": {
+      "singular": "agent",
+      "plural": "agents",
+      "shortNames": [
+        "agent"
+      ]
+    },
+    "apm.k8s.elastic.co/ApmServer": {
+      "singular": "apmserver",
+      "plural": "apmservers",
+      "shortNames": [
+        "apm"
+      ]
+    },
+    "autoops.k8s.elastic.co/AutoOpsAgentPolicy": {
+      "singular": "autoopsagentpolicy",
+      "plural": "autoopsagentpolicies",
+      "shortNames": [
+        "aop"
+      ]
+    },
+    "autoscaling.k8s.elastic.co/ElasticsearchAutoscaler": {
+      "singular": "elasticsearchautoscaler",
+      "plural": "elasticsearchautoscalers",
+      "shortNames": [
+        "esa"
+      ]
+    },
+    "beat.k8s.elastic.co/Beat": {
+      "singular": "beat",
+      "plural": "beats",
+      "shortNames": [
+        "beat"
+      ]
+    },
+    "elasticsearch.k8s.elastic.co/Elasticsearch": {
+      "singular": "elasticsearch",
+      "plural": "elasticsearches",
+      "shortNames": [
+        "es"
+      ]
+    },
+    "enterprisesearch.k8s.elastic.co/EnterpriseSearch": {
+      "singular": "enterprisesearch",
+      "plural": "enterprisesearches",
+      "shortNames": [
+        "ent"
+      ]
+    },
+    "kibana.k8s.elastic.co/Kibana": {
+      "singular": "kibana",
+      "plural": "kibanas",
+      "shortNames": [
+        "kb"
+      ]
+    },
+    "logstash.k8s.elastic.co/Logstash": {
+      "singular": "logstash",
+      "plural": "logstashes",
+      "shortNames": [
+        "ls"
+      ]
+    },
+    "maps.k8s.elastic.co/ElasticMapsServer": {
+      "singular": "elasticmapsserver",
+      "plural": "elasticmapsservers",
+      "shortNames": [
+        "ems"
+      ]
+    },
+    "packageregistry.k8s.elastic.co/PackageRegistry": {
+      "singular": "packageregistry",
+      "plural": "packageregistries",
+      "shortNames": [
+        "epr"
+      ]
+    },
+    "stackconfigpolicy.k8s.elastic.co/StackConfigPolicy": {
+      "singular": "stackconfigpolicy",
+      "plural": "stackconfigpolicies",
+      "shortNames": [
+        "scp"
+      ]
+    }
+  },
   "files": [
     "catalog/agent.k8s.elastic.co/agent_v1alpha1.fields.txt",
     "catalog/agent.k8s.elastic.co/agent_v1alpha1.json",

--- a/build/history/envoy-gateway.json
+++ b/build/history/envoy-gateway.json
@@ -2,8 +2,8 @@
   "name": "envoy-gateway",
   "repo": "envoyproxy/gateway",
   "version": "v1.8.2",
-  "builtAt": "2026-07-05T12:12:14.110Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:11.277Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "gateway.envoyproxy.io/Backend",
     "gateway.envoyproxy.io/BackendTrafficPolicy",
@@ -14,6 +14,64 @@
     "gateway.envoyproxy.io/HTTPRouteFilter",
     "gateway.envoyproxy.io/SecurityPolicy"
   ],
+  "resources": {
+    "gateway.envoyproxy.io/Backend": {
+      "singular": "backend",
+      "plural": "backends",
+      "shortNames": [
+        "be"
+      ]
+    },
+    "gateway.envoyproxy.io/BackendTrafficPolicy": {
+      "singular": "backendtrafficpolicy",
+      "plural": "backendtrafficpolicies",
+      "shortNames": [
+        "btp"
+      ]
+    },
+    "gateway.envoyproxy.io/ClientTrafficPolicy": {
+      "singular": "clienttrafficpolicy",
+      "plural": "clienttrafficpolicies",
+      "shortNames": [
+        "ctp"
+      ]
+    },
+    "gateway.envoyproxy.io/EnvoyExtensionPolicy": {
+      "singular": "envoyextensionpolicy",
+      "plural": "envoyextensionpolicies",
+      "shortNames": [
+        "eep"
+      ]
+    },
+    "gateway.envoyproxy.io/EnvoyPatchPolicy": {
+      "singular": "envoypatchpolicy",
+      "plural": "envoypatchpolicies",
+      "shortNames": [
+        "epp"
+      ]
+    },
+    "gateway.envoyproxy.io/EnvoyProxy": {
+      "singular": "envoyproxy",
+      "plural": "envoyproxies",
+      "shortNames": [
+        "eproxy"
+      ]
+    },
+    "gateway.envoyproxy.io/HTTPRouteFilter": {
+      "singular": "httproutefilter",
+      "plural": "httproutefilters",
+      "shortNames": [
+        "hrf"
+      ]
+    },
+    "gateway.envoyproxy.io/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies",
+      "shortNames": [
+        "sp"
+      ]
+    }
+  },
   "files": [
     "catalog/gateway.envoyproxy.io/backend_v1alpha1.fields.txt",
     "catalog/gateway.envoyproxy.io/backend_v1alpha1.json",

--- a/build/history/external-dns.json
+++ b/build/history/external-dns.json
@@ -2,11 +2,17 @@
   "name": "external-dns",
   "repo": "kubernetes-sigs/external-dns",
   "version": "v0.21.0",
-  "builtAt": "2026-07-05T17:57:04.649Z",
+  "builtAt": "2026-07-07T19:12:45.507Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "externaldns.k8s.io/DNSEndpoint"
   ],
+  "resources": {
+    "externaldns.k8s.io/DNSEndpoint": {
+      "singular": "dnsendpoint",
+      "plural": "dnsendpoints"
+    }
+  },
   "files": [
     "catalog/externaldns.k8s.io/dnsendpoint_v1alpha1.fields.txt",
     "catalog/externaldns.k8s.io/dnsendpoint_v1alpha1.json"

--- a/build/history/external-secrets.json
+++ b/build/history/external-secrets.json
@@ -2,8 +2,8 @@
   "name": "external-secrets",
   "repo": "external-secrets/external-secrets",
   "version": "v2.7.0",
-  "builtAt": "2026-07-05T09:08:59.168Z",
-  "fluxSchemaVersion": "0.7.0",
+  "builtAt": "2026-07-07T19:05:11.336Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "external-secrets.io/ClusterExternalSecret",
     "external-secrets.io/ClusterPushSecret",
@@ -30,6 +30,122 @@
     "generators.external-secrets.io/VaultDynamicSecret",
     "generators.external-secrets.io/Webhook"
   ],
+  "resources": {
+    "external-secrets.io/ClusterExternalSecret": {
+      "singular": "clusterexternalsecret",
+      "plural": "clusterexternalsecrets",
+      "shortNames": [
+        "ces"
+      ]
+    },
+    "external-secrets.io/ClusterPushSecret": {
+      "singular": "clusterpushsecret",
+      "plural": "clusterpushsecrets"
+    },
+    "external-secrets.io/ClusterSecretStore": {
+      "singular": "clustersecretstore",
+      "plural": "clustersecretstores",
+      "shortNames": [
+        "css"
+      ]
+    },
+    "external-secrets.io/ExternalSecret": {
+      "singular": "externalsecret",
+      "plural": "externalsecrets",
+      "shortNames": [
+        "es"
+      ]
+    },
+    "external-secrets.io/PushSecret": {
+      "singular": "pushsecret",
+      "plural": "pushsecrets",
+      "shortNames": [
+        "ps"
+      ]
+    },
+    "external-secrets.io/SecretStore": {
+      "singular": "secretstore",
+      "plural": "secretstores",
+      "shortNames": [
+        "ss"
+      ]
+    },
+    "generators.external-secrets.io/ACRAccessToken": {
+      "singular": "acraccesstoken",
+      "plural": "acraccesstokens"
+    },
+    "generators.external-secrets.io/BeyondtrustWorkloadCredentialsDynamicSecret": {
+      "singular": "beyondtrustworkloadcredentialsdynamicsecret",
+      "plural": "beyondtrustworkloadcredentialsdynamicsecrets"
+    },
+    "generators.external-secrets.io/CloudsmithAccessToken": {
+      "singular": "cloudsmithaccesstoken",
+      "plural": "cloudsmithaccesstokens"
+    },
+    "generators.external-secrets.io/ClusterGenerator": {
+      "singular": "clustergenerator",
+      "plural": "clustergenerators"
+    },
+    "generators.external-secrets.io/ECRAuthorizationToken": {
+      "singular": "ecrauthorizationtoken",
+      "plural": "ecrauthorizationtokens"
+    },
+    "generators.external-secrets.io/Fake": {
+      "singular": "fake",
+      "plural": "fakes"
+    },
+    "generators.external-secrets.io/GCRAccessToken": {
+      "singular": "gcraccesstoken",
+      "plural": "gcraccesstokens"
+    },
+    "generators.external-secrets.io/GeneratorState": {
+      "singular": "generatorstate",
+      "plural": "generatorstates",
+      "shortNames": [
+        "gs"
+      ]
+    },
+    "generators.external-secrets.io/GithubAccessToken": {
+      "singular": "githubaccesstoken",
+      "plural": "githubaccesstokens"
+    },
+    "generators.external-secrets.io/Grafana": {
+      "singular": "grafana",
+      "plural": "grafanas"
+    },
+    "generators.external-secrets.io/MFA": {
+      "singular": "mfa",
+      "plural": "mfas"
+    },
+    "generators.external-secrets.io/Password": {
+      "singular": "password",
+      "plural": "passwords"
+    },
+    "generators.external-secrets.io/QuayAccessToken": {
+      "singular": "quayaccesstoken",
+      "plural": "quayaccesstokens"
+    },
+    "generators.external-secrets.io/SSHKey": {
+      "singular": "sshkey",
+      "plural": "sshkeys"
+    },
+    "generators.external-secrets.io/STSSessionToken": {
+      "singular": "stssessiontoken",
+      "plural": "stssessiontokens"
+    },
+    "generators.external-secrets.io/UUID": {
+      "singular": "uuid",
+      "plural": "uuids"
+    },
+    "generators.external-secrets.io/VaultDynamicSecret": {
+      "singular": "vaultdynamicsecret",
+      "plural": "vaultdynamicsecrets"
+    },
+    "generators.external-secrets.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    }
+  },
   "files": [
     "catalog/external-secrets.io/clusterexternalsecret_v1.fields.txt",
     "catalog/external-secrets.io/clusterexternalsecret_v1.json",

--- a/build/history/flagger.json
+++ b/build/history/flagger.json
@@ -2,13 +2,27 @@
   "name": "flagger",
   "repo": "fluxcd/flagger",
   "version": "v1.43.0",
-  "builtAt": "2026-07-05T10:35:39.071Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:04:56.653Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "flagger.app/AlertProvider",
     "flagger.app/Canary",
     "flagger.app/MetricTemplate"
   ],
+  "resources": {
+    "flagger.app/AlertProvider": {
+      "singular": "alertprovider",
+      "plural": "alertproviders"
+    },
+    "flagger.app/Canary": {
+      "singular": "canary",
+      "plural": "canaries"
+    },
+    "flagger.app/MetricTemplate": {
+      "singular": "metrictemplate",
+      "plural": "metrictemplates"
+    }
+  },
   "files": [
     "catalog/flagger.app/alertprovider_v1beta1.fields.txt",
     "catalog/flagger.app/alertprovider_v1beta1.json",

--- a/build/history/fluent-operator.json
+++ b/build/history/fluent-operator.json
@@ -2,8 +2,8 @@
   "name": "fluent-operator",
   "repo": "fluent/fluent-operator",
   "version": "v3.9.0",
-  "builtAt": "2026-07-05T11:10:40.112Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:05:42.645Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "fluentbit.fluent.io/ClusterFilter",
     "fluentbit.fluent.io/ClusterFluentBitConfig",
@@ -28,6 +28,162 @@
     "fluentd.fluent.io/Input",
     "fluentd.fluent.io/Output"
   ],
+  "resources": {
+    "fluentbit.fluent.io/ClusterFilter": {
+      "singular": "clusterfilter",
+      "plural": "clusterfilters",
+      "shortNames": [
+        "cfbf"
+      ]
+    },
+    "fluentbit.fluent.io/ClusterFluentBitConfig": {
+      "singular": "clusterfluentbitconfig",
+      "plural": "clusterfluentbitconfigs",
+      "shortNames": [
+        "cfbc"
+      ]
+    },
+    "fluentbit.fluent.io/ClusterInput": {
+      "singular": "clusterinput",
+      "plural": "clusterinputs",
+      "shortNames": [
+        "cfbi"
+      ]
+    },
+    "fluentbit.fluent.io/ClusterMultilineParser": {
+      "singular": "clustermultilineparser",
+      "plural": "clustermultilineparsers",
+      "shortNames": [
+        "cfbmp"
+      ]
+    },
+    "fluentbit.fluent.io/ClusterOutput": {
+      "singular": "clusteroutput",
+      "plural": "clusteroutputs",
+      "shortNames": [
+        "cfbo"
+      ]
+    },
+    "fluentbit.fluent.io/ClusterParser": {
+      "singular": "clusterparser",
+      "plural": "clusterparsers",
+      "shortNames": [
+        "cfbp"
+      ]
+    },
+    "fluentbit.fluent.io/Collector": {
+      "singular": "collector",
+      "plural": "collectors",
+      "shortNames": [
+        "co"
+      ]
+    },
+    "fluentbit.fluent.io/Filter": {
+      "singular": "filter",
+      "plural": "filters",
+      "shortNames": [
+        "fbf"
+      ]
+    },
+    "fluentbit.fluent.io/FluentBit": {
+      "singular": "fluentbit",
+      "plural": "fluentbits",
+      "shortNames": [
+        "fb"
+      ]
+    },
+    "fluentbit.fluent.io/FluentBitConfig": {
+      "singular": "fluentbitconfig",
+      "plural": "fluentbitconfigs",
+      "shortNames": [
+        "fbc"
+      ]
+    },
+    "fluentbit.fluent.io/MultilineParser": {
+      "singular": "multilineparser",
+      "plural": "multilineparsers",
+      "shortNames": [
+        "fbmp"
+      ]
+    },
+    "fluentbit.fluent.io/Output": {
+      "singular": "output",
+      "plural": "outputs",
+      "shortNames": [
+        "fbo"
+      ]
+    },
+    "fluentbit.fluent.io/Parser": {
+      "singular": "parser",
+      "plural": "parsers",
+      "shortNames": [
+        "fbp"
+      ]
+    },
+    "fluentd.fluent.io/ClusterFilter": {
+      "singular": "clusterfilter",
+      "plural": "clusterfilters",
+      "shortNames": [
+        "cfdf"
+      ]
+    },
+    "fluentd.fluent.io/ClusterFluentdConfig": {
+      "singular": "clusterfluentdconfig",
+      "plural": "clusterfluentdconfigs",
+      "shortNames": [
+        "cfdc"
+      ]
+    },
+    "fluentd.fluent.io/ClusterInput": {
+      "singular": "clusterinput",
+      "plural": "clusterinputs",
+      "shortNames": [
+        "cfdi"
+      ]
+    },
+    "fluentd.fluent.io/ClusterOutput": {
+      "singular": "clusteroutput",
+      "plural": "clusteroutputs",
+      "shortNames": [
+        "cfdo"
+      ]
+    },
+    "fluentd.fluent.io/Filter": {
+      "singular": "filter",
+      "plural": "filters",
+      "shortNames": [
+        "fdf"
+      ]
+    },
+    "fluentd.fluent.io/Fluentd": {
+      "singular": "fluentd",
+      "plural": "fluentds",
+      "shortNames": [
+        "fd"
+      ]
+    },
+    "fluentd.fluent.io/FluentdConfig": {
+      "singular": "fluentdconfig",
+      "plural": "fluentdconfigs",
+      "shortNames": [
+        "fdc"
+      ]
+    },
+    "fluentd.fluent.io/Input": {
+      "singular": "input",
+      "plural": "inputs",
+      "shortNames": [
+        "fdi"
+      ]
+    },
+    "fluentd.fluent.io/Output": {
+      "singular": "output",
+      "plural": "outputs",
+      "shortNames": [
+        "fdo"
+      ]
+    }
+  },
   "files": [
     "catalog/fluentbit.fluent.io/clusterfilter_v1alpha2.fields.txt",
     "catalog/fluentbit.fluent.io/clusterfilter_v1alpha2.json",

--- a/build/history/flux-operator.json
+++ b/build/history/flux-operator.json
@@ -2,7 +2,7 @@
   "name": "flux-operator",
   "repo": "controlplaneio-fluxcd/flux-operator",
   "version": "v0.54.0",
-  "builtAt": "2026-07-07T16:06:42.074Z",
+  "builtAt": "2026-07-07T19:04:58.985Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "fluxcd.controlplane.io/FluxInstance",
@@ -10,6 +10,30 @@
     "fluxcd.controlplane.io/ResourceSet",
     "fluxcd.controlplane.io/ResourceSetInputProvider"
   ],
+  "resources": {
+    "fluxcd.controlplane.io/FluxInstance": {
+      "singular": "fluxinstance",
+      "plural": "fluxinstances"
+    },
+    "fluxcd.controlplane.io/FluxReport": {
+      "singular": "fluxreport",
+      "plural": "fluxreports"
+    },
+    "fluxcd.controlplane.io/ResourceSet": {
+      "singular": "resourceset",
+      "plural": "resourcesets",
+      "shortNames": [
+        "rset"
+      ]
+    },
+    "fluxcd.controlplane.io/ResourceSetInputProvider": {
+      "singular": "resourcesetinputprovider",
+      "plural": "resourcesetinputproviders",
+      "shortNames": [
+        "rsip"
+      ]
+    }
+  },
   "files": [
     "catalog/fluxcd.controlplane.io/fluxinstance_v1.fields.txt",
     "catalog/fluxcd.controlplane.io/fluxinstance_v1.json",

--- a/build/history/flux.json
+++ b/build/history/flux.json
@@ -2,7 +2,7 @@
   "name": "flux",
   "repo": "fluxcd/flux2",
   "version": "v2.9.1",
-  "builtAt": "2026-07-07T16:06:38.147Z",
+  "builtAt": "2026-07-07T19:24:26.807Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "helm.toolkit.fluxcd.io/HelmRelease",
@@ -21,6 +21,105 @@
     "source.toolkit.fluxcd.io/HelmRepository",
     "source.toolkit.fluxcd.io/OCIRepository"
   ],
+  "resources": {
+    "helm.toolkit.fluxcd.io/HelmRelease": {
+      "singular": "helmrelease",
+      "plural": "helmreleases",
+      "shortNames": [
+        "hr"
+      ]
+    },
+    "image.toolkit.fluxcd.io/ImagePolicy": {
+      "singular": "imagepolicy",
+      "plural": "imagepolicies",
+      "shortNames": [
+        "imgpol",
+        "imagepol"
+      ]
+    },
+    "image.toolkit.fluxcd.io/ImageRepository": {
+      "singular": "imagerepository",
+      "plural": "imagerepositories",
+      "shortNames": [
+        "imgrepo",
+        "imagerepo"
+      ]
+    },
+    "image.toolkit.fluxcd.io/ImageUpdateAutomation": {
+      "singular": "imageupdateautomation",
+      "plural": "imageupdateautomations",
+      "shortNames": [
+        "iua",
+        "imgupd",
+        "imgauto"
+      ]
+    },
+    "kustomize.toolkit.fluxcd.io/Kustomization": {
+      "singular": "kustomization",
+      "plural": "kustomizations",
+      "shortNames": [
+        "ks"
+      ]
+    },
+    "notification.toolkit.fluxcd.io/Alert": {
+      "singular": "alert",
+      "plural": "alerts"
+    },
+    "notification.toolkit.fluxcd.io/Provider": {
+      "singular": "provider",
+      "plural": "providers"
+    },
+    "notification.toolkit.fluxcd.io/Receiver": {
+      "singular": "receiver",
+      "plural": "receivers"
+    },
+    "source.extensions.fluxcd.io/ArtifactGenerator": {
+      "singular": "artifactgenerator",
+      "plural": "artifactgenerators",
+      "shortNames": [
+        "ag"
+      ]
+    },
+    "source.toolkit.fluxcd.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "source.toolkit.fluxcd.io/ExternalArtifact": {
+      "singular": "externalartifact",
+      "plural": "externalartifacts",
+      "shortNames": [
+        "ea"
+      ]
+    },
+    "source.toolkit.fluxcd.io/GitRepository": {
+      "singular": "gitrepository",
+      "plural": "gitrepositories",
+      "shortNames": [
+        "gitrepo"
+      ]
+    },
+    "source.toolkit.fluxcd.io/HelmChart": {
+      "singular": "helmchart",
+      "plural": "helmcharts",
+      "shortNames": [
+        "hc"
+      ]
+    },
+    "source.toolkit.fluxcd.io/HelmRepository": {
+      "singular": "helmrepository",
+      "plural": "helmrepositories",
+      "shortNames": [
+        "helmrepo"
+      ]
+    },
+    "source.toolkit.fluxcd.io/OCIRepository": {
+      "singular": "ocirepository",
+      "plural": "ocirepositories",
+      "shortNames": [
+        "ocirepo"
+      ]
+    }
+  },
   "files": [
     "catalog/helm.toolkit.fluxcd.io/helmrelease_v2.fields.txt",
     "catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json",

--- a/build/history/gatekeeper.json
+++ b/build/history/gatekeeper.json
@@ -2,8 +2,8 @@
   "name": "gatekeeper",
   "repo": "open-policy-agent/gatekeeper",
   "version": "v3.22.2",
-  "builtAt": "2026-07-05T12:10:28.052Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:08.798Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "config.gatekeeper.sh/Config",
     "connection.gatekeeper.sh/Connection",
@@ -23,6 +23,76 @@
     "syncset.gatekeeper.sh/SyncSet",
     "templates.gatekeeper.sh/ConstraintTemplate"
   ],
+  "resources": {
+    "config.gatekeeper.sh/Config": {
+      "singular": "config",
+      "plural": "configs"
+    },
+    "connection.gatekeeper.sh/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "expansion.gatekeeper.sh/ExpansionTemplate": {
+      "singular": "expansiontemplate",
+      "plural": "expansiontemplate"
+    },
+    "externaldata.gatekeeper.sh/Provider": {
+      "singular": "provider",
+      "plural": "providers"
+    },
+    "mutations.gatekeeper.sh/Assign": {
+      "singular": "assign",
+      "plural": "assign"
+    },
+    "mutations.gatekeeper.sh/AssignImage": {
+      "singular": "assignimage",
+      "plural": "assignimage"
+    },
+    "mutations.gatekeeper.sh/AssignMetadata": {
+      "singular": "assignmetadata",
+      "plural": "assignmetadata"
+    },
+    "mutations.gatekeeper.sh/ModifySet": {
+      "singular": "modifyset",
+      "plural": "modifyset"
+    },
+    "status.gatekeeper.sh/ConfigPodStatus": {
+      "singular": "configpodstatus",
+      "plural": "configpodstatuses"
+    },
+    "status.gatekeeper.sh/ConnectionPodStatus": {
+      "singular": "connectionpodstatus",
+      "plural": "connectionpodstatuses"
+    },
+    "status.gatekeeper.sh/ConstraintPodStatus": {
+      "singular": "constraintpodstatus",
+      "plural": "constraintpodstatuses"
+    },
+    "status.gatekeeper.sh/ConstraintTemplatePodStatus": {
+      "singular": "constrainttemplatepodstatus",
+      "plural": "constrainttemplatepodstatuses"
+    },
+    "status.gatekeeper.sh/ExpansionTemplatePodStatus": {
+      "singular": "expansiontemplatepodstatus",
+      "plural": "expansiontemplatepodstatuses"
+    },
+    "status.gatekeeper.sh/MutatorPodStatus": {
+      "singular": "mutatorpodstatus",
+      "plural": "mutatorpodstatuses"
+    },
+    "status.gatekeeper.sh/ProviderPodStatus": {
+      "singular": "providerpodstatus",
+      "plural": "providerpodstatuses"
+    },
+    "syncset.gatekeeper.sh/SyncSet": {
+      "singular": "syncset",
+      "plural": "syncsets"
+    },
+    "templates.gatekeeper.sh/ConstraintTemplate": {
+      "singular": "constrainttemplate",
+      "plural": "constrainttemplates"
+    }
+  },
   "files": [
     "catalog/config.gatekeeper.sh/config_v1alpha1.fields.txt",
     "catalog/config.gatekeeper.sh/config_v1alpha1.json",

--- a/build/history/gateway-api.json
+++ b/build/history/gateway-api.json
@@ -2,7 +2,7 @@
   "name": "gateway-api",
   "repo": "kubernetes-sigs/gateway-api",
   "version": "v1.6.0",
-  "builtAt": "2026-07-07T07:29:14.058Z",
+  "builtAt": "2026-07-07T19:05:08.436Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "gateway.networking.k8s.io/BackendTLSPolicy",
@@ -18,6 +18,77 @@
     "gateway.networking.x-k8s.io/XBackendTrafficPolicy",
     "gateway.networking.x-k8s.io/XMesh"
   ],
+  "resources": {
+    "gateway.networking.k8s.io/BackendTLSPolicy": {
+      "singular": "backendtlspolicy",
+      "plural": "backendtlspolicies",
+      "shortNames": [
+        "btlspolicy"
+      ]
+    },
+    "gateway.networking.k8s.io/GRPCRoute": {
+      "singular": "grpcroute",
+      "plural": "grpcroutes"
+    },
+    "gateway.networking.k8s.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways",
+      "shortNames": [
+        "gtw"
+      ]
+    },
+    "gateway.networking.k8s.io/GatewayClass": {
+      "singular": "gatewayclass",
+      "plural": "gatewayclasses",
+      "shortNames": [
+        "gc"
+      ]
+    },
+    "gateway.networking.k8s.io/HTTPRoute": {
+      "singular": "httproute",
+      "plural": "httproutes"
+    },
+    "gateway.networking.k8s.io/ListenerSet": {
+      "singular": "listenerset",
+      "plural": "listenersets",
+      "shortNames": [
+        "lset"
+      ]
+    },
+    "gateway.networking.k8s.io/ReferenceGrant": {
+      "singular": "referencegrant",
+      "plural": "referencegrants",
+      "shortNames": [
+        "refgrant"
+      ]
+    },
+    "gateway.networking.k8s.io/TCPRoute": {
+      "singular": "tcproute",
+      "plural": "tcproutes"
+    },
+    "gateway.networking.k8s.io/TLSRoute": {
+      "singular": "tlsroute",
+      "plural": "tlsroutes"
+    },
+    "gateway.networking.k8s.io/UDPRoute": {
+      "singular": "udproute",
+      "plural": "udproutes"
+    },
+    "gateway.networking.x-k8s.io/XBackendTrafficPolicy": {
+      "singular": "xbackendtrafficpolicy",
+      "plural": "xbackendtrafficpolicies",
+      "shortNames": [
+        "xbtrafficpolicy"
+      ]
+    },
+    "gateway.networking.x-k8s.io/XMesh": {
+      "singular": "xmesh",
+      "plural": "xmeshes",
+      "shortNames": [
+        "mesh"
+      ]
+    }
+  },
   "files": [
     "catalog/gateway.networking.k8s.io/backendtlspolicy_v1.fields.txt",
     "catalog/gateway.networking.k8s.io/backendtlspolicy_v1.json",

--- a/build/history/grafana-operator.json
+++ b/build/history/grafana-operator.json
@@ -2,7 +2,7 @@
   "name": "grafana-operator",
   "repo": "grafana/grafana-operator",
   "version": "v5.24.0",
-  "builtAt": "2026-07-06T22:30:49.004Z",
+  "builtAt": "2026-07-07T19:05:43.650Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "grafana.integreatly.org/Grafana",
@@ -19,6 +19,60 @@
     "grafana.integreatly.org/GrafanaNotificationTemplate",
     "grafana.integreatly.org/GrafanaServiceAccount"
   ],
+  "resources": {
+    "grafana.integreatly.org/Grafana": {
+      "singular": "grafana",
+      "plural": "grafanas"
+    },
+    "grafana.integreatly.org/GrafanaAlertRuleGroup": {
+      "singular": "grafanaalertrulegroup",
+      "plural": "grafanaalertrulegroups"
+    },
+    "grafana.integreatly.org/GrafanaContactPoint": {
+      "singular": "grafanacontactpoint",
+      "plural": "grafanacontactpoints"
+    },
+    "grafana.integreatly.org/GrafanaDashboard": {
+      "singular": "grafanadashboard",
+      "plural": "grafanadashboards"
+    },
+    "grafana.integreatly.org/GrafanaDatasource": {
+      "singular": "grafanadatasource",
+      "plural": "grafanadatasources"
+    },
+    "grafana.integreatly.org/GrafanaFolder": {
+      "singular": "grafanafolder",
+      "plural": "grafanafolders"
+    },
+    "grafana.integreatly.org/GrafanaLibraryPanel": {
+      "singular": "grafanalibrarypanel",
+      "plural": "grafanalibrarypanels"
+    },
+    "grafana.integreatly.org/GrafanaManifest": {
+      "singular": "grafanamanifest",
+      "plural": "grafanamanifests"
+    },
+    "grafana.integreatly.org/GrafanaMuteTiming": {
+      "singular": "grafanamutetiming",
+      "plural": "grafanamutetimings"
+    },
+    "grafana.integreatly.org/GrafanaNotificationPolicy": {
+      "singular": "grafananotificationpolicy",
+      "plural": "grafananotificationpolicies"
+    },
+    "grafana.integreatly.org/GrafanaNotificationPolicyRoute": {
+      "singular": "grafananotificationpolicyroute",
+      "plural": "grafananotificationpolicyroutes"
+    },
+    "grafana.integreatly.org/GrafanaNotificationTemplate": {
+      "singular": "grafananotificationtemplate",
+      "plural": "grafananotificationtemplates"
+    },
+    "grafana.integreatly.org/GrafanaServiceAccount": {
+      "singular": "grafanaserviceaccount",
+      "plural": "grafanaserviceaccounts"
+    }
+  },
   "files": [
     "catalog/grafana.integreatly.org/grafana_v1beta1.fields.txt",
     "catalog/grafana.integreatly.org/grafana_v1beta1.json",

--- a/build/history/istio.json
+++ b/build/history/istio.json
@@ -2,7 +2,7 @@
   "name": "istio",
   "repo": "istio/istio",
   "version": "1.30.2",
-  "builtAt": "2026-07-05T18:18:17.579Z",
+  "builtAt": "2026-07-07T19:13:05.381Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "extensions.istio.io/TrafficExtension",
@@ -21,6 +21,98 @@
     "security.istio.io/RequestAuthentication",
     "telemetry.istio.io/Telemetry"
   ],
+  "resources": {
+    "extensions.istio.io/TrafficExtension": {
+      "singular": "trafficextension",
+      "plural": "trafficextensions"
+    },
+    "extensions.istio.io/WasmPlugin": {
+      "singular": "wasmplugin",
+      "plural": "wasmplugins"
+    },
+    "networking.istio.io/DestinationRule": {
+      "singular": "destinationrule",
+      "plural": "destinationrules",
+      "shortNames": [
+        "dr"
+      ]
+    },
+    "networking.istio.io/EnvoyFilter": {
+      "singular": "envoyfilter",
+      "plural": "envoyfilters"
+    },
+    "networking.istio.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways",
+      "shortNames": [
+        "gw"
+      ]
+    },
+    "networking.istio.io/ProxyConfig": {
+      "singular": "proxyconfig",
+      "plural": "proxyconfigs"
+    },
+    "networking.istio.io/ServiceEntry": {
+      "singular": "serviceentry",
+      "plural": "serviceentries",
+      "shortNames": [
+        "se"
+      ]
+    },
+    "networking.istio.io/Sidecar": {
+      "singular": "sidecar",
+      "plural": "sidecars"
+    },
+    "networking.istio.io/VirtualService": {
+      "singular": "virtualservice",
+      "plural": "virtualservices",
+      "shortNames": [
+        "vs"
+      ]
+    },
+    "networking.istio.io/WorkloadEntry": {
+      "singular": "workloadentry",
+      "plural": "workloadentries",
+      "shortNames": [
+        "we"
+      ]
+    },
+    "networking.istio.io/WorkloadGroup": {
+      "singular": "workloadgroup",
+      "plural": "workloadgroups",
+      "shortNames": [
+        "wg"
+      ]
+    },
+    "security.istio.io/AuthorizationPolicy": {
+      "singular": "authorizationpolicy",
+      "plural": "authorizationpolicies",
+      "shortNames": [
+        "ap"
+      ]
+    },
+    "security.istio.io/PeerAuthentication": {
+      "singular": "peerauthentication",
+      "plural": "peerauthentications",
+      "shortNames": [
+        "pa"
+      ]
+    },
+    "security.istio.io/RequestAuthentication": {
+      "singular": "requestauthentication",
+      "plural": "requestauthentications",
+      "shortNames": [
+        "ra"
+      ]
+    },
+    "telemetry.istio.io/Telemetry": {
+      "singular": "telemetry",
+      "plural": "telemetries",
+      "shortNames": [
+        "telemetry"
+      ]
+    }
+  },
   "files": [
     "catalog/extensions.istio.io/trafficextension_v1alpha1.fields.txt",
     "catalog/extensions.istio.io/trafficextension_v1alpha1.json",

--- a/build/history/jobset.json
+++ b/build/history/jobset.json
@@ -2,11 +2,17 @@
   "name": "jobset",
   "repo": "kubernetes-sigs/jobset",
   "version": "v0.12.0",
-  "builtAt": "2026-07-05T17:29:25.403Z",
+  "builtAt": "2026-07-07T19:12:18.481Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "jobset.x-k8s.io/JobSet"
   ],
+  "resources": {
+    "jobset.x-k8s.io/JobSet": {
+      "singular": "jobset",
+      "plural": "jobsets"
+    }
+  },
   "files": [
     "catalog/jobset.x-k8s.io/jobset_v1alpha2.fields.txt",
     "catalog/jobset.x-k8s.io/jobset_v1alpha2.json"

--- a/build/history/kargo.json
+++ b/build/history/kargo.json
@@ -2,7 +2,7 @@
   "name": "kargo",
   "repo": "akuity/kargo",
   "version": "v1.10.8",
-  "builtAt": "2026-07-06T22:46:00.925Z",
+  "builtAt": "2026-07-07T19:11:05.152Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kargo.akuity.io/ClusterConfig",
@@ -15,6 +15,60 @@
     "kargo.akuity.io/Stage",
     "kargo.akuity.io/Warehouse"
   ],
+  "resources": {
+    "kargo.akuity.io/ClusterConfig": {
+      "singular": "clusterconfig",
+      "plural": "clusterconfigs",
+      "shortNames": [
+        "clusterconfig",
+        "clusterconfigs"
+      ]
+    },
+    "kargo.akuity.io/ClusterPromotionTask": {
+      "singular": "clusterpromotiontask",
+      "plural": "clusterpromotiontasks",
+      "shortNames": [
+        "clusterpromotask",
+        "clusterpromotasks"
+      ]
+    },
+    "kargo.akuity.io/Freight": {
+      "singular": "freight",
+      "plural": "freights"
+    },
+    "kargo.akuity.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "kargo.akuity.io/ProjectConfig": {
+      "singular": "projectconfig",
+      "plural": "projectconfigs"
+    },
+    "kargo.akuity.io/Promotion": {
+      "singular": "promotion",
+      "plural": "promotions",
+      "shortNames": [
+        "promo",
+        "promos"
+      ]
+    },
+    "kargo.akuity.io/PromotionTask": {
+      "singular": "promotiontask",
+      "plural": "promotiontasks",
+      "shortNames": [
+        "promotask",
+        "promotasks"
+      ]
+    },
+    "kargo.akuity.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "kargo.akuity.io/Warehouse": {
+      "singular": "warehouse",
+      "plural": "warehouses"
+    }
+  },
   "files": [
     "catalog/kargo.akuity.io/clusterconfig_v1alpha1.fields.txt",
     "catalog/kargo.akuity.io/clusterconfig_v1alpha1.json",

--- a/build/history/karpenter-aws.json
+++ b/build/history/karpenter-aws.json
@@ -2,11 +2,21 @@
   "name": "karpenter-aws",
   "repo": "aws/karpenter-provider-aws",
   "version": "v1.13.0",
-  "builtAt": "2026-07-05T16:20:06.565Z",
+  "builtAt": "2026-07-07T19:10:09.301Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "karpenter.k8s.aws/EC2NodeClass"
   ],
+  "resources": {
+    "karpenter.k8s.aws/EC2NodeClass": {
+      "singular": "ec2nodeclass",
+      "plural": "ec2nodeclasses",
+      "shortNames": [
+        "ec2nc",
+        "ec2ncs"
+      ]
+    }
+  },
   "files": [
     "catalog/karpenter.k8s.aws/ec2nodeclass_v1.fields.txt",
     "catalog/karpenter.k8s.aws/ec2nodeclass_v1.json"

--- a/build/history/karpenter-azure.json
+++ b/build/history/karpenter-azure.json
@@ -2,11 +2,21 @@
   "name": "karpenter-azure",
   "repo": "Azure/karpenter-provider-azure",
   "version": "v1.13.1",
-  "builtAt": "2026-07-05T16:20:07.971Z",
+  "builtAt": "2026-07-07T19:10:10.122Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "karpenter.azure.com/AKSNodeClass"
   ],
+  "resources": {
+    "karpenter.azure.com/AKSNodeClass": {
+      "singular": "aksnodeclass",
+      "plural": "aksnodeclasses",
+      "shortNames": [
+        "aksnc",
+        "aksncs"
+      ]
+    }
+  },
   "files": [
     "catalog/karpenter.azure.com/aksnodeclass_v1alpha2.fields.txt",
     "catalog/karpenter.azure.com/aksnodeclass_v1alpha2.json",

--- a/build/history/karpenter-provider-cluster-api.json
+++ b/build/history/karpenter-provider-cluster-api.json
@@ -2,11 +2,21 @@
   "name": "karpenter-provider-cluster-api",
   "repo": "kubernetes-sigs/karpenter-provider-cluster-api",
   "version": "v0.2.0",
-  "builtAt": "2026-07-05T18:04:07.859Z",
+  "builtAt": "2026-07-07T19:10:10.692Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "karpenter.cluster.x-k8s.io/ClusterAPINodeClass"
   ],
+  "resources": {
+    "karpenter.cluster.x-k8s.io/ClusterAPINodeClass": {
+      "singular": "clusterapinodeclass",
+      "plural": "clusterapinodeclasses",
+      "shortNames": [
+        "capinc",
+        "capincs"
+      ]
+    }
+  },
   "files": [
     "catalog/karpenter.cluster.x-k8s.io/clusterapinodeclass_v1alpha1.fields.txt",
     "catalog/karpenter.cluster.x-k8s.io/clusterapinodeclass_v1alpha1.json"

--- a/build/history/karpenter-provider-ibm-cloud.json
+++ b/build/history/karpenter-provider-ibm-cloud.json
@@ -2,11 +2,21 @@
   "name": "karpenter-provider-ibm-cloud",
   "repo": "kubernetes-sigs/karpenter-provider-ibm-cloud",
   "version": "v1.0.4",
-  "builtAt": "2026-07-05T18:05:31.204Z",
+  "builtAt": "2026-07-07T19:10:11.512Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "karpenter-ibm.sh/IBMNodeClass"
   ],
+  "resources": {
+    "karpenter-ibm.sh/IBMNodeClass": {
+      "singular": "ibmnodeclass",
+      "plural": "ibmnodeclasses",
+      "shortNames": [
+        "ibmnc",
+        "ibmncs"
+      ]
+    }
+  },
   "files": [
     "catalog/karpenter-ibm.sh/ibmnodeclass_v1alpha1.fields.txt",
     "catalog/karpenter-ibm.sh/ibmnodeclass_v1alpha1.json"

--- a/build/history/karpenter.json
+++ b/build/history/karpenter.json
@@ -2,13 +2,30 @@
   "name": "karpenter",
   "repo": "kubernetes-sigs/karpenter",
   "version": "v1.13.0",
-  "builtAt": "2026-07-05T16:20:05.434Z",
+  "builtAt": "2026-07-07T19:10:08.448Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "karpenter.sh/NodeClaim",
     "karpenter.sh/NodeOverlay",
     "karpenter.sh/NodePool"
   ],
+  "resources": {
+    "karpenter.sh/NodeClaim": {
+      "singular": "nodeclaim",
+      "plural": "nodeclaims"
+    },
+    "karpenter.sh/NodeOverlay": {
+      "singular": "nodeoverlay",
+      "plural": "nodeoverlays",
+      "shortNames": [
+        "overlays"
+      ]
+    },
+    "karpenter.sh/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    }
+  },
   "files": [
     "catalog/karpenter.sh/nodeclaim_v1.fields.txt",
     "catalog/karpenter.sh/nodeclaim_v1.json",

--- a/build/history/keda.json
+++ b/build/history/keda.json
@@ -2,8 +2,8 @@
   "name": "keda",
   "repo": "kedacore/keda",
   "version": "v2.20.1",
-  "builtAt": "2026-07-05T10:56:11.578Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:06:47.128Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "eventing.keda.sh/CloudEventSource",
     "eventing.keda.sh/ClusterCloudEventSource",
@@ -12,6 +12,46 @@
     "keda.sh/ScaledObject",
     "keda.sh/TriggerAuthentication"
   ],
+  "resources": {
+    "eventing.keda.sh/CloudEventSource": {
+      "singular": "cloudeventsource",
+      "plural": "cloudeventsources"
+    },
+    "eventing.keda.sh/ClusterCloudEventSource": {
+      "singular": "clustercloudeventsource",
+      "plural": "clustercloudeventsources"
+    },
+    "keda.sh/ClusterTriggerAuthentication": {
+      "singular": "clustertriggerauthentication",
+      "plural": "clustertriggerauthentications",
+      "shortNames": [
+        "cta",
+        "clustertriggerauth"
+      ]
+    },
+    "keda.sh/ScaledJob": {
+      "singular": "scaledjob",
+      "plural": "scaledjobs",
+      "shortNames": [
+        "sj"
+      ]
+    },
+    "keda.sh/ScaledObject": {
+      "singular": "scaledobject",
+      "plural": "scaledobjects",
+      "shortNames": [
+        "so"
+      ]
+    },
+    "keda.sh/TriggerAuthentication": {
+      "singular": "triggerauthentication",
+      "plural": "triggerauthentications",
+      "shortNames": [
+        "ta",
+        "triggerauth"
+      ]
+    }
+  },
   "files": [
     "catalog/eventing.keda.sh/cloudeventsource_v1alpha1.fields.txt",
     "catalog/eventing.keda.sh/cloudeventsource_v1alpha1.json",

--- a/build/history/kgateway.json
+++ b/build/history/kgateway.json
@@ -2,7 +2,7 @@
   "name": "kgateway",
   "repo": "kgateway-dev/kgateway",
   "version": "v2.3.5",
-  "builtAt": "2026-07-06T22:55:05.141Z",
+  "builtAt": "2026-07-07T19:07:14.423Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "gateway.kgateway.dev/Backend",
@@ -14,6 +14,40 @@
     "gateway.kgateway.dev/ListenerPolicy",
     "gateway.kgateway.dev/TrafficPolicy"
   ],
+  "resources": {
+    "gateway.kgateway.dev/Backend": {
+      "singular": "backend",
+      "plural": "backends"
+    },
+    "gateway.kgateway.dev/BackendConfigPolicy": {
+      "singular": "backendconfigpolicy",
+      "plural": "backendconfigpolicies"
+    },
+    "gateway.kgateway.dev/DirectResponse": {
+      "singular": "directresponse",
+      "plural": "directresponses"
+    },
+    "gateway.kgateway.dev/GatewayExtension": {
+      "singular": "gatewayextension",
+      "plural": "gatewayextensions"
+    },
+    "gateway.kgateway.dev/GatewayParameters": {
+      "singular": "gatewayparameters",
+      "plural": "gatewayparameters"
+    },
+    "gateway.kgateway.dev/HTTPListenerPolicy": {
+      "singular": "httplistenerpolicy",
+      "plural": "httplistenerpolicies"
+    },
+    "gateway.kgateway.dev/ListenerPolicy": {
+      "singular": "listenerpolicy",
+      "plural": "listenerpolicies"
+    },
+    "gateway.kgateway.dev/TrafficPolicy": {
+      "singular": "trafficpolicy",
+      "plural": "trafficpolicies"
+    }
+  },
   "files": [
     "catalog/gateway.kgateway.dev/backend_v1alpha1.fields.txt",
     "catalog/gateway.kgateway.dev/backend_v1alpha1.json",

--- a/build/history/kjob.json
+++ b/build/history/kjob.json
@@ -2,7 +2,7 @@
   "name": "kjob",
   "repo": "kubernetes-sigs/kjob",
   "version": "v0.1.0",
-  "builtAt": "2026-07-05T17:59:56.602Z",
+  "builtAt": "2026-07-07T19:13:04.154Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kjobctl.x-k8s.io/ApplicationProfile",
@@ -11,6 +11,28 @@
     "kjobctl.x-k8s.io/RayJobTemplate",
     "kjobctl.x-k8s.io/VolumeBundle"
   ],
+  "resources": {
+    "kjobctl.x-k8s.io/ApplicationProfile": {
+      "singular": "applicationprofile",
+      "plural": "applicationprofiles"
+    },
+    "kjobctl.x-k8s.io/JobTemplate": {
+      "singular": "jobtemplate",
+      "plural": "jobtemplates"
+    },
+    "kjobctl.x-k8s.io/RayClusterTemplate": {
+      "singular": "rayclustertemplate",
+      "plural": "rayclustertemplates"
+    },
+    "kjobctl.x-k8s.io/RayJobTemplate": {
+      "singular": "rayjobtemplate",
+      "plural": "rayjobtemplates"
+    },
+    "kjobctl.x-k8s.io/VolumeBundle": {
+      "singular": "volumebundle",
+      "plural": "volumebundles"
+    }
+  },
   "files": [
     "catalog/kjobctl.x-k8s.io/applicationprofile_v1alpha1.fields.txt",
     "catalog/kjobctl.x-k8s.io/applicationprofile_v1alpha1.json",

--- a/build/history/knative-eventing.json
+++ b/build/history/knative-eventing.json
@@ -2,7 +2,7 @@
   "name": "knative-eventing",
   "repo": "knative/eventing",
   "version": "knative-v1.22.2",
-  "builtAt": "2026-07-06T23:14:09.815Z",
+  "builtAt": "2026-07-07T19:06:48.919Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "eventing.knative.dev/Broker",
@@ -23,6 +23,85 @@
     "sources.knative.dev/PingSource",
     "sources.knative.dev/SinkBinding"
   ],
+  "resources": {
+    "eventing.knative.dev/Broker": {
+      "singular": "broker",
+      "plural": "brokers"
+    },
+    "eventing.knative.dev/EventPolicy": {
+      "singular": "eventpolicy",
+      "plural": "eventpolicies"
+    },
+    "eventing.knative.dev/EventTransform": {
+      "singular": "eventtransform",
+      "plural": "eventtransforms"
+    },
+    "eventing.knative.dev/EventType": {
+      "singular": "eventtype",
+      "plural": "eventtypes"
+    },
+    "eventing.knative.dev/RequestReply": {
+      "singular": "requestreply",
+      "plural": "requestreplies",
+      "shortNames": [
+        "rr"
+      ]
+    },
+    "eventing.knative.dev/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "flows.knative.dev/Parallel": {
+      "singular": "parallel",
+      "plural": "parallels"
+    },
+    "flows.knative.dev/Sequence": {
+      "singular": "sequence",
+      "plural": "sequences"
+    },
+    "messaging.knative.dev/Channel": {
+      "singular": "channel",
+      "plural": "channels",
+      "shortNames": [
+        "ch"
+      ]
+    },
+    "messaging.knative.dev/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions",
+      "shortNames": [
+        "sub"
+      ]
+    },
+    "sinks.knative.dev/IntegrationSink": {
+      "singular": "integrationsink",
+      "plural": "integrationsinks"
+    },
+    "sinks.knative.dev/JobSink": {
+      "singular": "jobsink",
+      "plural": "jobsinks"
+    },
+    "sources.knative.dev/ApiServerSource": {
+      "singular": "apiserversource",
+      "plural": "apiserversources"
+    },
+    "sources.knative.dev/ContainerSource": {
+      "singular": "containersource",
+      "plural": "containersources"
+    },
+    "sources.knative.dev/IntegrationSource": {
+      "singular": "integrationsource",
+      "plural": "integrationsources"
+    },
+    "sources.knative.dev/PingSource": {
+      "singular": "pingsource",
+      "plural": "pingsources"
+    },
+    "sources.knative.dev/SinkBinding": {
+      "singular": "sinkbinding",
+      "plural": "sinkbindings"
+    }
+  },
   "files": [
     "catalog/eventing.knative.dev/broker_v1.fields.txt",
     "catalog/eventing.knative.dev/broker_v1.json",

--- a/build/history/knative-serving.json
+++ b/build/history/knative-serving.json
@@ -2,7 +2,7 @@
   "name": "knative-serving",
   "repo": "knative/serving",
   "version": "knative-v1.22.1",
-  "builtAt": "2026-07-06T23:14:11.019Z",
+  "builtAt": "2026-07-07T19:06:47.959Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "autoscaling.internal.knative.dev/Metric",
@@ -18,6 +18,90 @@
     "serving.knative.dev/Route",
     "serving.knative.dev/Service"
   ],
+  "resources": {
+    "autoscaling.internal.knative.dev/Metric": {
+      "singular": "metric",
+      "plural": "metrics"
+    },
+    "autoscaling.internal.knative.dev/PodAutoscaler": {
+      "singular": "podautoscaler",
+      "plural": "podautoscalers",
+      "shortNames": [
+        "kpa",
+        "pa"
+      ]
+    },
+    "caching.internal.knative.dev/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "networking.internal.knative.dev/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates",
+      "shortNames": [
+        "kcert"
+      ]
+    },
+    "networking.internal.knative.dev/ClusterDomainClaim": {
+      "singular": "clusterdomainclaim",
+      "plural": "clusterdomainclaims",
+      "shortNames": [
+        "cdc"
+      ]
+    },
+    "networking.internal.knative.dev/Ingress": {
+      "singular": "ingress",
+      "plural": "ingresses",
+      "shortNames": [
+        "kingress",
+        "king"
+      ]
+    },
+    "networking.internal.knative.dev/ServerlessService": {
+      "singular": "serverlessservice",
+      "plural": "serverlessservices",
+      "shortNames": [
+        "sks"
+      ]
+    },
+    "serving.knative.dev/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations",
+      "shortNames": [
+        "config",
+        "cfg"
+      ]
+    },
+    "serving.knative.dev/DomainMapping": {
+      "singular": "domainmapping",
+      "plural": "domainmappings",
+      "shortNames": [
+        "dm"
+      ]
+    },
+    "serving.knative.dev/Revision": {
+      "singular": "revision",
+      "plural": "revisions",
+      "shortNames": [
+        "rev"
+      ]
+    },
+    "serving.knative.dev/Route": {
+      "singular": "route",
+      "plural": "routes",
+      "shortNames": [
+        "rt"
+      ]
+    },
+    "serving.knative.dev/Service": {
+      "singular": "service",
+      "plural": "services",
+      "shortNames": [
+        "kservice",
+        "ksvc"
+      ]
+    }
+  },
   "files": [
     "catalog/autoscaling.internal.knative.dev/metric_v1alpha1.fields.txt",
     "catalog/autoscaling.internal.knative.dev/metric_v1alpha1.json",

--- a/build/history/kro.json
+++ b/build/history/kro.json
@@ -2,12 +2,28 @@
   "name": "kro",
   "repo": "kubernetes-sigs/kro",
   "version": "v0.9.2",
-  "builtAt": "2026-07-05T17:58:46.414Z",
+  "builtAt": "2026-07-07T19:12:56.403Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "internal.kro.run/GraphRevision",
     "kro.run/ResourceGraphDefinition"
   ],
+  "resources": {
+    "internal.kro.run/GraphRevision": {
+      "singular": "graphrevision",
+      "plural": "graphrevisions",
+      "shortNames": [
+        "gr"
+      ]
+    },
+    "kro.run/ResourceGraphDefinition": {
+      "singular": "resourcegraphdefinition",
+      "plural": "resourcegraphdefinitions",
+      "shortNames": [
+        "rgd"
+      ]
+    }
+  },
   "files": [
     "catalog/internal.kro.run/graphrevision_v1alpha1.fields.txt",
     "catalog/internal.kro.run/graphrevision_v1alpha1.json",

--- a/build/history/kserve-llmisvc.json
+++ b/build/history/kserve-llmisvc.json
@@ -2,12 +2,25 @@
   "name": "kserve-llmisvc",
   "repo": "kserve/kserve",
   "version": "v0.19.0",
-  "builtAt": "2026-07-05T17:10:42.395Z",
+  "builtAt": "2026-07-07T19:11:50.861Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "serving.kserve.io/LLMInferenceService",
     "serving.kserve.io/LLMInferenceServiceConfig"
   ],
+  "resources": {
+    "serving.kserve.io/LLMInferenceService": {
+      "singular": "llminferenceservice",
+      "plural": "llminferenceservices",
+      "shortNames": [
+        "llmisvc"
+      ]
+    },
+    "serving.kserve.io/LLMInferenceServiceConfig": {
+      "singular": "llminferenceserviceconfig",
+      "plural": "llminferenceserviceconfigs"
+    }
+  },
   "files": [
     "catalog/serving.kserve.io/llminferenceservice_v1alpha1.fields.txt",
     "catalog/serving.kserve.io/llminferenceservice_v1alpha1.json",

--- a/build/history/kserve.json
+++ b/build/history/kserve.json
@@ -2,7 +2,7 @@
   "name": "kserve",
   "repo": "kserve/kserve",
   "version": "v0.19.0",
-  "builtAt": "2026-07-05T17:10:35.613Z",
+  "builtAt": "2026-07-07T19:16:42.251Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "serving.kserve.io/ClusterServingRuntime",
@@ -12,6 +12,41 @@
     "serving.kserve.io/ServingRuntime",
     "serving.kserve.io/TrainedModel"
   ],
+  "resources": {
+    "serving.kserve.io/ClusterServingRuntime": {
+      "singular": "clusterservingruntime",
+      "plural": "clusterservingruntimes"
+    },
+    "serving.kserve.io/ClusterStorageContainer": {
+      "singular": "clusterstoragecontainer",
+      "plural": "clusterstoragecontainers"
+    },
+    "serving.kserve.io/InferenceGraph": {
+      "singular": "inferencegraph",
+      "plural": "inferencegraphs",
+      "shortNames": [
+        "ig"
+      ]
+    },
+    "serving.kserve.io/InferenceService": {
+      "singular": "inferenceservice",
+      "plural": "inferenceservices",
+      "shortNames": [
+        "isvc"
+      ]
+    },
+    "serving.kserve.io/ServingRuntime": {
+      "singular": "servingruntime",
+      "plural": "servingruntimes"
+    },
+    "serving.kserve.io/TrainedModel": {
+      "singular": "trainedmodel",
+      "plural": "trainedmodels",
+      "shortNames": [
+        "tm"
+      ]
+    }
+  },
   "files": [
     "catalog/serving.kserve.io/clusterservingruntime_v1alpha1.fields.txt",
     "catalog/serving.kserve.io/clusterservingruntime_v1alpha1.json",

--- a/build/history/kube-ovn.json
+++ b/build/history/kube-ovn.json
@@ -2,7 +2,7 @@
   "name": "kube-ovn",
   "repo": "kubeovn/kube-ovn",
   "version": "v1.16.2",
-  "builtAt": "2026-07-05T19:00:57.198Z",
+  "builtAt": "2026-07-07T19:14:58.029Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kubeovn.io/BgpConf",
@@ -30,6 +30,171 @@
     "kubeovn.io/VpcEgressGateway",
     "kubeovn.io/VpcNatGateway"
   ],
+  "resources": {
+    "kubeovn.io/BgpConf": {
+      "singular": "bgp-conf",
+      "plural": "bgp-confs"
+    },
+    "kubeovn.io/DNSNameResolver": {
+      "singular": "dnsnameresolver",
+      "plural": "dnsnameresolvers",
+      "shortNames": [
+        "dnr"
+      ]
+    },
+    "kubeovn.io/EvpnConf": {
+      "singular": "evpn-conf",
+      "plural": "evpn-confs"
+    },
+    "kubeovn.io/IP": {
+      "singular": "ip",
+      "plural": "ips",
+      "shortNames": [
+        "ip"
+      ]
+    },
+    "kubeovn.io/IPPool": {
+      "singular": "ippool",
+      "plural": "ippools",
+      "shortNames": [
+        "ippool"
+      ]
+    },
+    "kubeovn.io/IptablesDnatRule": {
+      "singular": "iptables-dnat-rule",
+      "plural": "iptables-dnat-rules",
+      "shortNames": [
+        "dnat"
+      ]
+    },
+    "kubeovn.io/IptablesEIP": {
+      "singular": "iptables-eip",
+      "plural": "iptables-eips",
+      "shortNames": [
+        "eip"
+      ]
+    },
+    "kubeovn.io/IptablesFIPRule": {
+      "singular": "iptables-fip-rule",
+      "plural": "iptables-fip-rules",
+      "shortNames": [
+        "fip"
+      ]
+    },
+    "kubeovn.io/IptablesSnatRule": {
+      "singular": "iptables-snat-rule",
+      "plural": "iptables-snat-rules",
+      "shortNames": [
+        "snat"
+      ]
+    },
+    "kubeovn.io/OvnDnatRule": {
+      "singular": "ovn-dnat-rule",
+      "plural": "ovn-dnat-rules",
+      "shortNames": [
+        "odnat"
+      ]
+    },
+    "kubeovn.io/OvnEip": {
+      "singular": "ovn-eip",
+      "plural": "ovn-eips",
+      "shortNames": [
+        "oeip"
+      ]
+    },
+    "kubeovn.io/OvnFip": {
+      "singular": "ovn-fip",
+      "plural": "ovn-fips",
+      "shortNames": [
+        "ofip"
+      ]
+    },
+    "kubeovn.io/OvnSnatRule": {
+      "singular": "ovn-snat-rule",
+      "plural": "ovn-snat-rules",
+      "shortNames": [
+        "osnat"
+      ]
+    },
+    "kubeovn.io/ProviderNetwork": {
+      "singular": "provider-network",
+      "plural": "provider-networks",
+      "shortNames": [
+        "pn"
+      ]
+    },
+    "kubeovn.io/QoSPolicy": {
+      "singular": "qos-policy",
+      "plural": "qos-policies",
+      "shortNames": [
+        "qos"
+      ]
+    },
+    "kubeovn.io/SecurityGroup": {
+      "singular": "security-group",
+      "plural": "security-groups",
+      "shortNames": [
+        "sg"
+      ]
+    },
+    "kubeovn.io/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets",
+      "shortNames": [
+        "subnet"
+      ]
+    },
+    "kubeovn.io/SwitchLBRule": {
+      "singular": "switch-lb-rule",
+      "plural": "switch-lb-rules",
+      "shortNames": [
+        "slr"
+      ]
+    },
+    "kubeovn.io/Vip": {
+      "singular": "vip",
+      "plural": "vips",
+      "shortNames": [
+        "vip"
+      ]
+    },
+    "kubeovn.io/Vlan": {
+      "singular": "vlan",
+      "plural": "vlans",
+      "shortNames": [
+        "vlan"
+      ]
+    },
+    "kubeovn.io/Vpc": {
+      "singular": "vpc",
+      "plural": "vpcs",
+      "shortNames": [
+        "vpc"
+      ]
+    },
+    "kubeovn.io/VpcDns": {
+      "singular": "vpc-dns",
+      "plural": "vpc-dnses",
+      "shortNames": [
+        "vpc-dns"
+      ]
+    },
+    "kubeovn.io/VpcEgressGateway": {
+      "singular": "vpc-egress-gateway",
+      "plural": "vpc-egress-gateways",
+      "shortNames": [
+        "vpc-egress-gw",
+        "veg"
+      ]
+    },
+    "kubeovn.io/VpcNatGateway": {
+      "singular": "vpc-nat-gateway",
+      "plural": "vpc-nat-gateways",
+      "shortNames": [
+        "vpc-nat-gw"
+      ]
+    }
+  },
   "files": [
     "catalog/kubeovn.io/bgpconf_v1.fields.txt",
     "catalog/kubeovn.io/bgpconf_v1.json",

--- a/build/history/kubeedge.json
+++ b/build/history/kubeedge.json
@@ -2,7 +2,7 @@
   "name": "kubeedge",
   "repo": "kubeedge/kubeedge",
   "version": "v1.23.0",
-  "builtAt": "2026-07-05T18:19:40.219Z",
+  "builtAt": "2026-07-07T19:13:59.118Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "apps.kubeedge.io/EdgeApplication",
@@ -19,6 +19,72 @@
     "rules.kubeedge.io/Rule",
     "rules.kubeedge.io/RuleEndpoint"
   ],
+  "resources": {
+    "apps.kubeedge.io/EdgeApplication": {
+      "singular": "edgeapplication",
+      "plural": "edgeapplications",
+      "shortNames": [
+        "eapp"
+      ]
+    },
+    "apps.kubeedge.io/NodeGroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups",
+      "shortNames": [
+        "ng"
+      ]
+    },
+    "devices.kubeedge.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "devices.kubeedge.io/DeviceModel": {
+      "singular": "devicemodel",
+      "plural": "devicemodels"
+    },
+    "devices.kubeedge.io/DeviceStatus": {
+      "singular": "devicestatus",
+      "plural": "devicestatuses"
+    },
+    "operations.kubeedge.io/ConfigUpdateJob": {
+      "singular": "configupdatejob",
+      "plural": "configupdatejobs"
+    },
+    "operations.kubeedge.io/ImagePrePullJob": {
+      "singular": "imageprepulljob",
+      "plural": "imageprepulljobs"
+    },
+    "operations.kubeedge.io/NodeUpgradeJob": {
+      "singular": "nodeupgradejob",
+      "plural": "nodeupgradejobs"
+    },
+    "policy.kubeedge.io/ServiceAccountAccess": {
+      "singular": "serviceaccountaccess",
+      "plural": "serviceaccountaccesses",
+      "shortNames": [
+        "saaccess"
+      ]
+    },
+    "reliablesyncs.kubeedge.io/ClusterObjectSync": {
+      "singular": "clusterobjectsync",
+      "plural": "clusterobjectsyncs"
+    },
+    "reliablesyncs.kubeedge.io/ObjectSync": {
+      "singular": "objectsync",
+      "plural": "objectsyncs"
+    },
+    "rules.kubeedge.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "rules.kubeedge.io/RuleEndpoint": {
+      "singular": "ruleendpoint",
+      "plural": "ruleendpoints",
+      "shortNames": [
+        "re"
+      ]
+    }
+  },
   "files": [
     "catalog/apps.kubeedge.io/edgeapplication_v1alpha1.fields.txt",
     "catalog/apps.kubeedge.io/edgeapplication_v1alpha1.json",

--- a/build/history/kubernetes.json
+++ b/build/history/kubernetes.json
@@ -2,8 +2,8 @@
   "name": "kubernetes",
   "repo": "kubernetes/kubernetes",
   "version": "v1.36.2",
-  "builtAt": "2026-07-05T09:08:38.014Z",
-  "fluxSchemaVersion": "0.7.0",
+  "builtAt": "2026-07-07T19:41:27.955Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "admissionregistration.k8s.io/MutatingAdmissionPolicy",
     "admissionregistration.k8s.io/MutatingAdmissionPolicyBinding",

--- a/build/history/kubewarden.json
+++ b/build/history/kubewarden.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "repo": "kubewarden/kubewarden-controller",
   "version": "v1.36.0",
-  "builtAt": "2026-07-05T18:59:14.485Z",
+  "builtAt": "2026-07-07T19:14:57.042Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "policies.kubewarden.io/AdmissionPolicy",
@@ -11,6 +11,43 @@
     "policies.kubewarden.io/ClusterAdmissionPolicyGroup",
     "policies.kubewarden.io/PolicyServer"
   ],
+  "resources": {
+    "policies.kubewarden.io/AdmissionPolicy": {
+      "singular": "admissionpolicy",
+      "plural": "admissionpolicies",
+      "shortNames": [
+        "ap"
+      ]
+    },
+    "policies.kubewarden.io/AdmissionPolicyGroup": {
+      "singular": "admissionpolicygroup",
+      "plural": "admissionpolicygroups",
+      "shortNames": [
+        "apg"
+      ]
+    },
+    "policies.kubewarden.io/ClusterAdmissionPolicy": {
+      "singular": "clusteradmissionpolicy",
+      "plural": "clusteradmissionpolicies",
+      "shortNames": [
+        "cap"
+      ]
+    },
+    "policies.kubewarden.io/ClusterAdmissionPolicyGroup": {
+      "singular": "clusteradmissionpolicygroup",
+      "plural": "clusteradmissionpolicygroups",
+      "shortNames": [
+        "capg"
+      ]
+    },
+    "policies.kubewarden.io/PolicyServer": {
+      "singular": "policyserver",
+      "plural": "policyservers",
+      "shortNames": [
+        "ps"
+      ]
+    }
+  },
   "files": [
     "catalog/policies.kubewarden.io/admissionpolicy_v1.fields.txt",
     "catalog/policies.kubewarden.io/admissionpolicy_v1.json",

--- a/build/history/kueue.json
+++ b/build/history/kueue.json
@@ -2,8 +2,8 @@
   "name": "kueue",
   "repo": "kubernetes-sigs/kueue",
   "version": "v0.18.2",
-  "builtAt": "2026-07-05T13:14:40.071Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:18.621Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kueue.x-k8s.io/AdmissionCheck",
     "kueue.x-k8s.io/ClusterQueue",
@@ -17,6 +17,91 @@
     "kueue.x-k8s.io/Workload",
     "kueue.x-k8s.io/WorkloadPriorityClass"
   ],
+  "resources": {
+    "kueue.x-k8s.io/AdmissionCheck": {
+      "singular": "admissioncheck",
+      "plural": "admissionchecks",
+      "shortNames": [
+        "ac"
+      ]
+    },
+    "kueue.x-k8s.io/ClusterQueue": {
+      "singular": "clusterqueue",
+      "plural": "clusterqueues",
+      "shortNames": [
+        "cq"
+      ]
+    },
+    "kueue.x-k8s.io/Cohort": {
+      "singular": "cohort",
+      "plural": "cohorts",
+      "shortNames": [
+        "co"
+      ]
+    },
+    "kueue.x-k8s.io/LocalQueue": {
+      "singular": "localqueue",
+      "plural": "localqueues",
+      "shortNames": [
+        "queue",
+        "queues",
+        "lq"
+      ]
+    },
+    "kueue.x-k8s.io/MultiKueueCluster": {
+      "singular": "multikueuecluster",
+      "plural": "multikueueclusters",
+      "shortNames": [
+        "mkc"
+      ]
+    },
+    "kueue.x-k8s.io/MultiKueueConfig": {
+      "singular": "multikueueconfig",
+      "plural": "multikueueconfigs",
+      "shortNames": [
+        "mkconf"
+      ]
+    },
+    "kueue.x-k8s.io/ProvisioningRequestConfig": {
+      "singular": "provisioningrequestconfig",
+      "plural": "provisioningrequestconfigs",
+      "shortNames": [
+        "prc"
+      ]
+    },
+    "kueue.x-k8s.io/ResourceFlavor": {
+      "singular": "resourceflavor",
+      "plural": "resourceflavors",
+      "shortNames": [
+        "flavor",
+        "flavors",
+        "rf"
+      ]
+    },
+    "kueue.x-k8s.io/Topology": {
+      "singular": "topology",
+      "plural": "topologies",
+      "shortNames": [
+        "topo"
+      ]
+    },
+    "kueue.x-k8s.io/Workload": {
+      "singular": "workload",
+      "plural": "workloads",
+      "shortNames": [
+        "kwl",
+        "kueueworkload",
+        "kueueworkloads"
+      ]
+    },
+    "kueue.x-k8s.io/WorkloadPriorityClass": {
+      "singular": "workloadpriorityclass",
+      "plural": "workloadpriorityclasses",
+      "shortNames": [
+        "wpc"
+      ]
+    }
+  },
   "files": [
     "catalog/kueue.x-k8s.io/admissioncheck_v1beta1.fields.txt",
     "catalog/kueue.x-k8s.io/admissioncheck_v1beta1.json",

--- a/build/history/kwok.json
+++ b/build/history/kwok.json
@@ -2,7 +2,7 @@
   "name": "kwok",
   "repo": "kubernetes-sigs/kwok",
   "version": "v0.8.0",
-  "builtAt": "2026-07-05T17:55:51.067Z",
+  "builtAt": "2026-07-07T19:12:41.980Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kwok.x-k8s.io/Attach",
@@ -18,6 +18,56 @@
     "kwok.x-k8s.io/ResourceUsage",
     "kwok.x-k8s.io/Stage"
   ],
+  "resources": {
+    "kwok.x-k8s.io/Attach": {
+      "singular": "attach",
+      "plural": "attaches"
+    },
+    "kwok.x-k8s.io/ClusterAttach": {
+      "singular": "clusterattach",
+      "plural": "clusterattaches"
+    },
+    "kwok.x-k8s.io/ClusterExec": {
+      "singular": "clusterexec",
+      "plural": "clusterexecs"
+    },
+    "kwok.x-k8s.io/ClusterLogs": {
+      "singular": "clusterlogs",
+      "plural": "clusterlogs"
+    },
+    "kwok.x-k8s.io/ClusterPortForward": {
+      "singular": "clusterportforward",
+      "plural": "clusterportforwards"
+    },
+    "kwok.x-k8s.io/ClusterResourceUsage": {
+      "singular": "clusterresourceusage",
+      "plural": "clusterresourceusages"
+    },
+    "kwok.x-k8s.io/Exec": {
+      "singular": "exec",
+      "plural": "execs"
+    },
+    "kwok.x-k8s.io/Logs": {
+      "singular": "logs",
+      "plural": "logs"
+    },
+    "kwok.x-k8s.io/Metric": {
+      "singular": "metric",
+      "plural": "metrics"
+    },
+    "kwok.x-k8s.io/PortForward": {
+      "singular": "portforward",
+      "plural": "portforwards"
+    },
+    "kwok.x-k8s.io/ResourceUsage": {
+      "singular": "resourceusage",
+      "plural": "resourceusages"
+    },
+    "kwok.x-k8s.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    }
+  },
   "files": [
     "catalog/kwok.x-k8s.io/attach_v1alpha1.fields.txt",
     "catalog/kwok.x-k8s.io/attach_v1alpha1.json",

--- a/build/history/kyverno.json
+++ b/build/history/kyverno.json
@@ -2,8 +2,8 @@
   "name": "kyverno",
   "repo": "kyverno/kyverno",
   "version": "v1.18.1",
-  "builtAt": "2026-07-05T11:07:11.414Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:06:54.459Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "kyverno.io/CleanupPolicy",
     "kyverno.io/ClusterCleanupPolicy",
@@ -28,6 +28,159 @@
     "wgpolicyk8s.io/ClusterPolicyReport",
     "wgpolicyk8s.io/PolicyReport"
   ],
+  "resources": {
+    "kyverno.io/CleanupPolicy": {
+      "singular": "cleanuppolicy",
+      "plural": "cleanuppolicies",
+      "shortNames": [
+        "cleanpol"
+      ]
+    },
+    "kyverno.io/ClusterCleanupPolicy": {
+      "singular": "clustercleanuppolicy",
+      "plural": "clustercleanuppolicies",
+      "shortNames": [
+        "ccleanpol"
+      ]
+    },
+    "kyverno.io/ClusterPolicy": {
+      "singular": "clusterpolicy",
+      "plural": "clusterpolicies",
+      "shortNames": [
+        "cpol"
+      ]
+    },
+    "kyverno.io/GlobalContextEntry": {
+      "singular": "globalcontextentry",
+      "plural": "globalcontextentries",
+      "shortNames": [
+        "gctxentry"
+      ]
+    },
+    "kyverno.io/Policy": {
+      "singular": "policy",
+      "plural": "policies",
+      "shortNames": [
+        "pol"
+      ]
+    },
+    "kyverno.io/PolicyException": {
+      "singular": "policyexception",
+      "plural": "policyexceptions",
+      "shortNames": [
+        "polex"
+      ]
+    },
+    "kyverno.io/UpdateRequest": {
+      "singular": "updaterequest",
+      "plural": "updaterequests",
+      "shortNames": [
+        "ur"
+      ]
+    },
+    "policies.kyverno.io/DeletingPolicy": {
+      "singular": "deletingpolicy",
+      "plural": "deletingpolicies",
+      "shortNames": [
+        "dpol"
+      ]
+    },
+    "policies.kyverno.io/GeneratingPolicy": {
+      "singular": "generatingpolicy",
+      "plural": "generatingpolicies",
+      "shortNames": [
+        "gpol"
+      ]
+    },
+    "policies.kyverno.io/ImageValidatingPolicy": {
+      "singular": "imagevalidatingpolicy",
+      "plural": "imagevalidatingpolicies",
+      "shortNames": [
+        "ivpol"
+      ]
+    },
+    "policies.kyverno.io/MutatingPolicy": {
+      "singular": "mutatingpolicy",
+      "plural": "mutatingpolicies",
+      "shortNames": [
+        "mpol"
+      ]
+    },
+    "policies.kyverno.io/NamespacedDeletingPolicy": {
+      "singular": "namespaceddeletingpolicy",
+      "plural": "namespaceddeletingpolicies",
+      "shortNames": [
+        "ndpol"
+      ]
+    },
+    "policies.kyverno.io/NamespacedGeneratingPolicy": {
+      "singular": "namespacedgeneratingpolicy",
+      "plural": "namespacedgeneratingpolicies",
+      "shortNames": [
+        "ngpol"
+      ]
+    },
+    "policies.kyverno.io/NamespacedImageValidatingPolicy": {
+      "singular": "namespacedimagevalidatingpolicy",
+      "plural": "namespacedimagevalidatingpolicies",
+      "shortNames": [
+        "nivpol"
+      ]
+    },
+    "policies.kyverno.io/NamespacedMutatingPolicy": {
+      "singular": "namespacedmutatingpolicy",
+      "plural": "namespacedmutatingpolicies",
+      "shortNames": [
+        "nmpol"
+      ]
+    },
+    "policies.kyverno.io/NamespacedValidatingPolicy": {
+      "singular": "namespacedvalidatingpolicy",
+      "plural": "namespacedvalidatingpolicies",
+      "shortNames": [
+        "nvpol"
+      ]
+    },
+    "policies.kyverno.io/PolicyException": {
+      "singular": "policyexception",
+      "plural": "policyexceptions"
+    },
+    "policies.kyverno.io/ValidatingPolicy": {
+      "singular": "validatingpolicy",
+      "plural": "validatingpolicies",
+      "shortNames": [
+        "vpol"
+      ]
+    },
+    "reports.kyverno.io/ClusterEphemeralReport": {
+      "singular": "clusterephemeralreport",
+      "plural": "clusterephemeralreports",
+      "shortNames": [
+        "cephr"
+      ]
+    },
+    "reports.kyverno.io/EphemeralReport": {
+      "singular": "ephemeralreport",
+      "plural": "ephemeralreports",
+      "shortNames": [
+        "ephr"
+      ]
+    },
+    "wgpolicyk8s.io/ClusterPolicyReport": {
+      "singular": "clusterpolicyreport",
+      "plural": "clusterpolicyreports",
+      "shortNames": [
+        "cpolr"
+      ]
+    },
+    "wgpolicyk8s.io/PolicyReport": {
+      "singular": "policyreport",
+      "plural": "policyreports",
+      "shortNames": [
+        "polr"
+      ]
+    }
+  },
   "files": [
     "catalog/kyverno.io/cleanuppolicy_v2.fields.txt",
     "catalog/kyverno.io/cleanuppolicy_v2.json",

--- a/build/history/loki-operator.json
+++ b/build/history/loki-operator.json
@@ -2,7 +2,7 @@
   "name": "loki-operator",
   "repo": "grafana/loki",
   "version": "operator/v0.10.2",
-  "builtAt": "2026-07-06T23:14:24.812Z",
+  "builtAt": "2026-07-07T19:16:31.289Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "config.grafana.com/ProjectConfig",
@@ -11,6 +11,28 @@
     "loki.grafana.com/RecordingRule",
     "loki.grafana.com/RulerConfig"
   ],
+  "resources": {
+    "config.grafana.com/ProjectConfig": {
+      "singular": "projectconfig",
+      "plural": "projectconfigs"
+    },
+    "loki.grafana.com/AlertingRule": {
+      "singular": "alertingrule",
+      "plural": "alertingrules"
+    },
+    "loki.grafana.com/LokiStack": {
+      "singular": "lokistack",
+      "plural": "lokistacks"
+    },
+    "loki.grafana.com/RecordingRule": {
+      "singular": "recordingrule",
+      "plural": "recordingrules"
+    },
+    "loki.grafana.com/RulerConfig": {
+      "singular": "rulerconfig",
+      "plural": "rulerconfigs"
+    }
+  },
   "files": [
     "catalog/config.grafana.com/projectconfig_v1.fields.txt",
     "catalog/config.grafana.com/projectconfig_v1.json",

--- a/build/history/longhorn.json
+++ b/build/history/longhorn.json
@@ -2,8 +2,8 @@
   "name": "longhorn",
   "repo": "longhorn/longhorn",
   "version": "v1.12.0",
-  "builtAt": "2026-07-05T12:25:55.362Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:15.825Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "longhorn.io/BackingImage",
     "longhorn.io/BackingImageDataSource",
@@ -29,6 +29,169 @@
     "longhorn.io/Volume",
     "longhorn.io/VolumeAttachment"
   ],
+  "resources": {
+    "longhorn.io/BackingImage": {
+      "singular": "backingimage",
+      "plural": "backingimages",
+      "shortNames": [
+        "lhbi"
+      ]
+    },
+    "longhorn.io/BackingImageDataSource": {
+      "singular": "backingimagedatasource",
+      "plural": "backingimagedatasources",
+      "shortNames": [
+        "lhbids"
+      ]
+    },
+    "longhorn.io/BackingImageManager": {
+      "singular": "backingimagemanager",
+      "plural": "backingimagemanagers",
+      "shortNames": [
+        "lhbim"
+      ]
+    },
+    "longhorn.io/Backup": {
+      "singular": "backup",
+      "plural": "backups",
+      "shortNames": [
+        "lhb"
+      ]
+    },
+    "longhorn.io/BackupBackingImage": {
+      "singular": "backupbackingimage",
+      "plural": "backupbackingimages",
+      "shortNames": [
+        "lhbbi"
+      ]
+    },
+    "longhorn.io/BackupTarget": {
+      "singular": "backuptarget",
+      "plural": "backuptargets",
+      "shortNames": [
+        "lhbt"
+      ]
+    },
+    "longhorn.io/BackupVolume": {
+      "singular": "backupvolume",
+      "plural": "backupvolumes",
+      "shortNames": [
+        "lhbv"
+      ]
+    },
+    "longhorn.io/Engine": {
+      "singular": "engine",
+      "plural": "engines",
+      "shortNames": [
+        "lhe"
+      ]
+    },
+    "longhorn.io/EngineFrontend": {
+      "singular": "enginefrontend",
+      "plural": "enginefrontends",
+      "shortNames": [
+        "lhef"
+      ]
+    },
+    "longhorn.io/EngineImage": {
+      "singular": "engineimage",
+      "plural": "engineimages",
+      "shortNames": [
+        "lhei"
+      ]
+    },
+    "longhorn.io/InstanceManager": {
+      "singular": "instancemanager",
+      "plural": "instancemanagers",
+      "shortNames": [
+        "lhim"
+      ]
+    },
+    "longhorn.io/Node": {
+      "singular": "node",
+      "plural": "nodes",
+      "shortNames": [
+        "lhn"
+      ]
+    },
+    "longhorn.io/Orphan": {
+      "singular": "orphan",
+      "plural": "orphans",
+      "shortNames": [
+        "lho"
+      ]
+    },
+    "longhorn.io/RecurringJob": {
+      "singular": "recurringjob",
+      "plural": "recurringjobs",
+      "shortNames": [
+        "lhrj"
+      ]
+    },
+    "longhorn.io/Replica": {
+      "singular": "replica",
+      "plural": "replicas",
+      "shortNames": [
+        "lhr"
+      ]
+    },
+    "longhorn.io/Setting": {
+      "singular": "setting",
+      "plural": "settings",
+      "shortNames": [
+        "lhs"
+      ]
+    },
+    "longhorn.io/ShareManager": {
+      "singular": "sharemanager",
+      "plural": "sharemanagers",
+      "shortNames": [
+        "lhsm"
+      ]
+    },
+    "longhorn.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots",
+      "shortNames": [
+        "lhsnap"
+      ]
+    },
+    "longhorn.io/SupportBundle": {
+      "singular": "supportbundle",
+      "plural": "supportbundles",
+      "shortNames": [
+        "lhbundle"
+      ]
+    },
+    "longhorn.io/SystemBackup": {
+      "singular": "systembackup",
+      "plural": "systembackups",
+      "shortNames": [
+        "lhsb"
+      ]
+    },
+    "longhorn.io/SystemRestore": {
+      "singular": "systemrestore",
+      "plural": "systemrestores",
+      "shortNames": [
+        "lhsr"
+      ]
+    },
+    "longhorn.io/Volume": {
+      "singular": "volume",
+      "plural": "volumes",
+      "shortNames": [
+        "lhv"
+      ]
+    },
+    "longhorn.io/VolumeAttachment": {
+      "singular": "volumeattachment",
+      "plural": "volumeattachments",
+      "shortNames": [
+        "lhva"
+      ]
+    }
+  },
   "files": [
     "catalog/longhorn.io/backingimage_v1beta2.fields.txt",
     "catalog/longhorn.io/backingimage_v1beta2.json",

--- a/build/history/lws.json
+++ b/build/history/lws.json
@@ -2,12 +2,25 @@
   "name": "lws",
   "repo": "kubernetes-sigs/lws",
   "version": "v0.9.0",
-  "builtAt": "2026-07-05T17:54:21.589Z",
+  "builtAt": "2026-07-07T19:12:28.056Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "disaggregatedset.x-k8s.io/DisaggregatedSet",
     "leaderworkerset.x-k8s.io/LeaderWorkerSet"
   ],
+  "resources": {
+    "disaggregatedset.x-k8s.io/DisaggregatedSet": {
+      "singular": "disaggregatedset",
+      "plural": "disaggregatedsets"
+    },
+    "leaderworkerset.x-k8s.io/LeaderWorkerSet": {
+      "singular": "leaderworkerset",
+      "plural": "leaderworkersets",
+      "shortNames": [
+        "lws"
+      ]
+    }
+  },
   "files": [
     "catalog/disaggregatedset.x-k8s.io/disaggregatedset_v1.fields.txt",
     "catalog/disaggregatedset.x-k8s.io/disaggregatedset_v1.json",

--- a/build/history/mariadb-operator.json
+++ b/build/history/mariadb-operator.json
@@ -2,7 +2,7 @@
   "name": "mariadb-operator",
   "repo": "mariadb-operator/mariadb-operator",
   "version": "mariadb-operator-crds-26.6.0",
-  "builtAt": "2026-07-06T23:14:26.052Z",
+  "builtAt": "2026-07-07T19:14:39.715Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "k8s.mariadb.com/Backup",
@@ -18,6 +18,92 @@
     "k8s.mariadb.com/SqlJob",
     "k8s.mariadb.com/User"
   ],
+  "resources": {
+    "k8s.mariadb.com/Backup": {
+      "singular": "backup",
+      "plural": "backups",
+      "shortNames": [
+        "bmdb"
+      ]
+    },
+    "k8s.mariadb.com/Connection": {
+      "singular": "connection",
+      "plural": "connections",
+      "shortNames": [
+        "cmdb"
+      ]
+    },
+    "k8s.mariadb.com/Database": {
+      "singular": "database",
+      "plural": "databases",
+      "shortNames": [
+        "dmdb"
+      ]
+    },
+    "k8s.mariadb.com/ExternalMariaDB": {
+      "singular": "externalmariadb",
+      "plural": "externalmariadbs",
+      "shortNames": [
+        "emdb"
+      ]
+    },
+    "k8s.mariadb.com/Grant": {
+      "singular": "grant",
+      "plural": "grants",
+      "shortNames": [
+        "gmdb"
+      ]
+    },
+    "k8s.mariadb.com/MariaDB": {
+      "singular": "mariadb",
+      "plural": "mariadbs",
+      "shortNames": [
+        "mdb"
+      ]
+    },
+    "k8s.mariadb.com/MaxScale": {
+      "singular": "maxscale",
+      "plural": "maxscales",
+      "shortNames": [
+        "mxs"
+      ]
+    },
+    "k8s.mariadb.com/PhysicalBackup": {
+      "singular": "physicalbackup",
+      "plural": "physicalbackups",
+      "shortNames": [
+        "pbmdb"
+      ]
+    },
+    "k8s.mariadb.com/PointInTimeRecovery": {
+      "singular": "pointintimerecovery",
+      "plural": "pointintimerecoveries",
+      "shortNames": [
+        "pitr"
+      ]
+    },
+    "k8s.mariadb.com/Restore": {
+      "singular": "restore",
+      "plural": "restores",
+      "shortNames": [
+        "rmdb"
+      ]
+    },
+    "k8s.mariadb.com/SqlJob": {
+      "singular": "sqljob",
+      "plural": "sqljobs",
+      "shortNames": [
+        "smdb"
+      ]
+    },
+    "k8s.mariadb.com/User": {
+      "singular": "user",
+      "plural": "users",
+      "shortNames": [
+        "umdb"
+      ]
+    }
+  },
   "files": [
     "catalog/k8s.mariadb.com/backup_v1alpha1.fields.txt",
     "catalog/k8s.mariadb.com/backup_v1alpha1.json",

--- a/build/history/nats.json
+++ b/build/history/nats.json
@@ -2,8 +2,8 @@
   "name": "nats",
   "repo": "nats-io/nack",
   "version": "v0.23.0",
-  "builtAt": "2026-07-05T11:39:20.893Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:01.545Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "jetstream.nats.io/Account",
     "jetstream.nats.io/Consumer",
@@ -12,6 +12,35 @@
     "jetstream.nats.io/Stream",
     "jetstream.nats.io/StreamTemplate"
   ],
+  "resources": {
+    "jetstream.nats.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "jetstream.nats.io/Consumer": {
+      "singular": "consumer",
+      "plural": "consumers"
+    },
+    "jetstream.nats.io/KeyValue": {
+      "singular": "keyvalue",
+      "plural": "keyvalues",
+      "shortNames": [
+        "kv"
+      ]
+    },
+    "jetstream.nats.io/ObjectStore": {
+      "singular": "objectstore",
+      "plural": "objectstores"
+    },
+    "jetstream.nats.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "jetstream.nats.io/StreamTemplate": {
+      "singular": "streamtemplate",
+      "plural": "streamtemplates"
+    }
+  },
   "files": [
     "catalog/jetstream.nats.io/account_v1beta2.fields.txt",
     "catalog/jetstream.nats.io/account_v1beta2.json",

--- a/build/history/network-policy-api.json
+++ b/build/history/network-policy-api.json
@@ -2,11 +2,20 @@
   "name": "network-policy-api",
   "repo": "kubernetes-sigs/network-policy-api",
   "version": "v0.2.0",
-  "builtAt": "2026-07-05T17:56:18.742Z",
+  "builtAt": "2026-07-07T19:12:43.700Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "policy.networking.k8s.io/ClusterNetworkPolicy"
   ],
+  "resources": {
+    "policy.networking.k8s.io/ClusterNetworkPolicy": {
+      "singular": "clusternetworkpolicy",
+      "plural": "clusternetworkpolicies",
+      "shortNames": [
+        "cnp"
+      ]
+    }
+  },
   "files": [
     "catalog/policy.networking.k8s.io/clusternetworkpolicy_v1alpha2.fields.txt",
     "catalog/policy.networking.k8s.io/clusternetworkpolicy_v1alpha2.json"

--- a/build/history/node-feature-discovery-nrt.json
+++ b/build/history/node-feature-discovery-nrt.json
@@ -2,11 +2,20 @@
   "name": "node-feature-discovery-nrt",
   "repo": "kubernetes-sigs/node-feature-discovery",
   "version": "v0.18.3",
-  "builtAt": "2026-07-05T17:55:02.322Z",
+  "builtAt": "2026-07-07T19:12:40.521Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "topology.node.k8s.io/NodeResourceTopology"
   ],
+  "resources": {
+    "topology.node.k8s.io/NodeResourceTopology": {
+      "singular": "noderesourcetopology",
+      "plural": "noderesourcetopologies",
+      "shortNames": [
+        "node-res-topo"
+      ]
+    }
+  },
   "files": [
     "catalog/topology.node.k8s.io/noderesourcetopology_v1alpha1.fields.txt",
     "catalog/topology.node.k8s.io/noderesourcetopology_v1alpha1.json",

--- a/build/history/node-feature-discovery.json
+++ b/build/history/node-feature-discovery.json
@@ -2,13 +2,33 @@
   "name": "node-feature-discovery",
   "repo": "kubernetes-sigs/node-feature-discovery",
   "version": "v0.18.3",
-  "builtAt": "2026-07-05T17:55:01.049Z",
+  "builtAt": "2026-07-07T19:12:38.075Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "nfd.k8s-sigs.io/NodeFeature",
     "nfd.k8s-sigs.io/NodeFeatureGroup",
     "nfd.k8s-sigs.io/NodeFeatureRule"
   ],
+  "resources": {
+    "nfd.k8s-sigs.io/NodeFeature": {
+      "singular": "nodefeature",
+      "plural": "nodefeatures"
+    },
+    "nfd.k8s-sigs.io/NodeFeatureGroup": {
+      "singular": "nodefeaturegroup",
+      "plural": "nodefeaturegroups",
+      "shortNames": [
+        "nfg"
+      ]
+    },
+    "nfd.k8s-sigs.io/NodeFeatureRule": {
+      "singular": "nodefeaturerule",
+      "plural": "nodefeaturerules",
+      "shortNames": [
+        "nfr"
+      ]
+    }
+  },
   "files": [
     "catalog/nfd.k8s-sigs.io/nodefeature_v1alpha1.fields.txt",
     "catalog/nfd.k8s-sigs.io/nodefeature_v1alpha1.json",

--- a/build/history/onepassword-operator.json
+++ b/build/history/onepassword-operator.json
@@ -2,11 +2,20 @@
   "name": "onepassword-operator",
   "repo": "1Password/onepassword-operator",
   "version": "v1.12.0",
-  "builtAt": "2026-07-06T22:02:50.322Z",
+  "builtAt": "2026-07-07T19:05:11.988Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "onepassword.com/OnePasswordItem"
   ],
+  "resources": {
+    "onepassword.com/OnePasswordItem": {
+      "singular": "onepassworditem",
+      "plural": "onepassworditems",
+      "shortNames": [
+        "opi"
+      ]
+    }
+  },
   "files": [
     "catalog/onepassword.com/onepassworditem_v1.fields.txt",
     "catalog/onepassword.com/onepassworditem_v1.json"

--- a/build/history/open-feature-operator.json
+++ b/build/history/open-feature-operator.json
@@ -2,7 +2,7 @@
   "name": "open-feature-operator",
   "repo": "open-feature/open-feature-operator",
   "version": "v0.9.2",
-  "builtAt": "2026-07-05T18:25:20.090Z",
+  "builtAt": "2026-07-07T19:14:01.553Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "core.openfeature.dev/FeatureFlag",
@@ -12,6 +12,44 @@
     "core.openfeature.dev/Flagd",
     "core.openfeature.dev/InProcessConfiguration"
   ],
+  "resources": {
+    "core.openfeature.dev/FeatureFlag": {
+      "singular": "featureflag",
+      "plural": "featureflags",
+      "shortNames": [
+        "ff"
+      ]
+    },
+    "core.openfeature.dev/FeatureFlagConfiguration": {
+      "singular": "featureflagconfiguration",
+      "plural": "featureflagconfigurations",
+      "shortNames": [
+        "ffc"
+      ]
+    },
+    "core.openfeature.dev/FeatureFlagSource": {
+      "singular": "featureflagsource",
+      "plural": "featureflagsources",
+      "shortNames": [
+        "ffs"
+      ]
+    },
+    "core.openfeature.dev/FlagSourceConfiguration": {
+      "singular": "flagsourceconfiguration",
+      "plural": "flagsourceconfigurations",
+      "shortNames": [
+        "fsc"
+      ]
+    },
+    "core.openfeature.dev/Flagd": {
+      "singular": "flagd",
+      "plural": "flagds"
+    },
+    "core.openfeature.dev/InProcessConfiguration": {
+      "singular": "inprocessconfiguration",
+      "plural": "inprocessconfigurations"
+    }
+  },
   "files": [
     "catalog/core.openfeature.dev/featureflag_v1beta1.fields.txt",
     "catalog/core.openfeature.dev/featureflag_v1beta1.json",

--- a/build/history/openreports.json
+++ b/build/history/openreports.json
@@ -2,12 +2,28 @@
   "name": "openreports",
   "repo": "openreports/reports-api",
   "version": "v0.2.1",
-  "builtAt": "2026-07-05T18:25:44.426Z",
+  "builtAt": "2026-07-07T19:14:02.134Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "openreports.io/ClusterReport",
     "openreports.io/Report"
   ],
+  "resources": {
+    "openreports.io/ClusterReport": {
+      "singular": "clusterreport",
+      "plural": "clusterreports",
+      "shortNames": [
+        "creps"
+      ]
+    },
+    "openreports.io/Report": {
+      "singular": "report",
+      "plural": "reports",
+      "shortNames": [
+        "reps"
+      ]
+    }
+  },
   "files": [
     "catalog/openreports.io/clusterreport_v1alpha1.fields.txt",
     "catalog/openreports.io/clusterreport_v1alpha1.json",

--- a/build/history/opensearch-operator.json
+++ b/build/history/opensearch-operator.json
@@ -2,7 +2,7 @@
   "name": "opensearch-operator",
   "repo": "opensearch-project/opensearch-k8s-operator",
   "version": "opensearch-operator-3.0.2",
-  "builtAt": "2026-07-06T23:14:27.335Z",
+  "builtAt": "2026-07-07T19:06:45.952Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "opensearch.opster.io/OpenSearchCluster",
@@ -26,6 +26,146 @@
     "opensearch.org/OpensearchUser",
     "opensearch.org/OpensearchUserRoleBinding"
   ],
+  "resources": {
+    "opensearch.opster.io/OpenSearchCluster": {
+      "singular": "opensearchcluster",
+      "plural": "opensearchclusters",
+      "shortNames": [
+        "os",
+        "opensearch"
+      ]
+    },
+    "opensearch.opster.io/OpenSearchISMPolicy": {
+      "singular": "opensearchismpolicy",
+      "plural": "opensearchismpolicies",
+      "shortNames": [
+        "ismp",
+        "ismpolicy"
+      ]
+    },
+    "opensearch.opster.io/OpensearchActionGroup": {
+      "singular": "opensearchactiongroup",
+      "plural": "opensearchactiongroups",
+      "shortNames": [
+        "opensearchactiongroup"
+      ]
+    },
+    "opensearch.opster.io/OpensearchComponentTemplate": {
+      "singular": "opensearchcomponenttemplate",
+      "plural": "opensearchcomponenttemplates",
+      "shortNames": [
+        "opensearchcomponenttemplate"
+      ]
+    },
+    "opensearch.opster.io/OpensearchIndexTemplate": {
+      "singular": "opensearchindextemplate",
+      "plural": "opensearchindextemplates",
+      "shortNames": [
+        "opensearchindextemplate"
+      ]
+    },
+    "opensearch.opster.io/OpensearchRole": {
+      "singular": "opensearchrole",
+      "plural": "opensearchroles",
+      "shortNames": [
+        "opensearchrole"
+      ]
+    },
+    "opensearch.opster.io/OpensearchSnapshotPolicy": {
+      "singular": "opensearchsnapshotpolicy",
+      "plural": "opensearchsnapshotpolicies"
+    },
+    "opensearch.opster.io/OpensearchTenant": {
+      "singular": "opensearchtenant",
+      "plural": "opensearchtenants",
+      "shortNames": [
+        "opensearchtenant"
+      ]
+    },
+    "opensearch.opster.io/OpensearchUser": {
+      "singular": "opensearchuser",
+      "plural": "opensearchusers",
+      "shortNames": [
+        "opensearchuser"
+      ]
+    },
+    "opensearch.opster.io/OpensearchUserRoleBinding": {
+      "singular": "opensearchuserrolebinding",
+      "plural": "opensearchuserrolebindings",
+      "shortNames": [
+        "opensearchuserrolebinding"
+      ]
+    },
+    "opensearch.org/OpenSearchCluster": {
+      "singular": "opensearchcluster",
+      "plural": "opensearchclusters",
+      "shortNames": [
+        "os",
+        "opensearch"
+      ]
+    },
+    "opensearch.org/OpenSearchISMPolicy": {
+      "singular": "opensearchismpolicy",
+      "plural": "opensearchismpolicies",
+      "shortNames": [
+        "ismp",
+        "ismpolicy"
+      ]
+    },
+    "opensearch.org/OpensearchActionGroup": {
+      "singular": "opensearchactiongroup",
+      "plural": "opensearchactiongroups",
+      "shortNames": [
+        "opensearchactiongroup"
+      ]
+    },
+    "opensearch.org/OpensearchComponentTemplate": {
+      "singular": "opensearchcomponenttemplate",
+      "plural": "opensearchcomponenttemplates",
+      "shortNames": [
+        "opensearchcomponenttemplate"
+      ]
+    },
+    "opensearch.org/OpensearchIndexTemplate": {
+      "singular": "opensearchindextemplate",
+      "plural": "opensearchindextemplates",
+      "shortNames": [
+        "opensearchindextemplate"
+      ]
+    },
+    "opensearch.org/OpensearchRole": {
+      "singular": "opensearchrole",
+      "plural": "opensearchroles",
+      "shortNames": [
+        "opensearchrole"
+      ]
+    },
+    "opensearch.org/OpensearchSnapshotPolicy": {
+      "singular": "opensearchsnapshotpolicy",
+      "plural": "opensearchsnapshotpolicies"
+    },
+    "opensearch.org/OpensearchTenant": {
+      "singular": "opensearchtenant",
+      "plural": "opensearchtenants",
+      "shortNames": [
+        "opensearchtenant"
+      ]
+    },
+    "opensearch.org/OpensearchUser": {
+      "singular": "opensearchuser",
+      "plural": "opensearchusers",
+      "shortNames": [
+        "opensearchuser"
+      ]
+    },
+    "opensearch.org/OpensearchUserRoleBinding": {
+      "singular": "opensearchuserrolebinding",
+      "plural": "opensearchuserrolebindings",
+      "shortNames": [
+        "opensearchuserrolebinding"
+      ]
+    }
+  },
   "files": [
     "catalog/opensearch.opster.io/opensearchactiongroup_v1.fields.txt",
     "catalog/opensearch.opster.io/opensearchactiongroup_v1.json",

--- a/build/history/openshift.json
+++ b/build/history/openshift.json
@@ -2,8 +2,8 @@
   "name": "openshift",
   "repo": "openshift/api",
   "version": "v4.20",
-  "builtAt": "2026-07-05T09:08:39.114Z",
-  "fluxSchemaVersion": "0.7.0",
+  "builtAt": "2026-07-07T19:41:28.010Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "apiserver.openshift.io/APIRequestCount",
     "apps.openshift.io/DeploymentConfig",

--- a/build/history/opentelemetry.json
+++ b/build/history/opentelemetry.json
@@ -2,14 +2,40 @@
   "name": "opentelemetry",
   "repo": "open-telemetry/opentelemetry-operator",
   "version": "v0.154.0",
-  "builtAt": "2026-07-05T12:08:54.007Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:02.741Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "opentelemetry.io/Instrumentation",
     "opentelemetry.io/OpAMPBridge",
     "opentelemetry.io/OpenTelemetryCollector",
     "opentelemetry.io/TargetAllocator"
   ],
+  "resources": {
+    "opentelemetry.io/Instrumentation": {
+      "singular": "instrumentation",
+      "plural": "instrumentations",
+      "shortNames": [
+        "otelinst",
+        "otelinsts"
+      ]
+    },
+    "opentelemetry.io/OpAMPBridge": {
+      "singular": "opampbridge",
+      "plural": "opampbridges"
+    },
+    "opentelemetry.io/OpenTelemetryCollector": {
+      "singular": "opentelemetrycollector",
+      "plural": "opentelemetrycollectors",
+      "shortNames": [
+        "otelcol",
+        "otelcols"
+      ]
+    },
+    "opentelemetry.io/TargetAllocator": {
+      "singular": "targetallocator",
+      "plural": "targetallocators"
+    }
+  },
   "files": [
     "catalog/opentelemetry.io/instrumentation_v1alpha1.fields.txt",
     "catalog/opentelemetry.io/instrumentation_v1alpha1.json",

--- a/build/history/perses-operator.json
+++ b/build/history/perses-operator.json
@@ -2,7 +2,7 @@
   "name": "perses-operator",
   "repo": "perses/perses-operator",
   "version": "v0.4.0",
-  "builtAt": "2026-07-06T22:45:43.203Z",
+  "builtAt": "2026-07-07T19:06:44.988Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "perses.dev/Perses",
@@ -10,6 +10,36 @@
     "perses.dev/PersesDatasource",
     "perses.dev/PersesGlobalDatasource"
   ],
+  "resources": {
+    "perses.dev/Perses": {
+      "singular": "perses",
+      "plural": "perses",
+      "shortNames": [
+        "per"
+      ]
+    },
+    "perses.dev/PersesDashboard": {
+      "singular": "persesdashboard",
+      "plural": "persesdashboards",
+      "shortNames": [
+        "perdb"
+      ]
+    },
+    "perses.dev/PersesDatasource": {
+      "singular": "persesdatasource",
+      "plural": "persesdatasources",
+      "shortNames": [
+        "perds"
+      ]
+    },
+    "perses.dev/PersesGlobalDatasource": {
+      "singular": "persesglobaldatasource",
+      "plural": "persesglobaldatasources",
+      "shortNames": [
+        "pergds"
+      ]
+    }
+  },
   "files": [
     "catalog/perses.dev/perses_v1alpha1.fields.txt",
     "catalog/perses.dev/perses_v1alpha1.json",

--- a/build/history/prometheus-operator.json
+++ b/build/history/prometheus-operator.json
@@ -2,8 +2,8 @@
   "name": "prometheus-operator",
   "repo": "prometheus-operator/prometheus-operator",
   "version": "v0.92.1",
-  "builtAt": "2026-07-05T10:47:04.302Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:05:39.172Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "monitoring.coreos.com/Alertmanager",
     "monitoring.coreos.com/AlertmanagerConfig",
@@ -16,6 +16,78 @@
     "monitoring.coreos.com/ServiceMonitor",
     "monitoring.coreos.com/ThanosRuler"
   ],
+  "resources": {
+    "monitoring.coreos.com/Alertmanager": {
+      "singular": "alertmanager",
+      "plural": "alertmanagers",
+      "shortNames": [
+        "am"
+      ]
+    },
+    "monitoring.coreos.com/AlertmanagerConfig": {
+      "singular": "alertmanagerconfig",
+      "plural": "alertmanagerconfigs",
+      "shortNames": [
+        "amcfg"
+      ]
+    },
+    "monitoring.coreos.com/PodMonitor": {
+      "singular": "podmonitor",
+      "plural": "podmonitors",
+      "shortNames": [
+        "pmon"
+      ]
+    },
+    "monitoring.coreos.com/Probe": {
+      "singular": "probe",
+      "plural": "probes",
+      "shortNames": [
+        "prb"
+      ]
+    },
+    "monitoring.coreos.com/Prometheus": {
+      "singular": "prometheus",
+      "plural": "prometheuses",
+      "shortNames": [
+        "prom"
+      ]
+    },
+    "monitoring.coreos.com/PrometheusAgent": {
+      "singular": "prometheusagent",
+      "plural": "prometheusagents",
+      "shortNames": [
+        "promagent"
+      ]
+    },
+    "monitoring.coreos.com/PrometheusRule": {
+      "singular": "prometheusrule",
+      "plural": "prometheusrules",
+      "shortNames": [
+        "promrule"
+      ]
+    },
+    "monitoring.coreos.com/ScrapeConfig": {
+      "singular": "scrapeconfig",
+      "plural": "scrapeconfigs",
+      "shortNames": [
+        "scfg"
+      ]
+    },
+    "monitoring.coreos.com/ServiceMonitor": {
+      "singular": "servicemonitor",
+      "plural": "servicemonitors",
+      "shortNames": [
+        "smon"
+      ]
+    },
+    "monitoring.coreos.com/ThanosRuler": {
+      "singular": "thanosruler",
+      "plural": "thanosrulers",
+      "shortNames": [
+        "ruler"
+      ]
+    }
+  },
   "files": [
     "catalog/monitoring.coreos.com/alertmanager_v1.fields.txt",
     "catalog/monitoring.coreos.com/alertmanager_v1.json",

--- a/build/history/provider-upjet-aws.json
+++ b/build/history/provider-upjet-aws.json
@@ -2,8 +2,8 @@
   "name": "provider-upjet-aws",
   "repo": "crossplane-contrib/provider-upjet-aws",
   "version": "v2.6.0",
-  "builtAt": "2026-07-05T14:57:29.156Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:18.116Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "accessanalyzer.aws.m.upbound.io/Analyzer",
     "accessanalyzer.aws.m.upbound.io/ArchiveRule",
@@ -2049,6 +2049,8180 @@
     "xray.aws.upbound.io/Group",
     "xray.aws.upbound.io/SamplingRule"
   ],
+  "resources": {
+    "accessanalyzer.aws.m.upbound.io/Analyzer": {
+      "singular": "analyzer",
+      "plural": "analyzers"
+    },
+    "accessanalyzer.aws.m.upbound.io/ArchiveRule": {
+      "singular": "archiverule",
+      "plural": "archiverules"
+    },
+    "accessanalyzer.aws.upbound.io/Analyzer": {
+      "singular": "analyzer",
+      "plural": "analyzers"
+    },
+    "accessanalyzer.aws.upbound.io/ArchiveRule": {
+      "singular": "archiverule",
+      "plural": "archiverules"
+    },
+    "account.aws.m.upbound.io/AlternateContact": {
+      "singular": "alternatecontact",
+      "plural": "alternatecontacts"
+    },
+    "account.aws.m.upbound.io/Region": {
+      "singular": "region",
+      "plural": "regions"
+    },
+    "account.aws.upbound.io/AlternateContact": {
+      "singular": "alternatecontact",
+      "plural": "alternatecontacts"
+    },
+    "account.aws.upbound.io/Region": {
+      "singular": "region",
+      "plural": "regions"
+    },
+    "acm.aws.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "acm.aws.m.upbound.io/CertificateValidation": {
+      "singular": "certificatevalidation",
+      "plural": "certificatevalidations"
+    },
+    "acm.aws.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "acm.aws.upbound.io/CertificateValidation": {
+      "singular": "certificatevalidation",
+      "plural": "certificatevalidations"
+    },
+    "acmpca.aws.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "acmpca.aws.m.upbound.io/CertificateAuthority": {
+      "singular": "certificateauthority",
+      "plural": "certificateauthorities"
+    },
+    "acmpca.aws.m.upbound.io/CertificateAuthorityCertificate": {
+      "singular": "certificateauthoritycertificate",
+      "plural": "certificateauthoritycertificates"
+    },
+    "acmpca.aws.m.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "acmpca.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "acmpca.aws.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "acmpca.aws.upbound.io/CertificateAuthority": {
+      "singular": "certificateauthority",
+      "plural": "certificateauthorities"
+    },
+    "acmpca.aws.upbound.io/CertificateAuthorityCertificate": {
+      "singular": "certificateauthoritycertificate",
+      "plural": "certificateauthoritycertificates"
+    },
+    "acmpca.aws.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "acmpca.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "amp.aws.m.upbound.io/AlertManagerDefinition": {
+      "singular": "alertmanagerdefinition",
+      "plural": "alertmanagerdefinitions"
+    },
+    "amp.aws.m.upbound.io/RuleGroupNamespace": {
+      "singular": "rulegroupnamespace",
+      "plural": "rulegroupnamespaces"
+    },
+    "amp.aws.m.upbound.io/Scraper": {
+      "singular": "scraper",
+      "plural": "scrapers"
+    },
+    "amp.aws.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "amp.aws.upbound.io/AlertManagerDefinition": {
+      "singular": "alertmanagerdefinition",
+      "plural": "alertmanagerdefinitions"
+    },
+    "amp.aws.upbound.io/RuleGroupNamespace": {
+      "singular": "rulegroupnamespace",
+      "plural": "rulegroupnamespaces"
+    },
+    "amp.aws.upbound.io/Scraper": {
+      "singular": "scraper",
+      "plural": "scrapers"
+    },
+    "amp.aws.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "amplify.aws.m.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "amplify.aws.m.upbound.io/BackendEnvironment": {
+      "singular": "backendenvironment",
+      "plural": "backendenvironments"
+    },
+    "amplify.aws.m.upbound.io/Branch": {
+      "singular": "branch",
+      "plural": "branches"
+    },
+    "amplify.aws.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "amplify.aws.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "amplify.aws.upbound.io/BackendEnvironment": {
+      "singular": "backendenvironment",
+      "plural": "backendenvironments"
+    },
+    "amplify.aws.upbound.io/Branch": {
+      "singular": "branch",
+      "plural": "branches"
+    },
+    "amplify.aws.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "apigateway.aws.m.upbound.io/APIKey": {
+      "singular": "apikey",
+      "plural": "apikeys"
+    },
+    "apigateway.aws.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "apigateway.aws.m.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "apigateway.aws.m.upbound.io/BasePathMapping": {
+      "singular": "basepathmapping",
+      "plural": "basepathmappings"
+    },
+    "apigateway.aws.m.upbound.io/ClientCertificate": {
+      "singular": "clientcertificate",
+      "plural": "clientcertificates"
+    },
+    "apigateway.aws.m.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "apigateway.aws.m.upbound.io/DocumentationPart": {
+      "singular": "documentationpart",
+      "plural": "documentationparts"
+    },
+    "apigateway.aws.m.upbound.io/DocumentationVersion": {
+      "singular": "documentationversion",
+      "plural": "documentationversions"
+    },
+    "apigateway.aws.m.upbound.io/DomainName": {
+      "singular": "domainname",
+      "plural": "domainnames"
+    },
+    "apigateway.aws.m.upbound.io/GatewayResponse": {
+      "singular": "gatewayresponse",
+      "plural": "gatewayresponses"
+    },
+    "apigateway.aws.m.upbound.io/Integration": {
+      "singular": "integration",
+      "plural": "integrations"
+    },
+    "apigateway.aws.m.upbound.io/IntegrationResponse": {
+      "singular": "integrationresponse",
+      "plural": "integrationresponses"
+    },
+    "apigateway.aws.m.upbound.io/Method": {
+      "singular": "method",
+      "plural": "methods"
+    },
+    "apigateway.aws.m.upbound.io/MethodResponse": {
+      "singular": "methodresponse",
+      "plural": "methodresponses"
+    },
+    "apigateway.aws.m.upbound.io/MethodSettings": {
+      "singular": "methodsettings",
+      "plural": "methodsettings"
+    },
+    "apigateway.aws.m.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "apigateway.aws.m.upbound.io/RequestValidator": {
+      "singular": "requestvalidator",
+      "plural": "requestvalidators"
+    },
+    "apigateway.aws.m.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "apigateway.aws.m.upbound.io/RestAPI": {
+      "singular": "restapi",
+      "plural": "restapis"
+    },
+    "apigateway.aws.m.upbound.io/RestAPIPolicy": {
+      "singular": "restapipolicy",
+      "plural": "restapipolicies"
+    },
+    "apigateway.aws.m.upbound.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "apigateway.aws.m.upbound.io/UsagePlan": {
+      "singular": "usageplan",
+      "plural": "usageplans"
+    },
+    "apigateway.aws.m.upbound.io/UsagePlanKey": {
+      "singular": "usageplankey",
+      "plural": "usageplankeys"
+    },
+    "apigateway.aws.m.upbound.io/VPCLink": {
+      "singular": "vpclink",
+      "plural": "vpclinks"
+    },
+    "apigateway.aws.upbound.io/APIKey": {
+      "singular": "apikey",
+      "plural": "apikeys"
+    },
+    "apigateway.aws.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "apigateway.aws.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "apigateway.aws.upbound.io/BasePathMapping": {
+      "singular": "basepathmapping",
+      "plural": "basepathmappings"
+    },
+    "apigateway.aws.upbound.io/ClientCertificate": {
+      "singular": "clientcertificate",
+      "plural": "clientcertificates"
+    },
+    "apigateway.aws.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "apigateway.aws.upbound.io/DocumentationPart": {
+      "singular": "documentationpart",
+      "plural": "documentationparts"
+    },
+    "apigateway.aws.upbound.io/DocumentationVersion": {
+      "singular": "documentationversion",
+      "plural": "documentationversions"
+    },
+    "apigateway.aws.upbound.io/DomainName": {
+      "singular": "domainname",
+      "plural": "domainnames"
+    },
+    "apigateway.aws.upbound.io/GatewayResponse": {
+      "singular": "gatewayresponse",
+      "plural": "gatewayresponses"
+    },
+    "apigateway.aws.upbound.io/Integration": {
+      "singular": "integration",
+      "plural": "integrations"
+    },
+    "apigateway.aws.upbound.io/IntegrationResponse": {
+      "singular": "integrationresponse",
+      "plural": "integrationresponses"
+    },
+    "apigateway.aws.upbound.io/Method": {
+      "singular": "method",
+      "plural": "methods"
+    },
+    "apigateway.aws.upbound.io/MethodResponse": {
+      "singular": "methodresponse",
+      "plural": "methodresponses"
+    },
+    "apigateway.aws.upbound.io/MethodSettings": {
+      "singular": "methodsettings",
+      "plural": "methodsettings"
+    },
+    "apigateway.aws.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "apigateway.aws.upbound.io/RequestValidator": {
+      "singular": "requestvalidator",
+      "plural": "requestvalidators"
+    },
+    "apigateway.aws.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "apigateway.aws.upbound.io/RestAPI": {
+      "singular": "restapi",
+      "plural": "restapis"
+    },
+    "apigateway.aws.upbound.io/RestAPIPolicy": {
+      "singular": "restapipolicy",
+      "plural": "restapipolicies"
+    },
+    "apigateway.aws.upbound.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "apigateway.aws.upbound.io/UsagePlan": {
+      "singular": "usageplan",
+      "plural": "usageplans"
+    },
+    "apigateway.aws.upbound.io/UsagePlanKey": {
+      "singular": "usageplankey",
+      "plural": "usageplankeys"
+    },
+    "apigateway.aws.upbound.io/VPCLink": {
+      "singular": "vpclink",
+      "plural": "vpclinks"
+    },
+    "apigatewayv2.aws.m.upbound.io/API": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apigatewayv2.aws.m.upbound.io/APIMapping": {
+      "singular": "apimapping",
+      "plural": "apimappings"
+    },
+    "apigatewayv2.aws.m.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "apigatewayv2.aws.m.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "apigatewayv2.aws.m.upbound.io/DomainName": {
+      "singular": "domainname",
+      "plural": "domainnames"
+    },
+    "apigatewayv2.aws.m.upbound.io/Integration": {
+      "singular": "integration",
+      "plural": "integrations"
+    },
+    "apigatewayv2.aws.m.upbound.io/IntegrationResponse": {
+      "singular": "integrationresponse",
+      "plural": "integrationresponses"
+    },
+    "apigatewayv2.aws.m.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "apigatewayv2.aws.m.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "apigatewayv2.aws.m.upbound.io/RouteResponse": {
+      "singular": "routeresponse",
+      "plural": "routeresponses"
+    },
+    "apigatewayv2.aws.m.upbound.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "apigatewayv2.aws.m.upbound.io/VPCLink": {
+      "singular": "vpclink",
+      "plural": "vpclinks"
+    },
+    "apigatewayv2.aws.upbound.io/API": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apigatewayv2.aws.upbound.io/APIMapping": {
+      "singular": "apimapping",
+      "plural": "apimappings"
+    },
+    "apigatewayv2.aws.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "apigatewayv2.aws.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "apigatewayv2.aws.upbound.io/DomainName": {
+      "singular": "domainname",
+      "plural": "domainnames"
+    },
+    "apigatewayv2.aws.upbound.io/Integration": {
+      "singular": "integration",
+      "plural": "integrations"
+    },
+    "apigatewayv2.aws.upbound.io/IntegrationResponse": {
+      "singular": "integrationresponse",
+      "plural": "integrationresponses"
+    },
+    "apigatewayv2.aws.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "apigatewayv2.aws.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "apigatewayv2.aws.upbound.io/RouteResponse": {
+      "singular": "routeresponse",
+      "plural": "routeresponses"
+    },
+    "apigatewayv2.aws.upbound.io/Stage": {
+      "singular": "stage",
+      "plural": "stages"
+    },
+    "apigatewayv2.aws.upbound.io/VPCLink": {
+      "singular": "vpclink",
+      "plural": "vpclinks"
+    },
+    "appautoscaling.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "appautoscaling.aws.m.upbound.io/ScheduledAction": {
+      "singular": "scheduledaction",
+      "plural": "scheduledactions"
+    },
+    "appautoscaling.aws.m.upbound.io/Target": {
+      "singular": "target",
+      "plural": "targets"
+    },
+    "appautoscaling.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "appautoscaling.aws.upbound.io/ScheduledAction": {
+      "singular": "scheduledaction",
+      "plural": "scheduledactions"
+    },
+    "appautoscaling.aws.upbound.io/Target": {
+      "singular": "target",
+      "plural": "targets"
+    },
+    "appconfig.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "appconfig.aws.m.upbound.io/ConfigurationProfile": {
+      "singular": "configurationprofile",
+      "plural": "configurationprofiles"
+    },
+    "appconfig.aws.m.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "appconfig.aws.m.upbound.io/DeploymentStrategy": {
+      "singular": "deploymentstrategy",
+      "plural": "deploymentstrategies"
+    },
+    "appconfig.aws.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "appconfig.aws.m.upbound.io/Extension": {
+      "singular": "extension",
+      "plural": "extensions"
+    },
+    "appconfig.aws.m.upbound.io/ExtensionAssociation": {
+      "singular": "extensionassociation",
+      "plural": "extensionassociations"
+    },
+    "appconfig.aws.m.upbound.io/HostedConfigurationVersion": {
+      "singular": "hostedconfigurationversion",
+      "plural": "hostedconfigurationversions"
+    },
+    "appconfig.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "appconfig.aws.upbound.io/ConfigurationProfile": {
+      "singular": "configurationprofile",
+      "plural": "configurationprofiles"
+    },
+    "appconfig.aws.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "appconfig.aws.upbound.io/DeploymentStrategy": {
+      "singular": "deploymentstrategy",
+      "plural": "deploymentstrategies"
+    },
+    "appconfig.aws.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "appconfig.aws.upbound.io/Extension": {
+      "singular": "extension",
+      "plural": "extensions"
+    },
+    "appconfig.aws.upbound.io/ExtensionAssociation": {
+      "singular": "extensionassociation",
+      "plural": "extensionassociations"
+    },
+    "appconfig.aws.upbound.io/HostedConfigurationVersion": {
+      "singular": "hostedconfigurationversion",
+      "plural": "hostedconfigurationversions"
+    },
+    "appflow.aws.m.upbound.io/Flow": {
+      "singular": "flow",
+      "plural": "flows"
+    },
+    "appflow.aws.upbound.io/Flow": {
+      "singular": "flow",
+      "plural": "flows"
+    },
+    "appintegrations.aws.m.upbound.io/EventIntegration": {
+      "singular": "eventintegration",
+      "plural": "eventintegrations"
+    },
+    "appintegrations.aws.upbound.io/EventIntegration": {
+      "singular": "eventintegration",
+      "plural": "eventintegrations"
+    },
+    "applicationinsights.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "applicationinsights.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "appmesh.aws.m.upbound.io/GatewayRoute": {
+      "singular": "gatewayroute",
+      "plural": "gatewayroutes"
+    },
+    "appmesh.aws.m.upbound.io/Mesh": {
+      "singular": "mesh",
+      "plural": "meshes"
+    },
+    "appmesh.aws.m.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "appmesh.aws.m.upbound.io/VirtualGateway": {
+      "singular": "virtualgateway",
+      "plural": "virtualgateways"
+    },
+    "appmesh.aws.m.upbound.io/VirtualNode": {
+      "singular": "virtualnode",
+      "plural": "virtualnodes"
+    },
+    "appmesh.aws.m.upbound.io/VirtualRouter": {
+      "singular": "virtualrouter",
+      "plural": "virtualrouters"
+    },
+    "appmesh.aws.m.upbound.io/VirtualService": {
+      "singular": "virtualservice",
+      "plural": "virtualservices"
+    },
+    "appmesh.aws.upbound.io/GatewayRoute": {
+      "singular": "gatewayroute",
+      "plural": "gatewayroutes"
+    },
+    "appmesh.aws.upbound.io/Mesh": {
+      "singular": "mesh",
+      "plural": "meshes"
+    },
+    "appmesh.aws.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "appmesh.aws.upbound.io/VirtualGateway": {
+      "singular": "virtualgateway",
+      "plural": "virtualgateways"
+    },
+    "appmesh.aws.upbound.io/VirtualNode": {
+      "singular": "virtualnode",
+      "plural": "virtualnodes"
+    },
+    "appmesh.aws.upbound.io/VirtualRouter": {
+      "singular": "virtualrouter",
+      "plural": "virtualrouters"
+    },
+    "appmesh.aws.upbound.io/VirtualService": {
+      "singular": "virtualservice",
+      "plural": "virtualservices"
+    },
+    "apprunner.aws.m.upbound.io/AutoScalingConfigurationVersion": {
+      "singular": "autoscalingconfigurationversion",
+      "plural": "autoscalingconfigurationversions"
+    },
+    "apprunner.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "apprunner.aws.m.upbound.io/ObservabilityConfiguration": {
+      "singular": "observabilityconfiguration",
+      "plural": "observabilityconfigurations"
+    },
+    "apprunner.aws.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "apprunner.aws.m.upbound.io/VPCConnector": {
+      "singular": "vpcconnector",
+      "plural": "vpcconnectors"
+    },
+    "apprunner.aws.upbound.io/AutoScalingConfigurationVersion": {
+      "singular": "autoscalingconfigurationversion",
+      "plural": "autoscalingconfigurationversions"
+    },
+    "apprunner.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "apprunner.aws.upbound.io/ObservabilityConfiguration": {
+      "singular": "observabilityconfiguration",
+      "plural": "observabilityconfigurations"
+    },
+    "apprunner.aws.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "apprunner.aws.upbound.io/VPCConnector": {
+      "singular": "vpcconnector",
+      "plural": "vpcconnectors"
+    },
+    "appstream.aws.m.upbound.io/DirectoryConfig": {
+      "singular": "directoryconfig",
+      "plural": "directoryconfigs"
+    },
+    "appstream.aws.m.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleet"
+    },
+    "appstream.aws.m.upbound.io/FleetStackAssociation": {
+      "singular": "fleetstackassociation",
+      "plural": "fleetstackassociations"
+    },
+    "appstream.aws.m.upbound.io/ImageBuilder": {
+      "singular": "imagebuilder",
+      "plural": "imagebuilders"
+    },
+    "appstream.aws.m.upbound.io/Stack": {
+      "singular": "stack",
+      "plural": "stacks"
+    },
+    "appstream.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "appstream.aws.m.upbound.io/UserStackAssociation": {
+      "singular": "userstackassociation",
+      "plural": "userstackassociations"
+    },
+    "appstream.aws.upbound.io/DirectoryConfig": {
+      "singular": "directoryconfig",
+      "plural": "directoryconfigs"
+    },
+    "appstream.aws.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleet"
+    },
+    "appstream.aws.upbound.io/FleetStackAssociation": {
+      "singular": "fleetstackassociation",
+      "plural": "fleetstackassociations"
+    },
+    "appstream.aws.upbound.io/ImageBuilder": {
+      "singular": "imagebuilder",
+      "plural": "imagebuilders"
+    },
+    "appstream.aws.upbound.io/Stack": {
+      "singular": "stack",
+      "plural": "stacks"
+    },
+    "appstream.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "appstream.aws.upbound.io/UserStackAssociation": {
+      "singular": "userstackassociation",
+      "plural": "userstackassociations"
+    },
+    "appsync.aws.m.upbound.io/APICache": {
+      "singular": "apicache",
+      "plural": "apicaches"
+    },
+    "appsync.aws.m.upbound.io/APIKey": {
+      "singular": "apikey",
+      "plural": "apikeys"
+    },
+    "appsync.aws.m.upbound.io/Datasource": {
+      "singular": "datasource",
+      "plural": "datasources"
+    },
+    "appsync.aws.m.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "appsync.aws.m.upbound.io/GraphQLAPI": {
+      "singular": "graphqlapi",
+      "plural": "graphqlapis"
+    },
+    "appsync.aws.m.upbound.io/Resolver": {
+      "singular": "resolver",
+      "plural": "resolvers"
+    },
+    "appsync.aws.upbound.io/APICache": {
+      "singular": "apicache",
+      "plural": "apicaches"
+    },
+    "appsync.aws.upbound.io/APIKey": {
+      "singular": "apikey",
+      "plural": "apikeys"
+    },
+    "appsync.aws.upbound.io/Datasource": {
+      "singular": "datasource",
+      "plural": "datasources"
+    },
+    "appsync.aws.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "appsync.aws.upbound.io/GraphQLAPI": {
+      "singular": "graphqlapi",
+      "plural": "graphqlapis"
+    },
+    "appsync.aws.upbound.io/Resolver": {
+      "singular": "resolver",
+      "plural": "resolvers"
+    },
+    "athena.aws.m.upbound.io/DataCatalog": {
+      "singular": "datacatalog",
+      "plural": "datacatalogs"
+    },
+    "athena.aws.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "athena.aws.m.upbound.io/NamedQuery": {
+      "singular": "namedquery",
+      "plural": "namedqueries"
+    },
+    "athena.aws.m.upbound.io/Workgroup": {
+      "singular": "workgroup",
+      "plural": "workgroups"
+    },
+    "athena.aws.upbound.io/DataCatalog": {
+      "singular": "datacatalog",
+      "plural": "datacatalogs"
+    },
+    "athena.aws.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "athena.aws.upbound.io/NamedQuery": {
+      "singular": "namedquery",
+      "plural": "namedqueries"
+    },
+    "athena.aws.upbound.io/Workgroup": {
+      "singular": "workgroup",
+      "plural": "workgroups"
+    },
+    "autoscaling.aws.m.upbound.io/Attachment": {
+      "singular": "attachment",
+      "plural": "attachments"
+    },
+    "autoscaling.aws.m.upbound.io/AutoscalingGroup": {
+      "singular": "autoscalinggroup",
+      "plural": "autoscalinggroups"
+    },
+    "autoscaling.aws.m.upbound.io/GroupTag": {
+      "singular": "grouptag",
+      "plural": "grouptags"
+    },
+    "autoscaling.aws.m.upbound.io/LaunchConfiguration": {
+      "singular": "launchconfiguration",
+      "plural": "launchconfigurations"
+    },
+    "autoscaling.aws.m.upbound.io/LifecycleHook": {
+      "singular": "lifecyclehook",
+      "plural": "lifecyclehooks"
+    },
+    "autoscaling.aws.m.upbound.io/Notification": {
+      "singular": "notification",
+      "plural": "notifications"
+    },
+    "autoscaling.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "autoscaling.aws.m.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "autoscaling.aws.upbound.io/Attachment": {
+      "singular": "attachment",
+      "plural": "attachments"
+    },
+    "autoscaling.aws.upbound.io/AutoscalingGroup": {
+      "singular": "autoscalinggroup",
+      "plural": "autoscalinggroups"
+    },
+    "autoscaling.aws.upbound.io/GroupTag": {
+      "singular": "grouptag",
+      "plural": "grouptags"
+    },
+    "autoscaling.aws.upbound.io/LaunchConfiguration": {
+      "singular": "launchconfiguration",
+      "plural": "launchconfigurations"
+    },
+    "autoscaling.aws.upbound.io/LifecycleHook": {
+      "singular": "lifecyclehook",
+      "plural": "lifecyclehooks"
+    },
+    "autoscaling.aws.upbound.io/Notification": {
+      "singular": "notification",
+      "plural": "notifications"
+    },
+    "autoscaling.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "autoscaling.aws.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "autoscalingplans.aws.m.upbound.io/ScalingPlan": {
+      "singular": "scalingplan",
+      "plural": "scalingplans"
+    },
+    "autoscalingplans.aws.upbound.io/ScalingPlan": {
+      "singular": "scalingplan",
+      "plural": "scalingplans"
+    },
+    "aws.m.upbound.io/ClusterProviderConfig": {
+      "singular": "clusterproviderconfig",
+      "plural": "clusterproviderconfigs"
+    },
+    "aws.m.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "aws.m.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "aws.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "aws.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "backup.aws.m.upbound.io/Framework": {
+      "singular": "framework",
+      "plural": "frameworks"
+    },
+    "backup.aws.m.upbound.io/GlobalSettings": {
+      "singular": "globalsettings",
+      "plural": "globalsettings"
+    },
+    "backup.aws.m.upbound.io/Plan": {
+      "singular": "plan",
+      "plural": "plans"
+    },
+    "backup.aws.m.upbound.io/RegionSettings": {
+      "singular": "regionsettings",
+      "plural": "regionsettings"
+    },
+    "backup.aws.m.upbound.io/ReportPlan": {
+      "singular": "reportplan",
+      "plural": "reportplans"
+    },
+    "backup.aws.m.upbound.io/Selection": {
+      "singular": "selection",
+      "plural": "selections"
+    },
+    "backup.aws.m.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "backup.aws.m.upbound.io/VaultLockConfiguration": {
+      "singular": "vaultlockconfiguration",
+      "plural": "vaultlockconfigurations"
+    },
+    "backup.aws.m.upbound.io/VaultNotifications": {
+      "singular": "vaultnotifications",
+      "plural": "vaultnotifications"
+    },
+    "backup.aws.m.upbound.io/VaultPolicy": {
+      "singular": "vaultpolicy",
+      "plural": "vaultpolicies"
+    },
+    "backup.aws.upbound.io/Framework": {
+      "singular": "framework",
+      "plural": "frameworks"
+    },
+    "backup.aws.upbound.io/GlobalSettings": {
+      "singular": "globalsettings",
+      "plural": "globalsettings"
+    },
+    "backup.aws.upbound.io/Plan": {
+      "singular": "plan",
+      "plural": "plans"
+    },
+    "backup.aws.upbound.io/RegionSettings": {
+      "singular": "regionsettings",
+      "plural": "regionsettings"
+    },
+    "backup.aws.upbound.io/ReportPlan": {
+      "singular": "reportplan",
+      "plural": "reportplans"
+    },
+    "backup.aws.upbound.io/Selection": {
+      "singular": "selection",
+      "plural": "selections"
+    },
+    "backup.aws.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "backup.aws.upbound.io/VaultLockConfiguration": {
+      "singular": "vaultlockconfiguration",
+      "plural": "vaultlockconfigurations"
+    },
+    "backup.aws.upbound.io/VaultNotifications": {
+      "singular": "vaultnotifications",
+      "plural": "vaultnotifications"
+    },
+    "backup.aws.upbound.io/VaultPolicy": {
+      "singular": "vaultpolicy",
+      "plural": "vaultpolicies"
+    },
+    "batch.aws.m.upbound.io/ComputeEnvironment": {
+      "singular": "computeenvironment",
+      "plural": "computeenvironments"
+    },
+    "batch.aws.m.upbound.io/JobDefinition": {
+      "singular": "jobdefinition",
+      "plural": "jobdefinitions"
+    },
+    "batch.aws.m.upbound.io/JobQueue": {
+      "singular": "jobqueue",
+      "plural": "jobqueues"
+    },
+    "batch.aws.m.upbound.io/SchedulingPolicy": {
+      "singular": "schedulingpolicy",
+      "plural": "schedulingpolicies"
+    },
+    "batch.aws.upbound.io/ComputeEnvironment": {
+      "singular": "computeenvironment",
+      "plural": "computeenvironments"
+    },
+    "batch.aws.upbound.io/JobDefinition": {
+      "singular": "jobdefinition",
+      "plural": "jobdefinitions"
+    },
+    "batch.aws.upbound.io/JobQueue": {
+      "singular": "jobqueue",
+      "plural": "jobqueues"
+    },
+    "batch.aws.upbound.io/SchedulingPolicy": {
+      "singular": "schedulingpolicy",
+      "plural": "schedulingpolicies"
+    },
+    "bedrock.aws.m.upbound.io/InferenceProfile": {
+      "singular": "inferenceprofile",
+      "plural": "inferenceprofiles"
+    },
+    "bedrock.aws.upbound.io/InferenceProfile": {
+      "singular": "inferenceprofile",
+      "plural": "inferenceprofiles"
+    },
+    "bedrockagent.aws.m.upbound.io/Agent": {
+      "singular": "agent",
+      "plural": "agents"
+    },
+    "bedrockagent.aws.upbound.io/Agent": {
+      "singular": "agent",
+      "plural": "agents"
+    },
+    "bedrockagentcore.aws.m.upbound.io/APIKeyCredentialProvider": {
+      "singular": "apikeycredentialprovider",
+      "plural": "apikeycredentialproviders"
+    },
+    "bedrockagentcore.aws.m.upbound.io/AgentRuntime": {
+      "singular": "agentruntime",
+      "plural": "agentruntimes"
+    },
+    "bedrockagentcore.aws.m.upbound.io/AgentRuntimeEndpoint": {
+      "singular": "agentruntimeendpoint",
+      "plural": "agentruntimeendpoints"
+    },
+    "bedrockagentcore.aws.m.upbound.io/Browser": {
+      "singular": "browser",
+      "plural": "browsers"
+    },
+    "bedrockagentcore.aws.m.upbound.io/CodeInterpreter": {
+      "singular": "codeinterpreter",
+      "plural": "codeinterpreters"
+    },
+    "bedrockagentcore.aws.m.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "bedrockagentcore.aws.m.upbound.io/GatewayTarget": {
+      "singular": "gatewaytarget",
+      "plural": "gatewaytargets"
+    },
+    "bedrockagentcore.aws.m.upbound.io/Memory": {
+      "singular": "memory",
+      "plural": "memories"
+    },
+    "bedrockagentcore.aws.m.upbound.io/MemoryStrategy": {
+      "singular": "memorystrategy",
+      "plural": "memorystrategies"
+    },
+    "bedrockagentcore.aws.m.upbound.io/Oauth2CredentialProvider": {
+      "singular": "oauth2credentialprovider",
+      "plural": "oauth2credentialproviders"
+    },
+    "bedrockagentcore.aws.m.upbound.io/TokenVaultCmk": {
+      "singular": "tokenvaultcmk",
+      "plural": "tokenvaultcmks"
+    },
+    "bedrockagentcore.aws.m.upbound.io/WorkloadIdentity": {
+      "singular": "workloadidentity",
+      "plural": "workloadidentities"
+    },
+    "bedrockagentcore.aws.upbound.io/APIKeyCredentialProvider": {
+      "singular": "apikeycredentialprovider",
+      "plural": "apikeycredentialproviders"
+    },
+    "bedrockagentcore.aws.upbound.io/AgentRuntime": {
+      "singular": "agentruntime",
+      "plural": "agentruntimes"
+    },
+    "bedrockagentcore.aws.upbound.io/AgentRuntimeEndpoint": {
+      "singular": "agentruntimeendpoint",
+      "plural": "agentruntimeendpoints"
+    },
+    "bedrockagentcore.aws.upbound.io/Browser": {
+      "singular": "browser",
+      "plural": "browsers"
+    },
+    "bedrockagentcore.aws.upbound.io/CodeInterpreter": {
+      "singular": "codeinterpreter",
+      "plural": "codeinterpreters"
+    },
+    "bedrockagentcore.aws.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "bedrockagentcore.aws.upbound.io/GatewayTarget": {
+      "singular": "gatewaytarget",
+      "plural": "gatewaytargets"
+    },
+    "bedrockagentcore.aws.upbound.io/Memory": {
+      "singular": "memory",
+      "plural": "memories"
+    },
+    "bedrockagentcore.aws.upbound.io/MemoryStrategy": {
+      "singular": "memorystrategy",
+      "plural": "memorystrategies"
+    },
+    "bedrockagentcore.aws.upbound.io/Oauth2CredentialProvider": {
+      "singular": "oauth2credentialprovider",
+      "plural": "oauth2credentialproviders"
+    },
+    "bedrockagentcore.aws.upbound.io/TokenVaultCmk": {
+      "singular": "tokenvaultcmk",
+      "plural": "tokenvaultcmks"
+    },
+    "bedrockagentcore.aws.upbound.io/WorkloadIdentity": {
+      "singular": "workloadidentity",
+      "plural": "workloadidentities"
+    },
+    "budgets.aws.m.upbound.io/Budget": {
+      "singular": "budget",
+      "plural": "budgets"
+    },
+    "budgets.aws.m.upbound.io/BudgetAction": {
+      "singular": "budgetaction",
+      "plural": "budgetactions"
+    },
+    "budgets.aws.upbound.io/Budget": {
+      "singular": "budget",
+      "plural": "budgets"
+    },
+    "budgets.aws.upbound.io/BudgetAction": {
+      "singular": "budgetaction",
+      "plural": "budgetactions"
+    },
+    "ce.aws.m.upbound.io/AnomalyMonitor": {
+      "singular": "anomalymonitor",
+      "plural": "anomalymonitors"
+    },
+    "ce.aws.upbound.io/AnomalyMonitor": {
+      "singular": "anomalymonitor",
+      "plural": "anomalymonitors"
+    },
+    "chime.aws.m.upbound.io/VoiceConnector": {
+      "singular": "voiceconnector",
+      "plural": "voiceconnectors"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorGroup": {
+      "singular": "voiceconnectorgroup",
+      "plural": "voiceconnectorgroups"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorLogging": {
+      "singular": "voiceconnectorlogging",
+      "plural": "voiceconnectorloggings"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorOrigination": {
+      "singular": "voiceconnectororigination",
+      "plural": "voiceconnectororiginations"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorStreaming": {
+      "singular": "voiceconnectorstreaming",
+      "plural": "voiceconnectorstreamings"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorTermination": {
+      "singular": "voiceconnectortermination",
+      "plural": "voiceconnectorterminations"
+    },
+    "chime.aws.m.upbound.io/VoiceConnectorTerminationCredentials": {
+      "singular": "voiceconnectorterminationcredentials",
+      "plural": "voiceconnectorterminationcredentials"
+    },
+    "chime.aws.upbound.io/VoiceConnector": {
+      "singular": "voiceconnector",
+      "plural": "voiceconnectors"
+    },
+    "chime.aws.upbound.io/VoiceConnectorGroup": {
+      "singular": "voiceconnectorgroup",
+      "plural": "voiceconnectorgroups"
+    },
+    "chime.aws.upbound.io/VoiceConnectorLogging": {
+      "singular": "voiceconnectorlogging",
+      "plural": "voiceconnectorloggings"
+    },
+    "chime.aws.upbound.io/VoiceConnectorOrigination": {
+      "singular": "voiceconnectororigination",
+      "plural": "voiceconnectororiginations"
+    },
+    "chime.aws.upbound.io/VoiceConnectorStreaming": {
+      "singular": "voiceconnectorstreaming",
+      "plural": "voiceconnectorstreamings"
+    },
+    "chime.aws.upbound.io/VoiceConnectorTermination": {
+      "singular": "voiceconnectortermination",
+      "plural": "voiceconnectorterminations"
+    },
+    "chime.aws.upbound.io/VoiceConnectorTerminationCredentials": {
+      "singular": "voiceconnectorterminationcredentials",
+      "plural": "voiceconnectorterminationcredentials"
+    },
+    "cloud9.aws.m.upbound.io/EnvironmentEC2": {
+      "singular": "environmentec2",
+      "plural": "environmentec2s"
+    },
+    "cloud9.aws.m.upbound.io/EnvironmentMembership": {
+      "singular": "environmentmembership",
+      "plural": "environmentmemberships"
+    },
+    "cloud9.aws.upbound.io/EnvironmentEC2": {
+      "singular": "environmentec2",
+      "plural": "environmentec2s"
+    },
+    "cloud9.aws.upbound.io/EnvironmentMembership": {
+      "singular": "environmentmembership",
+      "plural": "environmentmemberships"
+    },
+    "cloudcontrol.aws.m.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "cloudcontrol.aws.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "cloudformation.aws.m.upbound.io/Stack": {
+      "singular": "stack",
+      "plural": "stacks"
+    },
+    "cloudformation.aws.m.upbound.io/StackSet": {
+      "singular": "stackset",
+      "plural": "stacksets"
+    },
+    "cloudformation.aws.m.upbound.io/StackSetInstance": {
+      "singular": "stacksetinstance",
+      "plural": "stacksetinstances"
+    },
+    "cloudformation.aws.upbound.io/Stack": {
+      "singular": "stack",
+      "plural": "stacks"
+    },
+    "cloudformation.aws.upbound.io/StackSet": {
+      "singular": "stackset",
+      "plural": "stacksets"
+    },
+    "cloudformation.aws.upbound.io/StackSetInstance": {
+      "singular": "stacksetinstance",
+      "plural": "stacksetinstances"
+    },
+    "cloudfront.aws.m.upbound.io/CachePolicy": {
+      "singular": "cachepolicy",
+      "plural": "cachepolicies"
+    },
+    "cloudfront.aws.m.upbound.io/Distribution": {
+      "singular": "distribution",
+      "plural": "distributions"
+    },
+    "cloudfront.aws.m.upbound.io/FieldLevelEncryptionConfig": {
+      "singular": "fieldlevelencryptionconfig",
+      "plural": "fieldlevelencryptionconfigs"
+    },
+    "cloudfront.aws.m.upbound.io/FieldLevelEncryptionProfile": {
+      "singular": "fieldlevelencryptionprofile",
+      "plural": "fieldlevelencryptionprofiles"
+    },
+    "cloudfront.aws.m.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudfront.aws.m.upbound.io/KeyGroup": {
+      "singular": "keygroup",
+      "plural": "keygroups"
+    },
+    "cloudfront.aws.m.upbound.io/MonitoringSubscription": {
+      "singular": "monitoringsubscription",
+      "plural": "monitoringsubscriptions"
+    },
+    "cloudfront.aws.m.upbound.io/OriginAccessControl": {
+      "singular": "originaccesscontrol",
+      "plural": "originaccesscontrols"
+    },
+    "cloudfront.aws.m.upbound.io/OriginAccessIdentity": {
+      "singular": "originaccessidentity",
+      "plural": "originaccessidentities"
+    },
+    "cloudfront.aws.m.upbound.io/OriginRequestPolicy": {
+      "singular": "originrequestpolicy",
+      "plural": "originrequestpolicies"
+    },
+    "cloudfront.aws.m.upbound.io/PublicKey": {
+      "singular": "publickey",
+      "plural": "publickeys"
+    },
+    "cloudfront.aws.m.upbound.io/RealtimeLogConfig": {
+      "singular": "realtimelogconfig",
+      "plural": "realtimelogconfigs"
+    },
+    "cloudfront.aws.m.upbound.io/ResponseHeadersPolicy": {
+      "singular": "responseheaderspolicy",
+      "plural": "responseheaderspolicies"
+    },
+    "cloudfront.aws.m.upbound.io/VPCOrigin": {
+      "singular": "vpcorigin",
+      "plural": "vpcorigins"
+    },
+    "cloudfront.aws.upbound.io/CachePolicy": {
+      "singular": "cachepolicy",
+      "plural": "cachepolicies"
+    },
+    "cloudfront.aws.upbound.io/Distribution": {
+      "singular": "distribution",
+      "plural": "distributions"
+    },
+    "cloudfront.aws.upbound.io/FieldLevelEncryptionConfig": {
+      "singular": "fieldlevelencryptionconfig",
+      "plural": "fieldlevelencryptionconfigs"
+    },
+    "cloudfront.aws.upbound.io/FieldLevelEncryptionProfile": {
+      "singular": "fieldlevelencryptionprofile",
+      "plural": "fieldlevelencryptionprofiles"
+    },
+    "cloudfront.aws.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudfront.aws.upbound.io/KeyGroup": {
+      "singular": "keygroup",
+      "plural": "keygroups"
+    },
+    "cloudfront.aws.upbound.io/MonitoringSubscription": {
+      "singular": "monitoringsubscription",
+      "plural": "monitoringsubscriptions"
+    },
+    "cloudfront.aws.upbound.io/OriginAccessControl": {
+      "singular": "originaccesscontrol",
+      "plural": "originaccesscontrols"
+    },
+    "cloudfront.aws.upbound.io/OriginAccessIdentity": {
+      "singular": "originaccessidentity",
+      "plural": "originaccessidentities"
+    },
+    "cloudfront.aws.upbound.io/OriginRequestPolicy": {
+      "singular": "originrequestpolicy",
+      "plural": "originrequestpolicies"
+    },
+    "cloudfront.aws.upbound.io/PublicKey": {
+      "singular": "publickey",
+      "plural": "publickeys"
+    },
+    "cloudfront.aws.upbound.io/RealtimeLogConfig": {
+      "singular": "realtimelogconfig",
+      "plural": "realtimelogconfigs"
+    },
+    "cloudfront.aws.upbound.io/ResponseHeadersPolicy": {
+      "singular": "responseheaderspolicy",
+      "plural": "responseheaderspolicies"
+    },
+    "cloudfront.aws.upbound.io/VPCOrigin": {
+      "singular": "vpcorigin",
+      "plural": "vpcorigins"
+    },
+    "cloudsearch.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "cloudsearch.aws.m.upbound.io/DomainServiceAccessPolicy": {
+      "singular": "domainserviceaccesspolicy",
+      "plural": "domainserviceaccesspolicies"
+    },
+    "cloudsearch.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "cloudsearch.aws.upbound.io/DomainServiceAccessPolicy": {
+      "singular": "domainserviceaccesspolicy",
+      "plural": "domainserviceaccesspolicies"
+    },
+    "cloudtrail.aws.m.upbound.io/EventDataStore": {
+      "singular": "eventdatastore",
+      "plural": "eventdatastores"
+    },
+    "cloudtrail.aws.m.upbound.io/Trail": {
+      "singular": "trail",
+      "plural": "trails"
+    },
+    "cloudtrail.aws.upbound.io/EventDataStore": {
+      "singular": "eventdatastore",
+      "plural": "eventdatastores"
+    },
+    "cloudtrail.aws.upbound.io/Trail": {
+      "singular": "trail",
+      "plural": "trails"
+    },
+    "cloudwatch.aws.m.upbound.io/CompositeAlarm": {
+      "singular": "compositealarm",
+      "plural": "compositealarms"
+    },
+    "cloudwatch.aws.m.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "cloudwatch.aws.m.upbound.io/MetricAlarm": {
+      "singular": "metricalarm",
+      "plural": "metricalarms"
+    },
+    "cloudwatch.aws.m.upbound.io/MetricStream": {
+      "singular": "metricstream",
+      "plural": "metricstreams"
+    },
+    "cloudwatch.aws.upbound.io/CompositeAlarm": {
+      "singular": "compositealarm",
+      "plural": "compositealarms"
+    },
+    "cloudwatch.aws.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "cloudwatch.aws.upbound.io/MetricAlarm": {
+      "singular": "metricalarm",
+      "plural": "metricalarms"
+    },
+    "cloudwatch.aws.upbound.io/MetricStream": {
+      "singular": "metricstream",
+      "plural": "metricstreams"
+    },
+    "cloudwatchevents.aws.m.upbound.io/APIDestination": {
+      "singular": "apidestination",
+      "plural": "apidestinations"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Archive": {
+      "singular": "archive",
+      "plural": "archives"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Bus": {
+      "singular": "bus",
+      "plural": "buses"
+    },
+    "cloudwatchevents.aws.m.upbound.io/BusPolicy": {
+      "singular": "buspolicy",
+      "plural": "buspolicies"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "cloudwatchevents.aws.m.upbound.io/Target": {
+      "singular": "target",
+      "plural": "targets"
+    },
+    "cloudwatchevents.aws.upbound.io/APIDestination": {
+      "singular": "apidestination",
+      "plural": "apidestinations"
+    },
+    "cloudwatchevents.aws.upbound.io/Archive": {
+      "singular": "archive",
+      "plural": "archives"
+    },
+    "cloudwatchevents.aws.upbound.io/Bus": {
+      "singular": "bus",
+      "plural": "buses"
+    },
+    "cloudwatchevents.aws.upbound.io/BusPolicy": {
+      "singular": "buspolicy",
+      "plural": "buspolicies"
+    },
+    "cloudwatchevents.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "cloudwatchevents.aws.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "cloudwatchevents.aws.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "cloudwatchevents.aws.upbound.io/Target": {
+      "singular": "target",
+      "plural": "targets"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/Definition": {
+      "singular": "definition",
+      "plural": "definitions"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/Destination": {
+      "singular": "destination",
+      "plural": "destinations"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/DestinationPolicy": {
+      "singular": "destinationpolicy",
+      "plural": "destinationpolicies"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/MetricFilter": {
+      "singular": "metricfilter",
+      "plural": "metricfilters"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "cloudwatchlogs.aws.m.upbound.io/SubscriptionFilter": {
+      "singular": "subscriptionfilter",
+      "plural": "subscriptionfilters"
+    },
+    "cloudwatchlogs.aws.upbound.io/Definition": {
+      "singular": "definition",
+      "plural": "definitions"
+    },
+    "cloudwatchlogs.aws.upbound.io/Destination": {
+      "singular": "destination",
+      "plural": "destinations"
+    },
+    "cloudwatchlogs.aws.upbound.io/DestinationPolicy": {
+      "singular": "destinationpolicy",
+      "plural": "destinationpolicies"
+    },
+    "cloudwatchlogs.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "cloudwatchlogs.aws.upbound.io/MetricFilter": {
+      "singular": "metricfilter",
+      "plural": "metricfilters"
+    },
+    "cloudwatchlogs.aws.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "cloudwatchlogs.aws.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "cloudwatchlogs.aws.upbound.io/SubscriptionFilter": {
+      "singular": "subscriptionfilter",
+      "plural": "subscriptionfilters"
+    },
+    "codeartifact.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "codeartifact.aws.m.upbound.io/DomainPermissionsPolicy": {
+      "singular": "domainpermissionspolicy",
+      "plural": "domainpermissionspolicies"
+    },
+    "codeartifact.aws.m.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "codeartifact.aws.m.upbound.io/RepositoryPermissionsPolicy": {
+      "singular": "repositorypermissionspolicy",
+      "plural": "repositorypermissionspolicies"
+    },
+    "codeartifact.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "codeartifact.aws.upbound.io/DomainPermissionsPolicy": {
+      "singular": "domainpermissionspolicy",
+      "plural": "domainpermissionspolicies"
+    },
+    "codeartifact.aws.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "codeartifact.aws.upbound.io/RepositoryPermissionsPolicy": {
+      "singular": "repositorypermissionspolicy",
+      "plural": "repositorypermissionspolicies"
+    },
+    "codebuild.aws.m.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "codebuild.aws.m.upbound.io/ReportGroup": {
+      "singular": "reportgroup",
+      "plural": "reportgroups"
+    },
+    "codebuild.aws.m.upbound.io/SourceCredential": {
+      "singular": "sourcecredential",
+      "plural": "sourcecredentials"
+    },
+    "codebuild.aws.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "codebuild.aws.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "codebuild.aws.upbound.io/ReportGroup": {
+      "singular": "reportgroup",
+      "plural": "reportgroups"
+    },
+    "codebuild.aws.upbound.io/SourceCredential": {
+      "singular": "sourcecredential",
+      "plural": "sourcecredentials"
+    },
+    "codebuild.aws.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "codecommit.aws.m.upbound.io/ApprovalRuleTemplate": {
+      "singular": "approvalruletemplate",
+      "plural": "approvalruletemplates"
+    },
+    "codecommit.aws.m.upbound.io/ApprovalRuleTemplateAssociation": {
+      "singular": "approvalruletemplateassociation",
+      "plural": "approvalruletemplateassociations"
+    },
+    "codecommit.aws.m.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "codecommit.aws.m.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "codecommit.aws.upbound.io/ApprovalRuleTemplate": {
+      "singular": "approvalruletemplate",
+      "plural": "approvalruletemplates"
+    },
+    "codecommit.aws.upbound.io/ApprovalRuleTemplateAssociation": {
+      "singular": "approvalruletemplateassociation",
+      "plural": "approvalruletemplateassociations"
+    },
+    "codecommit.aws.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "codecommit.aws.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "codeguruprofiler.aws.m.upbound.io/ProfilingGroup": {
+      "singular": "profilinggroup",
+      "plural": "profilinggroups"
+    },
+    "codeguruprofiler.aws.upbound.io/ProfilingGroup": {
+      "singular": "profilinggroup",
+      "plural": "profilinggroups"
+    },
+    "codepipeline.aws.m.upbound.io/Codepipeline": {
+      "singular": "codepipeline",
+      "plural": "codepipelines"
+    },
+    "codepipeline.aws.m.upbound.io/CustomActionType": {
+      "singular": "customactiontype",
+      "plural": "customactiontypes"
+    },
+    "codepipeline.aws.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "codepipeline.aws.upbound.io/Codepipeline": {
+      "singular": "codepipeline",
+      "plural": "codepipelines"
+    },
+    "codepipeline.aws.upbound.io/CustomActionType": {
+      "singular": "customactiontype",
+      "plural": "customactiontypes"
+    },
+    "codepipeline.aws.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "codestarconnections.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "codestarconnections.aws.m.upbound.io/Host": {
+      "singular": "host",
+      "plural": "hosts"
+    },
+    "codestarconnections.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "codestarconnections.aws.upbound.io/Host": {
+      "singular": "host",
+      "plural": "hosts"
+    },
+    "codestarnotifications.aws.m.upbound.io/NotificationRule": {
+      "singular": "notificationrule",
+      "plural": "notificationrules"
+    },
+    "codestarnotifications.aws.upbound.io/NotificationRule": {
+      "singular": "notificationrule",
+      "plural": "notificationrules"
+    },
+    "cognitoidentity.aws.m.upbound.io/CognitoIdentityPoolProviderPrincipalTag": {
+      "singular": "cognitoidentitypoolproviderprincipaltag",
+      "plural": "cognitoidentitypoolproviderprincipaltags"
+    },
+    "cognitoidentity.aws.m.upbound.io/Pool": {
+      "singular": "pool",
+      "plural": "pools"
+    },
+    "cognitoidentity.aws.m.upbound.io/PoolRolesAttachment": {
+      "singular": "poolrolesattachment",
+      "plural": "poolrolesattachments"
+    },
+    "cognitoidentity.aws.upbound.io/CognitoIdentityPoolProviderPrincipalTag": {
+      "singular": "cognitoidentitypoolproviderprincipaltag",
+      "plural": "cognitoidentitypoolproviderprincipaltags"
+    },
+    "cognitoidentity.aws.upbound.io/Pool": {
+      "singular": "pool",
+      "plural": "pools"
+    },
+    "cognitoidentity.aws.upbound.io/PoolRolesAttachment": {
+      "singular": "poolrolesattachment",
+      "plural": "poolrolesattachments"
+    },
+    "cognitoidp.aws.m.upbound.io/IdentityProvider": {
+      "singular": "identityprovider",
+      "plural": "identityproviders"
+    },
+    "cognitoidp.aws.m.upbound.io/ResourceServer": {
+      "singular": "resourceserver",
+      "plural": "resourceservers"
+    },
+    "cognitoidp.aws.m.upbound.io/RiskConfiguration": {
+      "singular": "riskconfiguration",
+      "plural": "riskconfigurations"
+    },
+    "cognitoidp.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "cognitoidp.aws.m.upbound.io/UserGroup": {
+      "singular": "usergroup",
+      "plural": "usergroups"
+    },
+    "cognitoidp.aws.m.upbound.io/UserInGroup": {
+      "singular": "useringroup",
+      "plural": "useringroups"
+    },
+    "cognitoidp.aws.m.upbound.io/UserPool": {
+      "singular": "userpool",
+      "plural": "userpools"
+    },
+    "cognitoidp.aws.m.upbound.io/UserPoolClient": {
+      "singular": "userpoolclient",
+      "plural": "userpoolclients"
+    },
+    "cognitoidp.aws.m.upbound.io/UserPoolDomain": {
+      "singular": "userpooldomain",
+      "plural": "userpooldomains"
+    },
+    "cognitoidp.aws.m.upbound.io/UserPoolUICustomization": {
+      "singular": "userpooluicustomization",
+      "plural": "userpooluicustomizations"
+    },
+    "cognitoidp.aws.upbound.io/IdentityProvider": {
+      "singular": "identityprovider",
+      "plural": "identityproviders"
+    },
+    "cognitoidp.aws.upbound.io/ResourceServer": {
+      "singular": "resourceserver",
+      "plural": "resourceservers"
+    },
+    "cognitoidp.aws.upbound.io/RiskConfiguration": {
+      "singular": "riskconfiguration",
+      "plural": "riskconfigurations"
+    },
+    "cognitoidp.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "cognitoidp.aws.upbound.io/UserGroup": {
+      "singular": "usergroup",
+      "plural": "usergroups"
+    },
+    "cognitoidp.aws.upbound.io/UserInGroup": {
+      "singular": "useringroup",
+      "plural": "useringroups"
+    },
+    "cognitoidp.aws.upbound.io/UserPool": {
+      "singular": "userpool",
+      "plural": "userpools"
+    },
+    "cognitoidp.aws.upbound.io/UserPoolClient": {
+      "singular": "userpoolclient",
+      "plural": "userpoolclients"
+    },
+    "cognitoidp.aws.upbound.io/UserPoolDomain": {
+      "singular": "userpooldomain",
+      "plural": "userpooldomains"
+    },
+    "cognitoidp.aws.upbound.io/UserPoolUICustomization": {
+      "singular": "userpooluicustomization",
+      "plural": "userpooluicustomizations"
+    },
+    "configservice.aws.m.upbound.io/AWSConfigurationRecorderStatus": {
+      "singular": "awsconfigurationrecorderstatus",
+      "plural": "awsconfigurationrecorderstatuses"
+    },
+    "configservice.aws.m.upbound.io/ConfigRule": {
+      "singular": "configrule",
+      "plural": "configrules"
+    },
+    "configservice.aws.m.upbound.io/ConfigurationAggregator": {
+      "singular": "configurationaggregator",
+      "plural": "configurationaggregators"
+    },
+    "configservice.aws.m.upbound.io/ConfigurationRecorder": {
+      "singular": "configurationrecorder",
+      "plural": "configurationrecorders"
+    },
+    "configservice.aws.m.upbound.io/ConformancePack": {
+      "singular": "conformancepack",
+      "plural": "conformancepacks"
+    },
+    "configservice.aws.m.upbound.io/DeliveryChannel": {
+      "singular": "deliverychannel",
+      "plural": "deliverychannels"
+    },
+    "configservice.aws.m.upbound.io/RemediationConfiguration": {
+      "singular": "remediationconfiguration",
+      "plural": "remediationconfigurations"
+    },
+    "configservice.aws.upbound.io/AWSConfigurationRecorderStatus": {
+      "singular": "awsconfigurationrecorderstatus",
+      "plural": "awsconfigurationrecorderstatuses"
+    },
+    "configservice.aws.upbound.io/ConfigRule": {
+      "singular": "configrule",
+      "plural": "configrules"
+    },
+    "configservice.aws.upbound.io/ConfigurationAggregator": {
+      "singular": "configurationaggregator",
+      "plural": "configurationaggregators"
+    },
+    "configservice.aws.upbound.io/ConfigurationRecorder": {
+      "singular": "configurationrecorder",
+      "plural": "configurationrecorders"
+    },
+    "configservice.aws.upbound.io/ConformancePack": {
+      "singular": "conformancepack",
+      "plural": "conformancepacks"
+    },
+    "configservice.aws.upbound.io/DeliveryChannel": {
+      "singular": "deliverychannel",
+      "plural": "deliverychannels"
+    },
+    "configservice.aws.upbound.io/RemediationConfiguration": {
+      "singular": "remediationconfiguration",
+      "plural": "remediationconfigurations"
+    },
+    "connect.aws.m.upbound.io/BotAssociation": {
+      "singular": "botassociation",
+      "plural": "botassociations"
+    },
+    "connect.aws.m.upbound.io/ContactFlow": {
+      "singular": "contactflow",
+      "plural": "contactflows"
+    },
+    "connect.aws.m.upbound.io/ContactFlowModule": {
+      "singular": "contactflowmodule",
+      "plural": "contactflowmodules"
+    },
+    "connect.aws.m.upbound.io/HoursOfOperation": {
+      "singular": "hoursofoperation",
+      "plural": "hoursofoperations"
+    },
+    "connect.aws.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "connect.aws.m.upbound.io/InstanceStorageConfig": {
+      "singular": "instancestorageconfig",
+      "plural": "instancestorageconfigs"
+    },
+    "connect.aws.m.upbound.io/LambdaFunctionAssociation": {
+      "singular": "lambdafunctionassociation",
+      "plural": "lambdafunctionassociations"
+    },
+    "connect.aws.m.upbound.io/PhoneNumber": {
+      "singular": "phonenumber",
+      "plural": "phonenumbers"
+    },
+    "connect.aws.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "connect.aws.m.upbound.io/QuickConnect": {
+      "singular": "quickconnect",
+      "plural": "quickconnects"
+    },
+    "connect.aws.m.upbound.io/RoutingProfile": {
+      "singular": "routingprofile",
+      "plural": "routingprofiles"
+    },
+    "connect.aws.m.upbound.io/SecurityProfile": {
+      "singular": "securityprofile",
+      "plural": "securityprofiles"
+    },
+    "connect.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "connect.aws.m.upbound.io/UserHierarchyStructure": {
+      "singular": "userhierarchystructure",
+      "plural": "userhierarchystructures"
+    },
+    "connect.aws.m.upbound.io/Vocabulary": {
+      "singular": "vocabulary",
+      "plural": "vocabularies"
+    },
+    "connect.aws.upbound.io/BotAssociation": {
+      "singular": "botassociation",
+      "plural": "botassociations"
+    },
+    "connect.aws.upbound.io/ContactFlow": {
+      "singular": "contactflow",
+      "plural": "contactflows"
+    },
+    "connect.aws.upbound.io/ContactFlowModule": {
+      "singular": "contactflowmodule",
+      "plural": "contactflowmodules"
+    },
+    "connect.aws.upbound.io/HoursOfOperation": {
+      "singular": "hoursofoperation",
+      "plural": "hoursofoperations"
+    },
+    "connect.aws.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "connect.aws.upbound.io/InstanceStorageConfig": {
+      "singular": "instancestorageconfig",
+      "plural": "instancestorageconfigs"
+    },
+    "connect.aws.upbound.io/LambdaFunctionAssociation": {
+      "singular": "lambdafunctionassociation",
+      "plural": "lambdafunctionassociations"
+    },
+    "connect.aws.upbound.io/PhoneNumber": {
+      "singular": "phonenumber",
+      "plural": "phonenumbers"
+    },
+    "connect.aws.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "connect.aws.upbound.io/QuickConnect": {
+      "singular": "quickconnect",
+      "plural": "quickconnects"
+    },
+    "connect.aws.upbound.io/RoutingProfile": {
+      "singular": "routingprofile",
+      "plural": "routingprofiles"
+    },
+    "connect.aws.upbound.io/SecurityProfile": {
+      "singular": "securityprofile",
+      "plural": "securityprofiles"
+    },
+    "connect.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "connect.aws.upbound.io/UserHierarchyStructure": {
+      "singular": "userhierarchystructure",
+      "plural": "userhierarchystructures"
+    },
+    "connect.aws.upbound.io/Vocabulary": {
+      "singular": "vocabulary",
+      "plural": "vocabularies"
+    },
+    "cur.aws.m.upbound.io/ReportDefinition": {
+      "singular": "reportdefinition",
+      "plural": "reportdefinitions"
+    },
+    "cur.aws.upbound.io/ReportDefinition": {
+      "singular": "reportdefinition",
+      "plural": "reportdefinitions"
+    },
+    "dataexchange.aws.m.upbound.io/DataSet": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "dataexchange.aws.m.upbound.io/Revision": {
+      "singular": "revision",
+      "plural": "revisions"
+    },
+    "dataexchange.aws.upbound.io/DataSet": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "dataexchange.aws.upbound.io/Revision": {
+      "singular": "revision",
+      "plural": "revisions"
+    },
+    "datapipeline.aws.m.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "datapipeline.aws.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "datasync.aws.m.upbound.io/LocationS3": {
+      "singular": "locations3",
+      "plural": "locations3s"
+    },
+    "datasync.aws.m.upbound.io/Task": {
+      "singular": "task",
+      "plural": "tasks"
+    },
+    "datasync.aws.upbound.io/LocationS3": {
+      "singular": "locations3",
+      "plural": "locations3s"
+    },
+    "datasync.aws.upbound.io/Task": {
+      "singular": "task",
+      "plural": "tasks"
+    },
+    "dax.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dax.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "dax.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "dax.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dax.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "dax.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "deploy.aws.m.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "deploy.aws.m.upbound.io/DeploymentConfig": {
+      "singular": "deploymentconfig",
+      "plural": "deploymentconfigs"
+    },
+    "deploy.aws.m.upbound.io/DeploymentGroup": {
+      "singular": "deploymentgroup",
+      "plural": "deploymentgroups"
+    },
+    "deploy.aws.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "deploy.aws.upbound.io/DeploymentConfig": {
+      "singular": "deploymentconfig",
+      "plural": "deploymentconfigs"
+    },
+    "deploy.aws.upbound.io/DeploymentGroup": {
+      "singular": "deploymentgroup",
+      "plural": "deploymentgroups"
+    },
+    "detective.aws.m.upbound.io/Graph": {
+      "singular": "graph",
+      "plural": "graphs"
+    },
+    "detective.aws.m.upbound.io/InvitationAccepter": {
+      "singular": "invitationaccepter",
+      "plural": "invitationaccepters"
+    },
+    "detective.aws.m.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "detective.aws.upbound.io/Graph": {
+      "singular": "graph",
+      "plural": "graphs"
+    },
+    "detective.aws.upbound.io/InvitationAccepter": {
+      "singular": "invitationaccepter",
+      "plural": "invitationaccepters"
+    },
+    "detective.aws.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "devicefarm.aws.m.upbound.io/DevicePool": {
+      "singular": "devicepool",
+      "plural": "devicepools"
+    },
+    "devicefarm.aws.m.upbound.io/InstanceProfile": {
+      "singular": "instanceprofile",
+      "plural": "instanceprofiles"
+    },
+    "devicefarm.aws.m.upbound.io/NetworkProfile": {
+      "singular": "networkprofile",
+      "plural": "networkprofiles"
+    },
+    "devicefarm.aws.m.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "devicefarm.aws.m.upbound.io/TestGridProject": {
+      "singular": "testgridproject",
+      "plural": "testgridprojects"
+    },
+    "devicefarm.aws.m.upbound.io/Upload": {
+      "singular": "upload",
+      "plural": "uploads"
+    },
+    "devicefarm.aws.upbound.io/DevicePool": {
+      "singular": "devicepool",
+      "plural": "devicepools"
+    },
+    "devicefarm.aws.upbound.io/InstanceProfile": {
+      "singular": "instanceprofile",
+      "plural": "instanceprofiles"
+    },
+    "devicefarm.aws.upbound.io/NetworkProfile": {
+      "singular": "networkprofile",
+      "plural": "networkprofiles"
+    },
+    "devicefarm.aws.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "devicefarm.aws.upbound.io/TestGridProject": {
+      "singular": "testgridproject",
+      "plural": "testgridprojects"
+    },
+    "devicefarm.aws.upbound.io/Upload": {
+      "singular": "upload",
+      "plural": "uploads"
+    },
+    "directconnect.aws.m.upbound.io/BGPPeer": {
+      "singular": "bgppeer",
+      "plural": "bgppeers"
+    },
+    "directconnect.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "directconnect.aws.m.upbound.io/ConnectionAssociation": {
+      "singular": "connectionassociation",
+      "plural": "connectionassociations"
+    },
+    "directconnect.aws.m.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "directconnect.aws.m.upbound.io/GatewayAssociation": {
+      "singular": "gatewayassociation",
+      "plural": "gatewayassociations"
+    },
+    "directconnect.aws.m.upbound.io/GatewayAssociationProposal": {
+      "singular": "gatewayassociationproposal",
+      "plural": "gatewayassociationproposals"
+    },
+    "directconnect.aws.m.upbound.io/HostedPrivateVirtualInterface": {
+      "singular": "hostedprivatevirtualinterface",
+      "plural": "hostedprivatevirtualinterfaces"
+    },
+    "directconnect.aws.m.upbound.io/HostedPrivateVirtualInterfaceAccepter": {
+      "singular": "hostedprivatevirtualinterfaceaccepter",
+      "plural": "hostedprivatevirtualinterfaceaccepters"
+    },
+    "directconnect.aws.m.upbound.io/HostedPublicVirtualInterface": {
+      "singular": "hostedpublicvirtualinterface",
+      "plural": "hostedpublicvirtualinterfaces"
+    },
+    "directconnect.aws.m.upbound.io/HostedPublicVirtualInterfaceAccepter": {
+      "singular": "hostedpublicvirtualinterfaceaccepter",
+      "plural": "hostedpublicvirtualinterfaceaccepters"
+    },
+    "directconnect.aws.m.upbound.io/HostedTransitVirtualInterface": {
+      "singular": "hostedtransitvirtualinterface",
+      "plural": "hostedtransitvirtualinterfaces"
+    },
+    "directconnect.aws.m.upbound.io/HostedTransitVirtualInterfaceAccepter": {
+      "singular": "hostedtransitvirtualinterfaceaccepter",
+      "plural": "hostedtransitvirtualinterfaceaccepters"
+    },
+    "directconnect.aws.m.upbound.io/Lag": {
+      "singular": "lag",
+      "plural": "lags"
+    },
+    "directconnect.aws.m.upbound.io/PrivateVirtualInterface": {
+      "singular": "privatevirtualinterface",
+      "plural": "privatevirtualinterfaces"
+    },
+    "directconnect.aws.m.upbound.io/PublicVirtualInterface": {
+      "singular": "publicvirtualinterface",
+      "plural": "publicvirtualinterfaces"
+    },
+    "directconnect.aws.m.upbound.io/TransitVirtualInterface": {
+      "singular": "transitvirtualinterface",
+      "plural": "transitvirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/BGPPeer": {
+      "singular": "bgppeer",
+      "plural": "bgppeers"
+    },
+    "directconnect.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "directconnect.aws.upbound.io/ConnectionAssociation": {
+      "singular": "connectionassociation",
+      "plural": "connectionassociations"
+    },
+    "directconnect.aws.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "directconnect.aws.upbound.io/GatewayAssociation": {
+      "singular": "gatewayassociation",
+      "plural": "gatewayassociations"
+    },
+    "directconnect.aws.upbound.io/GatewayAssociationProposal": {
+      "singular": "gatewayassociationproposal",
+      "plural": "gatewayassociationproposals"
+    },
+    "directconnect.aws.upbound.io/HostedPrivateVirtualInterface": {
+      "singular": "hostedprivatevirtualinterface",
+      "plural": "hostedprivatevirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/HostedPrivateVirtualInterfaceAccepter": {
+      "singular": "hostedprivatevirtualinterfaceaccepter",
+      "plural": "hostedprivatevirtualinterfaceaccepters"
+    },
+    "directconnect.aws.upbound.io/HostedPublicVirtualInterface": {
+      "singular": "hostedpublicvirtualinterface",
+      "plural": "hostedpublicvirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/HostedPublicVirtualInterfaceAccepter": {
+      "singular": "hostedpublicvirtualinterfaceaccepter",
+      "plural": "hostedpublicvirtualinterfaceaccepters"
+    },
+    "directconnect.aws.upbound.io/HostedTransitVirtualInterface": {
+      "singular": "hostedtransitvirtualinterface",
+      "plural": "hostedtransitvirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/HostedTransitVirtualInterfaceAccepter": {
+      "singular": "hostedtransitvirtualinterfaceaccepter",
+      "plural": "hostedtransitvirtualinterfaceaccepters"
+    },
+    "directconnect.aws.upbound.io/Lag": {
+      "singular": "lag",
+      "plural": "lags"
+    },
+    "directconnect.aws.upbound.io/PrivateVirtualInterface": {
+      "singular": "privatevirtualinterface",
+      "plural": "privatevirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/PublicVirtualInterface": {
+      "singular": "publicvirtualinterface",
+      "plural": "publicvirtualinterfaces"
+    },
+    "directconnect.aws.upbound.io/TransitVirtualInterface": {
+      "singular": "transitvirtualinterface",
+      "plural": "transitvirtualinterfaces"
+    },
+    "dlm.aws.m.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "dlm.aws.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "dms.aws.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "dms.aws.m.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "dms.aws.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "dms.aws.m.upbound.io/ReplicationInstance": {
+      "singular": "replicationinstance",
+      "plural": "replicationinstances"
+    },
+    "dms.aws.m.upbound.io/ReplicationSubnetGroup": {
+      "singular": "replicationsubnetgroup",
+      "plural": "replicationsubnetgroups"
+    },
+    "dms.aws.m.upbound.io/ReplicationTask": {
+      "singular": "replicationtask",
+      "plural": "replicationtasks"
+    },
+    "dms.aws.m.upbound.io/S3Endpoint": {
+      "singular": "s3endpoint",
+      "plural": "s3endpoints"
+    },
+    "dms.aws.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "dms.aws.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "dms.aws.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "dms.aws.upbound.io/ReplicationInstance": {
+      "singular": "replicationinstance",
+      "plural": "replicationinstances"
+    },
+    "dms.aws.upbound.io/ReplicationSubnetGroup": {
+      "singular": "replicationsubnetgroup",
+      "plural": "replicationsubnetgroups"
+    },
+    "dms.aws.upbound.io/ReplicationTask": {
+      "singular": "replicationtask",
+      "plural": "replicationtasks"
+    },
+    "dms.aws.upbound.io/S3Endpoint": {
+      "singular": "s3endpoint",
+      "plural": "s3endpoints"
+    },
+    "docdb.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "docdb.aws.m.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "docdb.aws.m.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "docdb.aws.m.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "docdb.aws.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "docdb.aws.m.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "docdb.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "docdb.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "docdb.aws.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "docdb.aws.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "docdb.aws.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "docdb.aws.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "docdb.aws.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "docdb.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "ds.aws.m.upbound.io/ConditionalForwarder": {
+      "singular": "conditionalforwarder",
+      "plural": "conditionalforwarders"
+    },
+    "ds.aws.m.upbound.io/Directory": {
+      "singular": "directory",
+      "plural": "directories"
+    },
+    "ds.aws.m.upbound.io/SharedDirectory": {
+      "singular": "shareddirectory",
+      "plural": "shareddirectories"
+    },
+    "ds.aws.upbound.io/ConditionalForwarder": {
+      "singular": "conditionalforwarder",
+      "plural": "conditionalforwarders"
+    },
+    "ds.aws.upbound.io/Directory": {
+      "singular": "directory",
+      "plural": "directories"
+    },
+    "ds.aws.upbound.io/SharedDirectory": {
+      "singular": "shareddirectory",
+      "plural": "shareddirectories"
+    },
+    "dsql.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dsql.aws.m.upbound.io/ClusterPeering": {
+      "singular": "clusterpeering",
+      "plural": "clusterpeerings"
+    },
+    "dsql.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dsql.aws.upbound.io/ClusterPeering": {
+      "singular": "clusterpeering",
+      "plural": "clusterpeerings"
+    },
+    "dynamodb.aws.m.upbound.io/ContributorInsights": {
+      "singular": "contributorinsights",
+      "plural": "contributorinsights"
+    },
+    "dynamodb.aws.m.upbound.io/GlobalTable": {
+      "singular": "globaltable",
+      "plural": "globaltables"
+    },
+    "dynamodb.aws.m.upbound.io/KinesisStreamingDestination": {
+      "singular": "kinesisstreamingdestination",
+      "plural": "kinesisstreamingdestinations"
+    },
+    "dynamodb.aws.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "dynamodb.aws.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "dynamodb.aws.m.upbound.io/TableItem": {
+      "singular": "tableitem",
+      "plural": "tableitems"
+    },
+    "dynamodb.aws.m.upbound.io/TableReplica": {
+      "singular": "tablereplica",
+      "plural": "tablereplicas"
+    },
+    "dynamodb.aws.m.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "dynamodb.aws.upbound.io/ContributorInsights": {
+      "singular": "contributorinsights",
+      "plural": "contributorinsights"
+    },
+    "dynamodb.aws.upbound.io/GlobalTable": {
+      "singular": "globaltable",
+      "plural": "globaltables"
+    },
+    "dynamodb.aws.upbound.io/KinesisStreamingDestination": {
+      "singular": "kinesisstreamingdestination",
+      "plural": "kinesisstreamingdestinations"
+    },
+    "dynamodb.aws.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "dynamodb.aws.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "dynamodb.aws.upbound.io/TableItem": {
+      "singular": "tableitem",
+      "plural": "tableitems"
+    },
+    "dynamodb.aws.upbound.io/TableReplica": {
+      "singular": "tablereplica",
+      "plural": "tablereplicas"
+    },
+    "dynamodb.aws.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "ec2.aws.m.upbound.io/AMI": {
+      "singular": "ami",
+      "plural": "amis"
+    },
+    "ec2.aws.m.upbound.io/AMICopy": {
+      "singular": "amicopy",
+      "plural": "amicopies"
+    },
+    "ec2.aws.m.upbound.io/AMILaunchPermission": {
+      "singular": "amilaunchpermission",
+      "plural": "amilaunchpermissions"
+    },
+    "ec2.aws.m.upbound.io/AvailabilityZoneGroup": {
+      "singular": "availabilityzonegroup",
+      "plural": "availabilityzonegroups"
+    },
+    "ec2.aws.m.upbound.io/CapacityBlockReservation": {
+      "singular": "capacityblockreservation",
+      "plural": "capacityblockreservations"
+    },
+    "ec2.aws.m.upbound.io/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "ec2.aws.m.upbound.io/CarrierGateway": {
+      "singular": "carriergateway",
+      "plural": "carriergateways"
+    },
+    "ec2.aws.m.upbound.io/CustomerGateway": {
+      "singular": "customergateway",
+      "plural": "customergateways"
+    },
+    "ec2.aws.m.upbound.io/DefaultNetworkACL": {
+      "singular": "defaultnetworkacl",
+      "plural": "defaultnetworkacls"
+    },
+    "ec2.aws.m.upbound.io/DefaultRouteTable": {
+      "singular": "defaultroutetable",
+      "plural": "defaultroutetables"
+    },
+    "ec2.aws.m.upbound.io/DefaultSecurityGroup": {
+      "singular": "defaultsecuritygroup",
+      "plural": "defaultsecuritygroups"
+    },
+    "ec2.aws.m.upbound.io/DefaultSubnet": {
+      "singular": "defaultsubnet",
+      "plural": "defaultsubnets"
+    },
+    "ec2.aws.m.upbound.io/DefaultVPC": {
+      "singular": "defaultvpc",
+      "plural": "defaultvpcs"
+    },
+    "ec2.aws.m.upbound.io/DefaultVPCDHCPOptions": {
+      "singular": "defaultvpcdhcpoptions",
+      "plural": "defaultvpcdhcpoptions"
+    },
+    "ec2.aws.m.upbound.io/EBSDefaultKMSKey": {
+      "singular": "ebsdefaultkmskey",
+      "plural": "ebsdefaultkmskeys"
+    },
+    "ec2.aws.m.upbound.io/EBSEncryptionByDefault": {
+      "singular": "ebsencryptionbydefault",
+      "plural": "ebsencryptionbydefaults"
+    },
+    "ec2.aws.m.upbound.io/EBSSnapshot": {
+      "singular": "ebssnapshot",
+      "plural": "ebssnapshots"
+    },
+    "ec2.aws.m.upbound.io/EBSSnapshotCopy": {
+      "singular": "ebssnapshotcopy",
+      "plural": "ebssnapshotcopies"
+    },
+    "ec2.aws.m.upbound.io/EBSSnapshotImport": {
+      "singular": "ebssnapshotimport",
+      "plural": "ebssnapshotimports"
+    },
+    "ec2.aws.m.upbound.io/EBSVolume": {
+      "singular": "ebsvolume",
+      "plural": "ebsvolumes"
+    },
+    "ec2.aws.m.upbound.io/EIP": {
+      "singular": "eip",
+      "plural": "eips"
+    },
+    "ec2.aws.m.upbound.io/EIPAssociation": {
+      "singular": "eipassociation",
+      "plural": "eipassociations"
+    },
+    "ec2.aws.m.upbound.io/EgressOnlyInternetGateway": {
+      "singular": "egressonlyinternetgateway",
+      "plural": "egressonlyinternetgateways"
+    },
+    "ec2.aws.m.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleets"
+    },
+    "ec2.aws.m.upbound.io/FlowLog": {
+      "singular": "flowlog",
+      "plural": "flowlogs"
+    },
+    "ec2.aws.m.upbound.io/Host": {
+      "singular": "host",
+      "plural": "hosts"
+    },
+    "ec2.aws.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "ec2.aws.m.upbound.io/InstanceState": {
+      "singular": "instancestate",
+      "plural": "instancestates"
+    },
+    "ec2.aws.m.upbound.io/InternetGateway": {
+      "singular": "internetgateway",
+      "plural": "internetgateways"
+    },
+    "ec2.aws.m.upbound.io/KeyPair": {
+      "singular": "keypair",
+      "plural": "keypairs"
+    },
+    "ec2.aws.m.upbound.io/LaunchTemplate": {
+      "singular": "launchtemplate",
+      "plural": "launchtemplates"
+    },
+    "ec2.aws.m.upbound.io/MainRouteTableAssociation": {
+      "singular": "mainroutetableassociation",
+      "plural": "mainroutetableassociations"
+    },
+    "ec2.aws.m.upbound.io/ManagedPrefixList": {
+      "singular": "managedprefixlist",
+      "plural": "managedprefixlists"
+    },
+    "ec2.aws.m.upbound.io/ManagedPrefixListEntry": {
+      "singular": "managedprefixlistentry",
+      "plural": "managedprefixlistentries"
+    },
+    "ec2.aws.m.upbound.io/NATGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "ec2.aws.m.upbound.io/NetworkACL": {
+      "singular": "networkacl",
+      "plural": "networkacls"
+    },
+    "ec2.aws.m.upbound.io/NetworkACLRule": {
+      "singular": "networkaclrule",
+      "plural": "networkaclrules"
+    },
+    "ec2.aws.m.upbound.io/NetworkInsightsAnalysis": {
+      "singular": "networkinsightsanalysis",
+      "plural": "networkinsightsanalyses"
+    },
+    "ec2.aws.m.upbound.io/NetworkInsightsPath": {
+      "singular": "networkinsightspath",
+      "plural": "networkinsightspaths"
+    },
+    "ec2.aws.m.upbound.io/NetworkInterface": {
+      "singular": "networkinterface",
+      "plural": "networkinterfaces"
+    },
+    "ec2.aws.m.upbound.io/NetworkInterfaceAttachment": {
+      "singular": "networkinterfaceattachment",
+      "plural": "networkinterfaceattachments"
+    },
+    "ec2.aws.m.upbound.io/NetworkInterfaceSgAttachment": {
+      "singular": "networkinterfacesgattachment",
+      "plural": "networkinterfacesgattachments"
+    },
+    "ec2.aws.m.upbound.io/PlacementGroup": {
+      "singular": "placementgroup",
+      "plural": "placementgroups"
+    },
+    "ec2.aws.m.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "ec2.aws.m.upbound.io/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "ec2.aws.m.upbound.io/RouteTableAssociation": {
+      "singular": "routetableassociation",
+      "plural": "routetableassociations"
+    },
+    "ec2.aws.m.upbound.io/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "ec2.aws.m.upbound.io/SecurityGroupEgressRule": {
+      "singular": "securitygroupegressrule",
+      "plural": "securitygroupegressrules"
+    },
+    "ec2.aws.m.upbound.io/SecurityGroupIngressRule": {
+      "singular": "securitygroupingressrule",
+      "plural": "securitygroupingressrules"
+    },
+    "ec2.aws.m.upbound.io/SecurityGroupRule": {
+      "singular": "securitygrouprule",
+      "plural": "securitygrouprules"
+    },
+    "ec2.aws.m.upbound.io/SerialConsoleAccess": {
+      "singular": "serialconsoleaccess",
+      "plural": "serialconsoleaccesses"
+    },
+    "ec2.aws.m.upbound.io/SnapshotCreateVolumePermission": {
+      "singular": "snapshotcreatevolumepermission",
+      "plural": "snapshotcreatevolumepermissions"
+    },
+    "ec2.aws.m.upbound.io/SpotDatafeedSubscription": {
+      "singular": "spotdatafeedsubscription",
+      "plural": "spotdatafeedsubscriptions"
+    },
+    "ec2.aws.m.upbound.io/SpotFleetRequest": {
+      "singular": "spotfleetrequest",
+      "plural": "spotfleetrequests"
+    },
+    "ec2.aws.m.upbound.io/SpotInstanceRequest": {
+      "singular": "spotinstancerequest",
+      "plural": "spotinstancerequests"
+    },
+    "ec2.aws.m.upbound.io/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets"
+    },
+    "ec2.aws.m.upbound.io/SubnetCidrReservation": {
+      "singular": "subnetcidrreservation",
+      "plural": "subnetcidrreservations"
+    },
+    "ec2.aws.m.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "ec2.aws.m.upbound.io/TrafficMirrorFilter": {
+      "singular": "trafficmirrorfilter",
+      "plural": "trafficmirrorfilters"
+    },
+    "ec2.aws.m.upbound.io/TrafficMirrorFilterRule": {
+      "singular": "trafficmirrorfilterrule",
+      "plural": "trafficmirrorfilterrules"
+    },
+    "ec2.aws.m.upbound.io/TransitGateway": {
+      "singular": "transitgateway",
+      "plural": "transitgateways"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayConnect": {
+      "singular": "transitgatewayconnect",
+      "plural": "transitgatewayconnects"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayConnectPeer": {
+      "singular": "transitgatewayconnectpeer",
+      "plural": "transitgatewayconnectpeers"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayMulticastDomain": {
+      "singular": "transitgatewaymulticastdomain",
+      "plural": "transitgatewaymulticastdomains"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayMulticastDomainAssociation": {
+      "singular": "transitgatewaymulticastdomainassociation",
+      "plural": "transitgatewaymulticastdomainassociations"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayMulticastGroupMember": {
+      "singular": "transitgatewaymulticastgroupmember",
+      "plural": "transitgatewaymulticastgroupmembers"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayMulticastGroupSource": {
+      "singular": "transitgatewaymulticastgroupsource",
+      "plural": "transitgatewaymulticastgroupsources"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayPeeringAttachment": {
+      "singular": "transitgatewaypeeringattachment",
+      "plural": "transitgatewaypeeringattachments"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayPeeringAttachmentAccepter": {
+      "singular": "transitgatewaypeeringattachmentaccepter",
+      "plural": "transitgatewaypeeringattachmentaccepters"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayPolicyTable": {
+      "singular": "transitgatewaypolicytable",
+      "plural": "transitgatewaypolicytables"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayPrefixListReference": {
+      "singular": "transitgatewayprefixlistreference",
+      "plural": "transitgatewayprefixlistreferences"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayRoute": {
+      "singular": "transitgatewayroute",
+      "plural": "transitgatewayroutes"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayRouteTable": {
+      "singular": "transitgatewayroutetable",
+      "plural": "transitgatewayroutetables"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayRouteTableAssociation": {
+      "singular": "transitgatewayroutetableassociation",
+      "plural": "transitgatewayroutetableassociations"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayRouteTablePropagation": {
+      "singular": "transitgatewayroutetablepropagation",
+      "plural": "transitgatewayroutetablepropagations"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayVPCAttachment": {
+      "singular": "transitgatewayvpcattachment",
+      "plural": "transitgatewayvpcattachments"
+    },
+    "ec2.aws.m.upbound.io/TransitGatewayVPCAttachmentAccepter": {
+      "singular": "transitgatewayvpcattachmentaccepter",
+      "plural": "transitgatewayvpcattachmentaccepters"
+    },
+    "ec2.aws.m.upbound.io/VPC": {
+      "singular": "vpc",
+      "plural": "vpcs"
+    },
+    "ec2.aws.m.upbound.io/VPCDHCPOptions": {
+      "singular": "vpcdhcpoptions",
+      "plural": "vpcdhcpoptions"
+    },
+    "ec2.aws.m.upbound.io/VPCDHCPOptionsAssociation": {
+      "singular": "vpcdhcpoptionsassociation",
+      "plural": "vpcdhcpoptionsassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpoint": {
+      "singular": "vpcendpoint",
+      "plural": "vpcendpoints"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointConnectionAccepter": {
+      "singular": "vpcendpointconnectionaccepter",
+      "plural": "vpcendpointconnectionaccepters"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointConnectionNotification": {
+      "singular": "vpcendpointconnectionnotification",
+      "plural": "vpcendpointconnectionnotifications"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointRouteTableAssociation": {
+      "singular": "vpcendpointroutetableassociation",
+      "plural": "vpcendpointroutetableassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointSecurityGroupAssociation": {
+      "singular": "vpcendpointsecuritygroupassociation",
+      "plural": "vpcendpointsecuritygroupassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointService": {
+      "singular": "vpcendpointservice",
+      "plural": "vpcendpointservices"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointServiceAllowedPrincipal": {
+      "singular": "vpcendpointserviceallowedprincipal",
+      "plural": "vpcendpointserviceallowedprincipals"
+    },
+    "ec2.aws.m.upbound.io/VPCEndpointSubnetAssociation": {
+      "singular": "vpcendpointsubnetassociation",
+      "plural": "vpcendpointsubnetassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCIPv4CidrBlockAssociation": {
+      "singular": "vpcipv4cidrblockassociation",
+      "plural": "vpcipv4cidrblockassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCIPv6CidrBlockAssociation": {
+      "singular": "vpcipv6cidrblockassociation",
+      "plural": "vpcipv6cidrblockassociations"
+    },
+    "ec2.aws.m.upbound.io/VPCIpam": {
+      "singular": "vpcipam",
+      "plural": "vpcipams"
+    },
+    "ec2.aws.m.upbound.io/VPCIpamPool": {
+      "singular": "vpcipampool",
+      "plural": "vpcipampools"
+    },
+    "ec2.aws.m.upbound.io/VPCIpamPoolCidr": {
+      "singular": "vpcipampoolcidr",
+      "plural": "vpcipampoolcidrs"
+    },
+    "ec2.aws.m.upbound.io/VPCIpamPoolCidrAllocation": {
+      "singular": "vpcipampoolcidrallocation",
+      "plural": "vpcipampoolcidrallocations"
+    },
+    "ec2.aws.m.upbound.io/VPCIpamScope": {
+      "singular": "vpcipamscope",
+      "plural": "vpcipamscopes"
+    },
+    "ec2.aws.m.upbound.io/VPCPeeringConnection": {
+      "singular": "vpcpeeringconnection",
+      "plural": "vpcpeeringconnections"
+    },
+    "ec2.aws.m.upbound.io/VPCPeeringConnectionAccepter": {
+      "singular": "vpcpeeringconnectionaccepter",
+      "plural": "vpcpeeringconnectionaccepters"
+    },
+    "ec2.aws.m.upbound.io/VPCPeeringConnectionOptions": {
+      "singular": "vpcpeeringconnectionoptions",
+      "plural": "vpcpeeringconnectionoptions"
+    },
+    "ec2.aws.m.upbound.io/VPNConnection": {
+      "singular": "vpnconnection",
+      "plural": "vpnconnections"
+    },
+    "ec2.aws.m.upbound.io/VPNConnectionRoute": {
+      "singular": "vpnconnectionroute",
+      "plural": "vpnconnectionroutes"
+    },
+    "ec2.aws.m.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "ec2.aws.m.upbound.io/VPNGatewayAttachment": {
+      "singular": "vpngatewayattachment",
+      "plural": "vpngatewayattachments"
+    },
+    "ec2.aws.m.upbound.io/VPNGatewayRoutePropagation": {
+      "singular": "vpngatewayroutepropagation",
+      "plural": "vpngatewayroutepropagations"
+    },
+    "ec2.aws.m.upbound.io/VolumeAttachment": {
+      "singular": "volumeattachment",
+      "plural": "volumeattachments"
+    },
+    "ec2.aws.upbound.io/AMI": {
+      "singular": "ami",
+      "plural": "amis"
+    },
+    "ec2.aws.upbound.io/AMICopy": {
+      "singular": "amicopy",
+      "plural": "amicopies"
+    },
+    "ec2.aws.upbound.io/AMILaunchPermission": {
+      "singular": "amilaunchpermission",
+      "plural": "amilaunchpermissions"
+    },
+    "ec2.aws.upbound.io/AvailabilityZoneGroup": {
+      "singular": "availabilityzonegroup",
+      "plural": "availabilityzonegroups"
+    },
+    "ec2.aws.upbound.io/CapacityBlockReservation": {
+      "singular": "capacityblockreservation",
+      "plural": "capacityblockreservations"
+    },
+    "ec2.aws.upbound.io/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "ec2.aws.upbound.io/CarrierGateway": {
+      "singular": "carriergateway",
+      "plural": "carriergateways"
+    },
+    "ec2.aws.upbound.io/CustomerGateway": {
+      "singular": "customergateway",
+      "plural": "customergateways"
+    },
+    "ec2.aws.upbound.io/DefaultNetworkACL": {
+      "singular": "defaultnetworkacl",
+      "plural": "defaultnetworkacls"
+    },
+    "ec2.aws.upbound.io/DefaultRouteTable": {
+      "singular": "defaultroutetable",
+      "plural": "defaultroutetables"
+    },
+    "ec2.aws.upbound.io/DefaultSecurityGroup": {
+      "singular": "defaultsecuritygroup",
+      "plural": "defaultsecuritygroups"
+    },
+    "ec2.aws.upbound.io/DefaultSubnet": {
+      "singular": "defaultsubnet",
+      "plural": "defaultsubnets"
+    },
+    "ec2.aws.upbound.io/DefaultVPC": {
+      "singular": "defaultvpc",
+      "plural": "defaultvpcs"
+    },
+    "ec2.aws.upbound.io/DefaultVPCDHCPOptions": {
+      "singular": "defaultvpcdhcpoptions",
+      "plural": "defaultvpcdhcpoptions"
+    },
+    "ec2.aws.upbound.io/EBSDefaultKMSKey": {
+      "singular": "ebsdefaultkmskey",
+      "plural": "ebsdefaultkmskeys"
+    },
+    "ec2.aws.upbound.io/EBSEncryptionByDefault": {
+      "singular": "ebsencryptionbydefault",
+      "plural": "ebsencryptionbydefaults"
+    },
+    "ec2.aws.upbound.io/EBSSnapshot": {
+      "singular": "ebssnapshot",
+      "plural": "ebssnapshots"
+    },
+    "ec2.aws.upbound.io/EBSSnapshotCopy": {
+      "singular": "ebssnapshotcopy",
+      "plural": "ebssnapshotcopies"
+    },
+    "ec2.aws.upbound.io/EBSSnapshotImport": {
+      "singular": "ebssnapshotimport",
+      "plural": "ebssnapshotimports"
+    },
+    "ec2.aws.upbound.io/EBSVolume": {
+      "singular": "ebsvolume",
+      "plural": "ebsvolumes"
+    },
+    "ec2.aws.upbound.io/EIP": {
+      "singular": "eip",
+      "plural": "eips"
+    },
+    "ec2.aws.upbound.io/EIPAssociation": {
+      "singular": "eipassociation",
+      "plural": "eipassociations"
+    },
+    "ec2.aws.upbound.io/EgressOnlyInternetGateway": {
+      "singular": "egressonlyinternetgateway",
+      "plural": "egressonlyinternetgateways"
+    },
+    "ec2.aws.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleets"
+    },
+    "ec2.aws.upbound.io/FlowLog": {
+      "singular": "flowlog",
+      "plural": "flowlogs"
+    },
+    "ec2.aws.upbound.io/Host": {
+      "singular": "host",
+      "plural": "hosts"
+    },
+    "ec2.aws.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "ec2.aws.upbound.io/InstanceState": {
+      "singular": "instancestate",
+      "plural": "instancestates"
+    },
+    "ec2.aws.upbound.io/InternetGateway": {
+      "singular": "internetgateway",
+      "plural": "internetgateways"
+    },
+    "ec2.aws.upbound.io/KeyPair": {
+      "singular": "keypair",
+      "plural": "keypairs"
+    },
+    "ec2.aws.upbound.io/LaunchTemplate": {
+      "singular": "launchtemplate",
+      "plural": "launchtemplates"
+    },
+    "ec2.aws.upbound.io/MainRouteTableAssociation": {
+      "singular": "mainroutetableassociation",
+      "plural": "mainroutetableassociations"
+    },
+    "ec2.aws.upbound.io/ManagedPrefixList": {
+      "singular": "managedprefixlist",
+      "plural": "managedprefixlists"
+    },
+    "ec2.aws.upbound.io/ManagedPrefixListEntry": {
+      "singular": "managedprefixlistentry",
+      "plural": "managedprefixlistentries"
+    },
+    "ec2.aws.upbound.io/NATGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "ec2.aws.upbound.io/NetworkACL": {
+      "singular": "networkacl",
+      "plural": "networkacls"
+    },
+    "ec2.aws.upbound.io/NetworkACLRule": {
+      "singular": "networkaclrule",
+      "plural": "networkaclrules"
+    },
+    "ec2.aws.upbound.io/NetworkInsightsAnalysis": {
+      "singular": "networkinsightsanalysis",
+      "plural": "networkinsightsanalyses"
+    },
+    "ec2.aws.upbound.io/NetworkInsightsPath": {
+      "singular": "networkinsightspath",
+      "plural": "networkinsightspaths"
+    },
+    "ec2.aws.upbound.io/NetworkInterface": {
+      "singular": "networkinterface",
+      "plural": "networkinterfaces"
+    },
+    "ec2.aws.upbound.io/NetworkInterfaceAttachment": {
+      "singular": "networkinterfaceattachment",
+      "plural": "networkinterfaceattachments"
+    },
+    "ec2.aws.upbound.io/NetworkInterfaceSgAttachment": {
+      "singular": "networkinterfacesgattachment",
+      "plural": "networkinterfacesgattachments"
+    },
+    "ec2.aws.upbound.io/PlacementGroup": {
+      "singular": "placementgroup",
+      "plural": "placementgroups"
+    },
+    "ec2.aws.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "ec2.aws.upbound.io/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "ec2.aws.upbound.io/RouteTableAssociation": {
+      "singular": "routetableassociation",
+      "plural": "routetableassociations"
+    },
+    "ec2.aws.upbound.io/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "ec2.aws.upbound.io/SecurityGroupEgressRule": {
+      "singular": "securitygroupegressrule",
+      "plural": "securitygroupegressrules"
+    },
+    "ec2.aws.upbound.io/SecurityGroupIngressRule": {
+      "singular": "securitygroupingressrule",
+      "plural": "securitygroupingressrules"
+    },
+    "ec2.aws.upbound.io/SecurityGroupRule": {
+      "singular": "securitygrouprule",
+      "plural": "securitygrouprules"
+    },
+    "ec2.aws.upbound.io/SerialConsoleAccess": {
+      "singular": "serialconsoleaccess",
+      "plural": "serialconsoleaccesses"
+    },
+    "ec2.aws.upbound.io/SnapshotCreateVolumePermission": {
+      "singular": "snapshotcreatevolumepermission",
+      "plural": "snapshotcreatevolumepermissions"
+    },
+    "ec2.aws.upbound.io/SpotDatafeedSubscription": {
+      "singular": "spotdatafeedsubscription",
+      "plural": "spotdatafeedsubscriptions"
+    },
+    "ec2.aws.upbound.io/SpotFleetRequest": {
+      "singular": "spotfleetrequest",
+      "plural": "spotfleetrequests"
+    },
+    "ec2.aws.upbound.io/SpotInstanceRequest": {
+      "singular": "spotinstancerequest",
+      "plural": "spotinstancerequests"
+    },
+    "ec2.aws.upbound.io/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets"
+    },
+    "ec2.aws.upbound.io/SubnetCidrReservation": {
+      "singular": "subnetcidrreservation",
+      "plural": "subnetcidrreservations"
+    },
+    "ec2.aws.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "ec2.aws.upbound.io/TrafficMirrorFilter": {
+      "singular": "trafficmirrorfilter",
+      "plural": "trafficmirrorfilters"
+    },
+    "ec2.aws.upbound.io/TrafficMirrorFilterRule": {
+      "singular": "trafficmirrorfilterrule",
+      "plural": "trafficmirrorfilterrules"
+    },
+    "ec2.aws.upbound.io/TransitGateway": {
+      "singular": "transitgateway",
+      "plural": "transitgateways"
+    },
+    "ec2.aws.upbound.io/TransitGatewayConnect": {
+      "singular": "transitgatewayconnect",
+      "plural": "transitgatewayconnects"
+    },
+    "ec2.aws.upbound.io/TransitGatewayConnectPeer": {
+      "singular": "transitgatewayconnectpeer",
+      "plural": "transitgatewayconnectpeers"
+    },
+    "ec2.aws.upbound.io/TransitGatewayMulticastDomain": {
+      "singular": "transitgatewaymulticastdomain",
+      "plural": "transitgatewaymulticastdomains"
+    },
+    "ec2.aws.upbound.io/TransitGatewayMulticastDomainAssociation": {
+      "singular": "transitgatewaymulticastdomainassociation",
+      "plural": "transitgatewaymulticastdomainassociations"
+    },
+    "ec2.aws.upbound.io/TransitGatewayMulticastGroupMember": {
+      "singular": "transitgatewaymulticastgroupmember",
+      "plural": "transitgatewaymulticastgroupmembers"
+    },
+    "ec2.aws.upbound.io/TransitGatewayMulticastGroupSource": {
+      "singular": "transitgatewaymulticastgroupsource",
+      "plural": "transitgatewaymulticastgroupsources"
+    },
+    "ec2.aws.upbound.io/TransitGatewayPeeringAttachment": {
+      "singular": "transitgatewaypeeringattachment",
+      "plural": "transitgatewaypeeringattachments"
+    },
+    "ec2.aws.upbound.io/TransitGatewayPeeringAttachmentAccepter": {
+      "singular": "transitgatewaypeeringattachmentaccepter",
+      "plural": "transitgatewaypeeringattachmentaccepters"
+    },
+    "ec2.aws.upbound.io/TransitGatewayPolicyTable": {
+      "singular": "transitgatewaypolicytable",
+      "plural": "transitgatewaypolicytables"
+    },
+    "ec2.aws.upbound.io/TransitGatewayPrefixListReference": {
+      "singular": "transitgatewayprefixlistreference",
+      "plural": "transitgatewayprefixlistreferences"
+    },
+    "ec2.aws.upbound.io/TransitGatewayRoute": {
+      "singular": "transitgatewayroute",
+      "plural": "transitgatewayroutes"
+    },
+    "ec2.aws.upbound.io/TransitGatewayRouteTable": {
+      "singular": "transitgatewayroutetable",
+      "plural": "transitgatewayroutetables"
+    },
+    "ec2.aws.upbound.io/TransitGatewayRouteTableAssociation": {
+      "singular": "transitgatewayroutetableassociation",
+      "plural": "transitgatewayroutetableassociations"
+    },
+    "ec2.aws.upbound.io/TransitGatewayRouteTablePropagation": {
+      "singular": "transitgatewayroutetablepropagation",
+      "plural": "transitgatewayroutetablepropagations"
+    },
+    "ec2.aws.upbound.io/TransitGatewayVPCAttachment": {
+      "singular": "transitgatewayvpcattachment",
+      "plural": "transitgatewayvpcattachments"
+    },
+    "ec2.aws.upbound.io/TransitGatewayVPCAttachmentAccepter": {
+      "singular": "transitgatewayvpcattachmentaccepter",
+      "plural": "transitgatewayvpcattachmentaccepters"
+    },
+    "ec2.aws.upbound.io/VPC": {
+      "singular": "vpc",
+      "plural": "vpcs"
+    },
+    "ec2.aws.upbound.io/VPCDHCPOptions": {
+      "singular": "vpcdhcpoptions",
+      "plural": "vpcdhcpoptions"
+    },
+    "ec2.aws.upbound.io/VPCDHCPOptionsAssociation": {
+      "singular": "vpcdhcpoptionsassociation",
+      "plural": "vpcdhcpoptionsassociations"
+    },
+    "ec2.aws.upbound.io/VPCEndpoint": {
+      "singular": "vpcendpoint",
+      "plural": "vpcendpoints"
+    },
+    "ec2.aws.upbound.io/VPCEndpointConnectionAccepter": {
+      "singular": "vpcendpointconnectionaccepter",
+      "plural": "vpcendpointconnectionaccepters"
+    },
+    "ec2.aws.upbound.io/VPCEndpointConnectionNotification": {
+      "singular": "vpcendpointconnectionnotification",
+      "plural": "vpcendpointconnectionnotifications"
+    },
+    "ec2.aws.upbound.io/VPCEndpointRouteTableAssociation": {
+      "singular": "vpcendpointroutetableassociation",
+      "plural": "vpcendpointroutetableassociations"
+    },
+    "ec2.aws.upbound.io/VPCEndpointSecurityGroupAssociation": {
+      "singular": "vpcendpointsecuritygroupassociation",
+      "plural": "vpcendpointsecuritygroupassociations"
+    },
+    "ec2.aws.upbound.io/VPCEndpointService": {
+      "singular": "vpcendpointservice",
+      "plural": "vpcendpointservices"
+    },
+    "ec2.aws.upbound.io/VPCEndpointServiceAllowedPrincipal": {
+      "singular": "vpcendpointserviceallowedprincipal",
+      "plural": "vpcendpointserviceallowedprincipals"
+    },
+    "ec2.aws.upbound.io/VPCEndpointSubnetAssociation": {
+      "singular": "vpcendpointsubnetassociation",
+      "plural": "vpcendpointsubnetassociations"
+    },
+    "ec2.aws.upbound.io/VPCIPv4CidrBlockAssociation": {
+      "singular": "vpcipv4cidrblockassociation",
+      "plural": "vpcipv4cidrblockassociations"
+    },
+    "ec2.aws.upbound.io/VPCIPv6CidrBlockAssociation": {
+      "singular": "vpcipv6cidrblockassociation",
+      "plural": "vpcipv6cidrblockassociations"
+    },
+    "ec2.aws.upbound.io/VPCIpam": {
+      "singular": "vpcipam",
+      "plural": "vpcipams"
+    },
+    "ec2.aws.upbound.io/VPCIpamPool": {
+      "singular": "vpcipampool",
+      "plural": "vpcipampools"
+    },
+    "ec2.aws.upbound.io/VPCIpamPoolCidr": {
+      "singular": "vpcipampoolcidr",
+      "plural": "vpcipampoolcidrs"
+    },
+    "ec2.aws.upbound.io/VPCIpamPoolCidrAllocation": {
+      "singular": "vpcipampoolcidrallocation",
+      "plural": "vpcipampoolcidrallocations"
+    },
+    "ec2.aws.upbound.io/VPCIpamScope": {
+      "singular": "vpcipamscope",
+      "plural": "vpcipamscopes"
+    },
+    "ec2.aws.upbound.io/VPCPeeringConnection": {
+      "singular": "vpcpeeringconnection",
+      "plural": "vpcpeeringconnections"
+    },
+    "ec2.aws.upbound.io/VPCPeeringConnectionAccepter": {
+      "singular": "vpcpeeringconnectionaccepter",
+      "plural": "vpcpeeringconnectionaccepters"
+    },
+    "ec2.aws.upbound.io/VPCPeeringConnectionOptions": {
+      "singular": "vpcpeeringconnectionoptions",
+      "plural": "vpcpeeringconnectionoptions"
+    },
+    "ec2.aws.upbound.io/VPNConnection": {
+      "singular": "vpnconnection",
+      "plural": "vpnconnections"
+    },
+    "ec2.aws.upbound.io/VPNConnectionRoute": {
+      "singular": "vpnconnectionroute",
+      "plural": "vpnconnectionroutes"
+    },
+    "ec2.aws.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "ec2.aws.upbound.io/VPNGatewayAttachment": {
+      "singular": "vpngatewayattachment",
+      "plural": "vpngatewayattachments"
+    },
+    "ec2.aws.upbound.io/VPNGatewayRoutePropagation": {
+      "singular": "vpngatewayroutepropagation",
+      "plural": "vpngatewayroutepropagations"
+    },
+    "ec2.aws.upbound.io/VolumeAttachment": {
+      "singular": "volumeattachment",
+      "plural": "volumeattachments"
+    },
+    "ecr.aws.m.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "ecr.aws.m.upbound.io/PullThroughCacheRule": {
+      "singular": "pullthroughcacherule",
+      "plural": "pullthroughcacherules"
+    },
+    "ecr.aws.m.upbound.io/RegistryPolicy": {
+      "singular": "registrypolicy",
+      "plural": "registrypolicies"
+    },
+    "ecr.aws.m.upbound.io/RegistryScanningConfiguration": {
+      "singular": "registryscanningconfiguration",
+      "plural": "registryscanningconfigurations"
+    },
+    "ecr.aws.m.upbound.io/ReplicationConfiguration": {
+      "singular": "replicationconfiguration",
+      "plural": "replicationconfigurations"
+    },
+    "ecr.aws.m.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "ecr.aws.m.upbound.io/RepositoryCreationTemplate": {
+      "singular": "repositorycreationtemplate",
+      "plural": "repositorycreationtemplates"
+    },
+    "ecr.aws.m.upbound.io/RepositoryPolicy": {
+      "singular": "repositorypolicy",
+      "plural": "repositorypolicies"
+    },
+    "ecr.aws.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "ecr.aws.upbound.io/PullThroughCacheRule": {
+      "singular": "pullthroughcacherule",
+      "plural": "pullthroughcacherules"
+    },
+    "ecr.aws.upbound.io/RegistryPolicy": {
+      "singular": "registrypolicy",
+      "plural": "registrypolicies"
+    },
+    "ecr.aws.upbound.io/RegistryScanningConfiguration": {
+      "singular": "registryscanningconfiguration",
+      "plural": "registryscanningconfigurations"
+    },
+    "ecr.aws.upbound.io/ReplicationConfiguration": {
+      "singular": "replicationconfiguration",
+      "plural": "replicationconfigurations"
+    },
+    "ecr.aws.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "ecr.aws.upbound.io/RepositoryCreationTemplate": {
+      "singular": "repositorycreationtemplate",
+      "plural": "repositorycreationtemplates"
+    },
+    "ecr.aws.upbound.io/RepositoryPolicy": {
+      "singular": "repositorypolicy",
+      "plural": "repositorypolicies"
+    },
+    "ecrpublic.aws.m.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "ecrpublic.aws.m.upbound.io/RepositoryPolicy": {
+      "singular": "repositorypolicy",
+      "plural": "repositorypolicies"
+    },
+    "ecrpublic.aws.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "ecrpublic.aws.upbound.io/RepositoryPolicy": {
+      "singular": "repositorypolicy",
+      "plural": "repositorypolicies"
+    },
+    "ecs.aws.m.upbound.io/AccountSettingDefault": {
+      "singular": "accountsettingdefault",
+      "plural": "accountsettingdefaults"
+    },
+    "ecs.aws.m.upbound.io/CapacityProvider": {
+      "singular": "capacityprovider",
+      "plural": "capacityproviders"
+    },
+    "ecs.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "ecs.aws.m.upbound.io/ClusterCapacityProviders": {
+      "singular": "clustercapacityproviders",
+      "plural": "clustercapacityproviders"
+    },
+    "ecs.aws.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "ecs.aws.m.upbound.io/TaskDefinition": {
+      "singular": "taskdefinition",
+      "plural": "taskdefinitions"
+    },
+    "ecs.aws.upbound.io/AccountSettingDefault": {
+      "singular": "accountsettingdefault",
+      "plural": "accountsettingdefaults"
+    },
+    "ecs.aws.upbound.io/CapacityProvider": {
+      "singular": "capacityprovider",
+      "plural": "capacityproviders"
+    },
+    "ecs.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "ecs.aws.upbound.io/ClusterCapacityProviders": {
+      "singular": "clustercapacityproviders",
+      "plural": "clustercapacityproviders"
+    },
+    "ecs.aws.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "ecs.aws.upbound.io/TaskDefinition": {
+      "singular": "taskdefinition",
+      "plural": "taskdefinitions"
+    },
+    "efs.aws.m.upbound.io/AccessPoint": {
+      "singular": "accesspoint",
+      "plural": "accesspoints"
+    },
+    "efs.aws.m.upbound.io/BackupPolicy": {
+      "singular": "backuppolicy",
+      "plural": "backuppolicies"
+    },
+    "efs.aws.m.upbound.io/FileSystem": {
+      "singular": "filesystem",
+      "plural": "filesystems"
+    },
+    "efs.aws.m.upbound.io/FileSystemPolicy": {
+      "singular": "filesystempolicy",
+      "plural": "filesystempolicies"
+    },
+    "efs.aws.m.upbound.io/MountTarget": {
+      "singular": "mounttarget",
+      "plural": "mounttargets"
+    },
+    "efs.aws.m.upbound.io/ReplicationConfiguration": {
+      "singular": "replicationconfiguration",
+      "plural": "replicationconfigurations"
+    },
+    "efs.aws.upbound.io/AccessPoint": {
+      "singular": "accesspoint",
+      "plural": "accesspoints"
+    },
+    "efs.aws.upbound.io/BackupPolicy": {
+      "singular": "backuppolicy",
+      "plural": "backuppolicies"
+    },
+    "efs.aws.upbound.io/FileSystem": {
+      "singular": "filesystem",
+      "plural": "filesystems"
+    },
+    "efs.aws.upbound.io/FileSystemPolicy": {
+      "singular": "filesystempolicy",
+      "plural": "filesystempolicies"
+    },
+    "efs.aws.upbound.io/MountTarget": {
+      "singular": "mounttarget",
+      "plural": "mounttargets"
+    },
+    "efs.aws.upbound.io/ReplicationConfiguration": {
+      "singular": "replicationconfiguration",
+      "plural": "replicationconfigurations"
+    },
+    "eks.aws.m.upbound.io/AccessEntry": {
+      "singular": "accessentry",
+      "plural": "accessentries"
+    },
+    "eks.aws.m.upbound.io/AccessPolicyAssociation": {
+      "singular": "accesspolicyassociation",
+      "plural": "accesspolicyassociations"
+    },
+    "eks.aws.m.upbound.io/Addon": {
+      "singular": "addon",
+      "plural": "addons"
+    },
+    "eks.aws.m.upbound.io/Capability": {
+      "singular": "capability",
+      "plural": "capabilities"
+    },
+    "eks.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "eks.aws.m.upbound.io/ClusterAuth": {
+      "singular": "clusterauth",
+      "plural": "clusterauths"
+    },
+    "eks.aws.m.upbound.io/FargateProfile": {
+      "singular": "fargateprofile",
+      "plural": "fargateprofiles"
+    },
+    "eks.aws.m.upbound.io/IdentityProviderConfig": {
+      "singular": "identityproviderconfig",
+      "plural": "identityproviderconfigs"
+    },
+    "eks.aws.m.upbound.io/NodeGroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups"
+    },
+    "eks.aws.m.upbound.io/PodIdentityAssociation": {
+      "singular": "podidentityassociation",
+      "plural": "podidentityassociations"
+    },
+    "eks.aws.upbound.io/AccessEntry": {
+      "singular": "accessentry",
+      "plural": "accessentries"
+    },
+    "eks.aws.upbound.io/AccessPolicyAssociation": {
+      "singular": "accesspolicyassociation",
+      "plural": "accesspolicyassociations"
+    },
+    "eks.aws.upbound.io/Addon": {
+      "singular": "addon",
+      "plural": "addons"
+    },
+    "eks.aws.upbound.io/Capability": {
+      "singular": "capability",
+      "plural": "capabilities"
+    },
+    "eks.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "eks.aws.upbound.io/ClusterAuth": {
+      "singular": "clusterauth",
+      "plural": "clusterauths"
+    },
+    "eks.aws.upbound.io/FargateProfile": {
+      "singular": "fargateprofile",
+      "plural": "fargateprofiles"
+    },
+    "eks.aws.upbound.io/IdentityProviderConfig": {
+      "singular": "identityproviderconfig",
+      "plural": "identityproviderconfigs"
+    },
+    "eks.aws.upbound.io/NodeGroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups"
+    },
+    "eks.aws.upbound.io/PodIdentityAssociation": {
+      "singular": "podidentityassociation",
+      "plural": "podidentityassociations"
+    },
+    "elasticache.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "elasticache.aws.m.upbound.io/GlobalReplicationGroup": {
+      "singular": "globalreplicationgroup",
+      "plural": "globalreplicationgroups"
+    },
+    "elasticache.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "elasticache.aws.m.upbound.io/ReplicationGroup": {
+      "singular": "replicationgroup",
+      "plural": "replicationgroups"
+    },
+    "elasticache.aws.m.upbound.io/ServerlessCache": {
+      "singular": "serverlesscache",
+      "plural": "serverlesscaches"
+    },
+    "elasticache.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "elasticache.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "elasticache.aws.m.upbound.io/UserGroup": {
+      "singular": "usergroup",
+      "plural": "usergroups"
+    },
+    "elasticache.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "elasticache.aws.upbound.io/GlobalReplicationGroup": {
+      "singular": "globalreplicationgroup",
+      "plural": "globalreplicationgroups"
+    },
+    "elasticache.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "elasticache.aws.upbound.io/ReplicationGroup": {
+      "singular": "replicationgroup",
+      "plural": "replicationgroups"
+    },
+    "elasticache.aws.upbound.io/ServerlessCache": {
+      "singular": "serverlesscache",
+      "plural": "serverlesscaches"
+    },
+    "elasticache.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "elasticache.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "elasticache.aws.upbound.io/UserGroup": {
+      "singular": "usergroup",
+      "plural": "usergroups"
+    },
+    "elasticbeanstalk.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "elasticbeanstalk.aws.m.upbound.io/ApplicationVersion": {
+      "singular": "applicationversion",
+      "plural": "applicationversions"
+    },
+    "elasticbeanstalk.aws.m.upbound.io/ConfigurationTemplate": {
+      "singular": "configurationtemplate",
+      "plural": "configurationtemplates"
+    },
+    "elasticbeanstalk.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "elasticbeanstalk.aws.upbound.io/ApplicationVersion": {
+      "singular": "applicationversion",
+      "plural": "applicationversions"
+    },
+    "elasticbeanstalk.aws.upbound.io/ConfigurationTemplate": {
+      "singular": "configurationtemplate",
+      "plural": "configurationtemplates"
+    },
+    "elasticsearch.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "elasticsearch.aws.m.upbound.io/DomainPolicy": {
+      "singular": "domainpolicy",
+      "plural": "domainpolicies"
+    },
+    "elasticsearch.aws.m.upbound.io/DomainSAMLOptions": {
+      "singular": "domainsamloptions",
+      "plural": "domainsamloptions"
+    },
+    "elasticsearch.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "elasticsearch.aws.upbound.io/DomainPolicy": {
+      "singular": "domainpolicy",
+      "plural": "domainpolicies"
+    },
+    "elasticsearch.aws.upbound.io/DomainSAMLOptions": {
+      "singular": "domainsamloptions",
+      "plural": "domainsamloptions"
+    },
+    "elastictranscoder.aws.m.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "elastictranscoder.aws.m.upbound.io/Preset": {
+      "singular": "preset",
+      "plural": "presets"
+    },
+    "elastictranscoder.aws.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "elastictranscoder.aws.upbound.io/Preset": {
+      "singular": "preset",
+      "plural": "presets"
+    },
+    "elb.aws.m.upbound.io/AppCookieStickinessPolicy": {
+      "singular": "appcookiestickinesspolicy",
+      "plural": "appcookiestickinesspolicies"
+    },
+    "elb.aws.m.upbound.io/Attachment": {
+      "singular": "attachment",
+      "plural": "attachments"
+    },
+    "elb.aws.m.upbound.io/BackendServerPolicy": {
+      "singular": "backendserverpolicy",
+      "plural": "backendserverpolicies"
+    },
+    "elb.aws.m.upbound.io/ELB": {
+      "singular": "elb",
+      "plural": "elbs"
+    },
+    "elb.aws.m.upbound.io/LBCookieStickinessPolicy": {
+      "singular": "lbcookiestickinesspolicy",
+      "plural": "lbcookiestickinesspolicies"
+    },
+    "elb.aws.m.upbound.io/LBSSLNegotiationPolicy": {
+      "singular": "lbsslnegotiationpolicy",
+      "plural": "lbsslnegotiationpolicies"
+    },
+    "elb.aws.m.upbound.io/ListenerPolicy": {
+      "singular": "listenerpolicy",
+      "plural": "listenerpolicies"
+    },
+    "elb.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "elb.aws.m.upbound.io/ProxyProtocolPolicy": {
+      "singular": "proxyprotocolpolicy",
+      "plural": "proxyprotocolpolicies"
+    },
+    "elb.aws.upbound.io/AppCookieStickinessPolicy": {
+      "singular": "appcookiestickinesspolicy",
+      "plural": "appcookiestickinesspolicies"
+    },
+    "elb.aws.upbound.io/Attachment": {
+      "singular": "attachment",
+      "plural": "attachments"
+    },
+    "elb.aws.upbound.io/BackendServerPolicy": {
+      "singular": "backendserverpolicy",
+      "plural": "backendserverpolicies"
+    },
+    "elb.aws.upbound.io/ELB": {
+      "singular": "elb",
+      "plural": "elbs"
+    },
+    "elb.aws.upbound.io/LBCookieStickinessPolicy": {
+      "singular": "lbcookiestickinesspolicy",
+      "plural": "lbcookiestickinesspolicies"
+    },
+    "elb.aws.upbound.io/LBSSLNegotiationPolicy": {
+      "singular": "lbsslnegotiationpolicy",
+      "plural": "lbsslnegotiationpolicies"
+    },
+    "elb.aws.upbound.io/ListenerPolicy": {
+      "singular": "listenerpolicy",
+      "plural": "listenerpolicies"
+    },
+    "elb.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "elb.aws.upbound.io/ProxyProtocolPolicy": {
+      "singular": "proxyprotocolpolicy",
+      "plural": "proxyprotocolpolicies"
+    },
+    "elbv2.aws.m.upbound.io/LB": {
+      "singular": "lb",
+      "plural": "lbs"
+    },
+    "elbv2.aws.m.upbound.io/LBListener": {
+      "singular": "lblistener",
+      "plural": "lblisteners"
+    },
+    "elbv2.aws.m.upbound.io/LBListenerCertificate": {
+      "singular": "lblistenercertificate",
+      "plural": "lblistenercertificates"
+    },
+    "elbv2.aws.m.upbound.io/LBListenerRule": {
+      "singular": "lblistenerrule",
+      "plural": "lblistenerrules"
+    },
+    "elbv2.aws.m.upbound.io/LBTargetGroup": {
+      "singular": "lbtargetgroup",
+      "plural": "lbtargetgroups"
+    },
+    "elbv2.aws.m.upbound.io/LBTargetGroupAttachment": {
+      "singular": "lbtargetgroupattachment",
+      "plural": "lbtargetgroupattachments"
+    },
+    "elbv2.aws.m.upbound.io/LBTrustStore": {
+      "singular": "lbtruststore",
+      "plural": "lbtruststores"
+    },
+    "elbv2.aws.upbound.io/LB": {
+      "singular": "lb",
+      "plural": "lbs"
+    },
+    "elbv2.aws.upbound.io/LBListener": {
+      "singular": "lblistener",
+      "plural": "lblisteners"
+    },
+    "elbv2.aws.upbound.io/LBListenerCertificate": {
+      "singular": "lblistenercertificate",
+      "plural": "lblistenercertificates"
+    },
+    "elbv2.aws.upbound.io/LBListenerRule": {
+      "singular": "lblistenerrule",
+      "plural": "lblistenerrules"
+    },
+    "elbv2.aws.upbound.io/LBTargetGroup": {
+      "singular": "lbtargetgroup",
+      "plural": "lbtargetgroups"
+    },
+    "elbv2.aws.upbound.io/LBTargetGroupAttachment": {
+      "singular": "lbtargetgroupattachment",
+      "plural": "lbtargetgroupattachments"
+    },
+    "elbv2.aws.upbound.io/LBTrustStore": {
+      "singular": "lbtruststore",
+      "plural": "lbtruststores"
+    },
+    "emr.aws.m.upbound.io/SecurityConfiguration": {
+      "singular": "securityconfiguration",
+      "plural": "securityconfigurations"
+    },
+    "emr.aws.upbound.io/SecurityConfiguration": {
+      "singular": "securityconfiguration",
+      "plural": "securityconfigurations"
+    },
+    "emrcontainers.aws.m.upbound.io/VirtualCluster": {
+      "singular": "virtualcluster",
+      "plural": "virtualclusters"
+    },
+    "emrcontainers.aws.upbound.io/VirtualCluster": {
+      "singular": "virtualcluster",
+      "plural": "virtualclusters"
+    },
+    "emrserverless.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "emrserverless.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "evidently.aws.m.upbound.io/Feature": {
+      "singular": "feature",
+      "plural": "features"
+    },
+    "evidently.aws.m.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "evidently.aws.m.upbound.io/Segment": {
+      "singular": "segment",
+      "plural": "segments"
+    },
+    "evidently.aws.upbound.io/Feature": {
+      "singular": "feature",
+      "plural": "features"
+    },
+    "evidently.aws.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "evidently.aws.upbound.io/Segment": {
+      "singular": "segment",
+      "plural": "segments"
+    },
+    "firehose.aws.m.upbound.io/DeliveryStream": {
+      "singular": "deliverystream",
+      "plural": "deliverystreams"
+    },
+    "firehose.aws.upbound.io/DeliveryStream": {
+      "singular": "deliverystream",
+      "plural": "deliverystreams"
+    },
+    "fis.aws.m.upbound.io/ExperimentTemplate": {
+      "singular": "experimenttemplate",
+      "plural": "experimenttemplates"
+    },
+    "fis.aws.upbound.io/ExperimentTemplate": {
+      "singular": "experimenttemplate",
+      "plural": "experimenttemplates"
+    },
+    "fsx.aws.m.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "fsx.aws.m.upbound.io/DataRepositoryAssociation": {
+      "singular": "datarepositoryassociation",
+      "plural": "datarepositoryassociations"
+    },
+    "fsx.aws.m.upbound.io/LustreFileSystem": {
+      "singular": "lustrefilesystem",
+      "plural": "lustrefilesystems"
+    },
+    "fsx.aws.m.upbound.io/OntapFileSystem": {
+      "singular": "ontapfilesystem",
+      "plural": "ontapfilesystems"
+    },
+    "fsx.aws.m.upbound.io/OntapStorageVirtualMachine": {
+      "singular": "ontapstoragevirtualmachine",
+      "plural": "ontapstoragevirtualmachines"
+    },
+    "fsx.aws.m.upbound.io/WindowsFileSystem": {
+      "singular": "windowsfilesystem",
+      "plural": "windowsfilesystems"
+    },
+    "fsx.aws.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "fsx.aws.upbound.io/DataRepositoryAssociation": {
+      "singular": "datarepositoryassociation",
+      "plural": "datarepositoryassociations"
+    },
+    "fsx.aws.upbound.io/LustreFileSystem": {
+      "singular": "lustrefilesystem",
+      "plural": "lustrefilesystems"
+    },
+    "fsx.aws.upbound.io/OntapFileSystem": {
+      "singular": "ontapfilesystem",
+      "plural": "ontapfilesystems"
+    },
+    "fsx.aws.upbound.io/OntapStorageVirtualMachine": {
+      "singular": "ontapstoragevirtualmachine",
+      "plural": "ontapstoragevirtualmachines"
+    },
+    "fsx.aws.upbound.io/WindowsFileSystem": {
+      "singular": "windowsfilesystem",
+      "plural": "windowsfilesystems"
+    },
+    "gamelift.aws.m.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "gamelift.aws.m.upbound.io/Build": {
+      "singular": "build",
+      "plural": "builds"
+    },
+    "gamelift.aws.m.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleet"
+    },
+    "gamelift.aws.m.upbound.io/GameSessionQueue": {
+      "singular": "gamesessionqueue",
+      "plural": "gamesessionqueues"
+    },
+    "gamelift.aws.m.upbound.io/Script": {
+      "singular": "script",
+      "plural": "scripts"
+    },
+    "gamelift.aws.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "gamelift.aws.upbound.io/Build": {
+      "singular": "build",
+      "plural": "builds"
+    },
+    "gamelift.aws.upbound.io/Fleet": {
+      "singular": "fleet",
+      "plural": "fleet"
+    },
+    "gamelift.aws.upbound.io/GameSessionQueue": {
+      "singular": "gamesessionqueue",
+      "plural": "gamesessionqueues"
+    },
+    "gamelift.aws.upbound.io/Script": {
+      "singular": "script",
+      "plural": "scripts"
+    },
+    "glacier.aws.m.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "glacier.aws.m.upbound.io/VaultLock": {
+      "singular": "vaultlock",
+      "plural": "vaultlocks"
+    },
+    "glacier.aws.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "glacier.aws.upbound.io/VaultLock": {
+      "singular": "vaultlock",
+      "plural": "vaultlocks"
+    },
+    "globalaccelerator.aws.m.upbound.io/Accelerator": {
+      "singular": "accelerator",
+      "plural": "accelerators"
+    },
+    "globalaccelerator.aws.m.upbound.io/EndpointGroup": {
+      "singular": "endpointgroup",
+      "plural": "endpointgroups"
+    },
+    "globalaccelerator.aws.m.upbound.io/Listener": {
+      "singular": "listener",
+      "plural": "listeners"
+    },
+    "globalaccelerator.aws.upbound.io/Accelerator": {
+      "singular": "accelerator",
+      "plural": "accelerators"
+    },
+    "globalaccelerator.aws.upbound.io/EndpointGroup": {
+      "singular": "endpointgroup",
+      "plural": "endpointgroups"
+    },
+    "globalaccelerator.aws.upbound.io/Listener": {
+      "singular": "listener",
+      "plural": "listeners"
+    },
+    "glue.aws.m.upbound.io/CatalogDatabase": {
+      "singular": "catalogdatabase",
+      "plural": "catalogdatabases"
+    },
+    "glue.aws.m.upbound.io/CatalogTable": {
+      "singular": "catalogtable",
+      "plural": "catalogtables"
+    },
+    "glue.aws.m.upbound.io/CatalogTableOptimizer": {
+      "singular": "catalogtableoptimizer",
+      "plural": "catalogtableoptimizers"
+    },
+    "glue.aws.m.upbound.io/Classifier": {
+      "singular": "classifier",
+      "plural": "classifiers"
+    },
+    "glue.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "glue.aws.m.upbound.io/Crawler": {
+      "singular": "crawler",
+      "plural": "crawlers"
+    },
+    "glue.aws.m.upbound.io/DataCatalogEncryptionSettings": {
+      "singular": "datacatalogencryptionsettings",
+      "plural": "datacatalogencryptionsettings"
+    },
+    "glue.aws.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "glue.aws.m.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "glue.aws.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "glue.aws.m.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "glue.aws.m.upbound.io/SecurityConfiguration": {
+      "singular": "securityconfiguration",
+      "plural": "securityconfigurations"
+    },
+    "glue.aws.m.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "glue.aws.m.upbound.io/UserDefinedFunction": {
+      "singular": "userdefinedfunction",
+      "plural": "userdefinedfunctions"
+    },
+    "glue.aws.m.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    },
+    "glue.aws.upbound.io/CatalogDatabase": {
+      "singular": "catalogdatabase",
+      "plural": "catalogdatabases"
+    },
+    "glue.aws.upbound.io/CatalogTable": {
+      "singular": "catalogtable",
+      "plural": "catalogtables"
+    },
+    "glue.aws.upbound.io/CatalogTableOptimizer": {
+      "singular": "catalogtableoptimizer",
+      "plural": "catalogtableoptimizers"
+    },
+    "glue.aws.upbound.io/Classifier": {
+      "singular": "classifier",
+      "plural": "classifiers"
+    },
+    "glue.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "glue.aws.upbound.io/Crawler": {
+      "singular": "crawler",
+      "plural": "crawlers"
+    },
+    "glue.aws.upbound.io/DataCatalogEncryptionSettings": {
+      "singular": "datacatalogencryptionsettings",
+      "plural": "datacatalogencryptionsettings"
+    },
+    "glue.aws.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "glue.aws.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "glue.aws.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "glue.aws.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "glue.aws.upbound.io/SecurityConfiguration": {
+      "singular": "securityconfiguration",
+      "plural": "securityconfigurations"
+    },
+    "glue.aws.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "glue.aws.upbound.io/UserDefinedFunction": {
+      "singular": "userdefinedfunction",
+      "plural": "userdefinedfunctions"
+    },
+    "glue.aws.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    },
+    "grafana.aws.m.upbound.io/LicenseAssociation": {
+      "singular": "licenseassociation",
+      "plural": "licenseassociations"
+    },
+    "grafana.aws.m.upbound.io/RoleAssociation": {
+      "singular": "roleassociation",
+      "plural": "roleassociations"
+    },
+    "grafana.aws.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "grafana.aws.m.upbound.io/WorkspaceAPIKey": {
+      "singular": "workspaceapikey",
+      "plural": "workspaceapikeys"
+    },
+    "grafana.aws.m.upbound.io/WorkspaceSAMLConfiguration": {
+      "singular": "workspacesamlconfiguration",
+      "plural": "workspacesamlconfigurations"
+    },
+    "grafana.aws.upbound.io/LicenseAssociation": {
+      "singular": "licenseassociation",
+      "plural": "licenseassociations"
+    },
+    "grafana.aws.upbound.io/RoleAssociation": {
+      "singular": "roleassociation",
+      "plural": "roleassociations"
+    },
+    "grafana.aws.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "grafana.aws.upbound.io/WorkspaceAPIKey": {
+      "singular": "workspaceapikey",
+      "plural": "workspaceapikeys"
+    },
+    "grafana.aws.upbound.io/WorkspaceSAMLConfiguration": {
+      "singular": "workspacesamlconfiguration",
+      "plural": "workspacesamlconfigurations"
+    },
+    "guardduty.aws.m.upbound.io/Detector": {
+      "singular": "detector",
+      "plural": "detectors"
+    },
+    "guardduty.aws.m.upbound.io/Filter": {
+      "singular": "filter",
+      "plural": "filters"
+    },
+    "guardduty.aws.m.upbound.io/MalwareProtectionPlan": {
+      "singular": "malwareprotectionplan",
+      "plural": "malwareprotectionplans"
+    },
+    "guardduty.aws.m.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "guardduty.aws.upbound.io/Detector": {
+      "singular": "detector",
+      "plural": "detectors"
+    },
+    "guardduty.aws.upbound.io/Filter": {
+      "singular": "filter",
+      "plural": "filters"
+    },
+    "guardduty.aws.upbound.io/MalwareProtectionPlan": {
+      "singular": "malwareprotectionplan",
+      "plural": "malwareprotectionplans"
+    },
+    "guardduty.aws.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "iam.aws.m.upbound.io/AccessKey": {
+      "singular": "accesskey",
+      "plural": "accesskeys"
+    },
+    "iam.aws.m.upbound.io/AccountAlias": {
+      "singular": "accountalias",
+      "plural": "accountaliases"
+    },
+    "iam.aws.m.upbound.io/AccountPasswordPolicy": {
+      "singular": "accountpasswordpolicy",
+      "plural": "accountpasswordpolicies"
+    },
+    "iam.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "iam.aws.m.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "iam.aws.m.upbound.io/GroupPolicyAttachment": {
+      "singular": "grouppolicyattachment",
+      "plural": "grouppolicyattachments"
+    },
+    "iam.aws.m.upbound.io/InstanceProfile": {
+      "singular": "instanceprofile",
+      "plural": "instanceprofiles"
+    },
+    "iam.aws.m.upbound.io/OpenIDConnectProvider": {
+      "singular": "openidconnectprovider",
+      "plural": "openidconnectproviders"
+    },
+    "iam.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "iam.aws.m.upbound.io/Role": {
+      "singular": "role",
+      "plural": "roles"
+    },
+    "iam.aws.m.upbound.io/RolePolicy": {
+      "singular": "rolepolicy",
+      "plural": "rolepolicies"
+    },
+    "iam.aws.m.upbound.io/RolePolicyAttachment": {
+      "singular": "rolepolicyattachment",
+      "plural": "rolepolicyattachments"
+    },
+    "iam.aws.m.upbound.io/SAMLProvider": {
+      "singular": "samlprovider",
+      "plural": "samlproviders"
+    },
+    "iam.aws.m.upbound.io/ServerCertificate": {
+      "singular": "servercertificate",
+      "plural": "servercertificates"
+    },
+    "iam.aws.m.upbound.io/ServiceLinkedRole": {
+      "singular": "servicelinkedrole",
+      "plural": "servicelinkedroles"
+    },
+    "iam.aws.m.upbound.io/ServiceSpecificCredential": {
+      "singular": "servicespecificcredential",
+      "plural": "servicespecificcredentials"
+    },
+    "iam.aws.m.upbound.io/SigningCertificate": {
+      "singular": "signingcertificate",
+      "plural": "signingcertificates"
+    },
+    "iam.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "iam.aws.m.upbound.io/UserGroupMembership": {
+      "singular": "usergroupmembership",
+      "plural": "usergroupmemberships"
+    },
+    "iam.aws.m.upbound.io/UserLoginProfile": {
+      "singular": "userloginprofile",
+      "plural": "userloginprofiles"
+    },
+    "iam.aws.m.upbound.io/UserPolicyAttachment": {
+      "singular": "userpolicyattachment",
+      "plural": "userpolicyattachments"
+    },
+    "iam.aws.m.upbound.io/UserSSHKey": {
+      "singular": "usersshkey",
+      "plural": "usersshkeys"
+    },
+    "iam.aws.m.upbound.io/VirtualMfaDevice": {
+      "singular": "virtualmfadevice",
+      "plural": "virtualmfadevices"
+    },
+    "iam.aws.upbound.io/AccessKey": {
+      "singular": "accesskey",
+      "plural": "accesskeys"
+    },
+    "iam.aws.upbound.io/AccountAlias": {
+      "singular": "accountalias",
+      "plural": "accountaliases"
+    },
+    "iam.aws.upbound.io/AccountPasswordPolicy": {
+      "singular": "accountpasswordpolicy",
+      "plural": "accountpasswordpolicies"
+    },
+    "iam.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "iam.aws.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "iam.aws.upbound.io/GroupPolicyAttachment": {
+      "singular": "grouppolicyattachment",
+      "plural": "grouppolicyattachments"
+    },
+    "iam.aws.upbound.io/InstanceProfile": {
+      "singular": "instanceprofile",
+      "plural": "instanceprofiles"
+    },
+    "iam.aws.upbound.io/OpenIDConnectProvider": {
+      "singular": "openidconnectprovider",
+      "plural": "openidconnectproviders"
+    },
+    "iam.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "iam.aws.upbound.io/Role": {
+      "singular": "role",
+      "plural": "roles"
+    },
+    "iam.aws.upbound.io/RolePolicy": {
+      "singular": "rolepolicy",
+      "plural": "rolepolicies"
+    },
+    "iam.aws.upbound.io/RolePolicyAttachment": {
+      "singular": "rolepolicyattachment",
+      "plural": "rolepolicyattachments"
+    },
+    "iam.aws.upbound.io/SAMLProvider": {
+      "singular": "samlprovider",
+      "plural": "samlproviders"
+    },
+    "iam.aws.upbound.io/ServerCertificate": {
+      "singular": "servercertificate",
+      "plural": "servercertificates"
+    },
+    "iam.aws.upbound.io/ServiceLinkedRole": {
+      "singular": "servicelinkedrole",
+      "plural": "servicelinkedroles"
+    },
+    "iam.aws.upbound.io/ServiceSpecificCredential": {
+      "singular": "servicespecificcredential",
+      "plural": "servicespecificcredentials"
+    },
+    "iam.aws.upbound.io/SigningCertificate": {
+      "singular": "signingcertificate",
+      "plural": "signingcertificates"
+    },
+    "iam.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "iam.aws.upbound.io/UserGroupMembership": {
+      "singular": "usergroupmembership",
+      "plural": "usergroupmemberships"
+    },
+    "iam.aws.upbound.io/UserLoginProfile": {
+      "singular": "userloginprofile",
+      "plural": "userloginprofiles"
+    },
+    "iam.aws.upbound.io/UserPolicyAttachment": {
+      "singular": "userpolicyattachment",
+      "plural": "userpolicyattachments"
+    },
+    "iam.aws.upbound.io/UserSSHKey": {
+      "singular": "usersshkey",
+      "plural": "usersshkeys"
+    },
+    "iam.aws.upbound.io/VirtualMfaDevice": {
+      "singular": "virtualmfadevice",
+      "plural": "virtualmfadevices"
+    },
+    "identitystore.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "identitystore.aws.m.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "identitystore.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "identitystore.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "identitystore.aws.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "identitystore.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "imagebuilder.aws.m.upbound.io/Component": {
+      "singular": "component",
+      "plural": "components"
+    },
+    "imagebuilder.aws.m.upbound.io/ContainerRecipe": {
+      "singular": "containerrecipe",
+      "plural": "containerrecipes"
+    },
+    "imagebuilder.aws.m.upbound.io/DistributionConfiguration": {
+      "singular": "distributionconfiguration",
+      "plural": "distributionconfigurations"
+    },
+    "imagebuilder.aws.m.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "imagebuilder.aws.m.upbound.io/ImagePipeline": {
+      "singular": "imagepipeline",
+      "plural": "imagepipelines"
+    },
+    "imagebuilder.aws.m.upbound.io/ImageRecipe": {
+      "singular": "imagerecipe",
+      "plural": "imagerecipes"
+    },
+    "imagebuilder.aws.m.upbound.io/InfrastructureConfiguration": {
+      "singular": "infrastructureconfiguration",
+      "plural": "infrastructureconfigurations"
+    },
+    "imagebuilder.aws.upbound.io/Component": {
+      "singular": "component",
+      "plural": "components"
+    },
+    "imagebuilder.aws.upbound.io/ContainerRecipe": {
+      "singular": "containerrecipe",
+      "plural": "containerrecipes"
+    },
+    "imagebuilder.aws.upbound.io/DistributionConfiguration": {
+      "singular": "distributionconfiguration",
+      "plural": "distributionconfigurations"
+    },
+    "imagebuilder.aws.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "imagebuilder.aws.upbound.io/ImagePipeline": {
+      "singular": "imagepipeline",
+      "plural": "imagepipelines"
+    },
+    "imagebuilder.aws.upbound.io/ImageRecipe": {
+      "singular": "imagerecipe",
+      "plural": "imagerecipes"
+    },
+    "imagebuilder.aws.upbound.io/InfrastructureConfiguration": {
+      "singular": "infrastructureconfiguration",
+      "plural": "infrastructureconfigurations"
+    },
+    "inspector.aws.m.upbound.io/AssessmentTarget": {
+      "singular": "assessmenttarget",
+      "plural": "assessmenttargets"
+    },
+    "inspector.aws.m.upbound.io/AssessmentTemplate": {
+      "singular": "assessmenttemplate",
+      "plural": "assessmenttemplates"
+    },
+    "inspector.aws.m.upbound.io/ResourceGroup": {
+      "singular": "resourcegroup",
+      "plural": "resourcegroups"
+    },
+    "inspector.aws.upbound.io/AssessmentTarget": {
+      "singular": "assessmenttarget",
+      "plural": "assessmenttargets"
+    },
+    "inspector.aws.upbound.io/AssessmentTemplate": {
+      "singular": "assessmenttemplate",
+      "plural": "assessmenttemplates"
+    },
+    "inspector.aws.upbound.io/ResourceGroup": {
+      "singular": "resourcegroup",
+      "plural": "resourcegroups"
+    },
+    "inspector2.aws.m.upbound.io/Enabler": {
+      "singular": "enabler",
+      "plural": "enablers"
+    },
+    "inspector2.aws.upbound.io/Enabler": {
+      "singular": "enabler",
+      "plural": "enablers"
+    },
+    "iot.aws.m.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "iot.aws.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "iot.aws.m.upbound.io/DomainConfiguration": {
+      "singular": "domainconfiguration",
+      "plural": "domainconfigurations"
+    },
+    "iot.aws.m.upbound.io/IndexingConfiguration": {
+      "singular": "indexingconfiguration",
+      "plural": "indexingconfigurations"
+    },
+    "iot.aws.m.upbound.io/LoggingOptions": {
+      "singular": "loggingoptions",
+      "plural": "loggingoptions"
+    },
+    "iot.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "iot.aws.m.upbound.io/PolicyAttachment": {
+      "singular": "policyattachment",
+      "plural": "policyattachments"
+    },
+    "iot.aws.m.upbound.io/ProvisioningTemplate": {
+      "singular": "provisioningtemplate",
+      "plural": "provisioningtemplates"
+    },
+    "iot.aws.m.upbound.io/RoleAlias": {
+      "singular": "rolealias",
+      "plural": "rolealiases"
+    },
+    "iot.aws.m.upbound.io/Thing": {
+      "singular": "thing",
+      "plural": "things"
+    },
+    "iot.aws.m.upbound.io/ThingGroup": {
+      "singular": "thinggroup",
+      "plural": "thinggroups"
+    },
+    "iot.aws.m.upbound.io/ThingGroupMembership": {
+      "singular": "thinggroupmembership",
+      "plural": "thinggroupmemberships"
+    },
+    "iot.aws.m.upbound.io/ThingPrincipalAttachment": {
+      "singular": "thingprincipalattachment",
+      "plural": "thingprincipalattachments"
+    },
+    "iot.aws.m.upbound.io/ThingType": {
+      "singular": "thingtype",
+      "plural": "thingtypes"
+    },
+    "iot.aws.m.upbound.io/TopicRule": {
+      "singular": "topicrule",
+      "plural": "topicrules"
+    },
+    "iot.aws.m.upbound.io/TopicRuleDestination": {
+      "singular": "topicruledestination",
+      "plural": "topicruledestinations"
+    },
+    "iot.aws.upbound.io/Authorizer": {
+      "singular": "authorizer",
+      "plural": "authorizers"
+    },
+    "iot.aws.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "iot.aws.upbound.io/DomainConfiguration": {
+      "singular": "domainconfiguration",
+      "plural": "domainconfigurations"
+    },
+    "iot.aws.upbound.io/IndexingConfiguration": {
+      "singular": "indexingconfiguration",
+      "plural": "indexingconfigurations"
+    },
+    "iot.aws.upbound.io/LoggingOptions": {
+      "singular": "loggingoptions",
+      "plural": "loggingoptions"
+    },
+    "iot.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "iot.aws.upbound.io/PolicyAttachment": {
+      "singular": "policyattachment",
+      "plural": "policyattachments"
+    },
+    "iot.aws.upbound.io/ProvisioningTemplate": {
+      "singular": "provisioningtemplate",
+      "plural": "provisioningtemplates"
+    },
+    "iot.aws.upbound.io/RoleAlias": {
+      "singular": "rolealias",
+      "plural": "rolealiases"
+    },
+    "iot.aws.upbound.io/Thing": {
+      "singular": "thing",
+      "plural": "things"
+    },
+    "iot.aws.upbound.io/ThingGroup": {
+      "singular": "thinggroup",
+      "plural": "thinggroups"
+    },
+    "iot.aws.upbound.io/ThingGroupMembership": {
+      "singular": "thinggroupmembership",
+      "plural": "thinggroupmemberships"
+    },
+    "iot.aws.upbound.io/ThingPrincipalAttachment": {
+      "singular": "thingprincipalattachment",
+      "plural": "thingprincipalattachments"
+    },
+    "iot.aws.upbound.io/ThingType": {
+      "singular": "thingtype",
+      "plural": "thingtypes"
+    },
+    "iot.aws.upbound.io/TopicRule": {
+      "singular": "topicrule",
+      "plural": "topicrules"
+    },
+    "iot.aws.upbound.io/TopicRuleDestination": {
+      "singular": "topicruledestination",
+      "plural": "topicruledestinations"
+    },
+    "ivs.aws.m.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "ivs.aws.m.upbound.io/RecordingConfiguration": {
+      "singular": "recordingconfiguration",
+      "plural": "recordingconfigurations"
+    },
+    "ivs.aws.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "ivs.aws.upbound.io/RecordingConfiguration": {
+      "singular": "recordingconfiguration",
+      "plural": "recordingconfigurations"
+    },
+    "kafka.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "kafka.aws.m.upbound.io/ClusterPolicy": {
+      "singular": "clusterpolicy",
+      "plural": "clusterpolicies"
+    },
+    "kafka.aws.m.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "kafka.aws.m.upbound.io/Replicator": {
+      "singular": "replicator",
+      "plural": "replicators"
+    },
+    "kafka.aws.m.upbound.io/ScramSecretAssociation": {
+      "singular": "scramsecretassociation",
+      "plural": "scramsecretassociations"
+    },
+    "kafka.aws.m.upbound.io/ServerlessCluster": {
+      "singular": "serverlesscluster",
+      "plural": "serverlessclusters"
+    },
+    "kafka.aws.m.upbound.io/SingleScramSecretAssociation": {
+      "singular": "singlescramsecretassociation",
+      "plural": "singlescramsecretassociations"
+    },
+    "kafka.aws.m.upbound.io/VPCConnection": {
+      "singular": "vpcconnection",
+      "plural": "vpcconnections"
+    },
+    "kafka.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "kafka.aws.upbound.io/ClusterPolicy": {
+      "singular": "clusterpolicy",
+      "plural": "clusterpolicies"
+    },
+    "kafka.aws.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "kafka.aws.upbound.io/Replicator": {
+      "singular": "replicator",
+      "plural": "replicators"
+    },
+    "kafka.aws.upbound.io/ScramSecretAssociation": {
+      "singular": "scramsecretassociation",
+      "plural": "scramsecretassociations"
+    },
+    "kafka.aws.upbound.io/ServerlessCluster": {
+      "singular": "serverlesscluster",
+      "plural": "serverlessclusters"
+    },
+    "kafka.aws.upbound.io/SingleScramSecretAssociation": {
+      "singular": "singlescramsecretassociation",
+      "plural": "singlescramsecretassociations"
+    },
+    "kafka.aws.upbound.io/VPCConnection": {
+      "singular": "vpcconnection",
+      "plural": "vpcconnections"
+    },
+    "kafkaconnect.aws.m.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "kafkaconnect.aws.m.upbound.io/CustomPlugin": {
+      "singular": "customplugin",
+      "plural": "customplugins"
+    },
+    "kafkaconnect.aws.m.upbound.io/WorkerConfiguration": {
+      "singular": "workerconfiguration",
+      "plural": "workerconfigurations"
+    },
+    "kafkaconnect.aws.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "kafkaconnect.aws.upbound.io/CustomPlugin": {
+      "singular": "customplugin",
+      "plural": "customplugins"
+    },
+    "kafkaconnect.aws.upbound.io/WorkerConfiguration": {
+      "singular": "workerconfiguration",
+      "plural": "workerconfigurations"
+    },
+    "kendra.aws.m.upbound.io/DataSource": {
+      "singular": "datasource",
+      "plural": "datasources"
+    },
+    "kendra.aws.m.upbound.io/Experience": {
+      "singular": "experience",
+      "plural": "experiences"
+    },
+    "kendra.aws.m.upbound.io/Index": {
+      "singular": "index",
+      "plural": "indices"
+    },
+    "kendra.aws.m.upbound.io/QuerySuggestionsBlockList": {
+      "singular": "querysuggestionsblocklist",
+      "plural": "querysuggestionsblocklists"
+    },
+    "kendra.aws.m.upbound.io/Thesaurus": {
+      "singular": "thesaurus",
+      "plural": "thesaurus"
+    },
+    "kendra.aws.upbound.io/DataSource": {
+      "singular": "datasource",
+      "plural": "datasources"
+    },
+    "kendra.aws.upbound.io/Experience": {
+      "singular": "experience",
+      "plural": "experiences"
+    },
+    "kendra.aws.upbound.io/Index": {
+      "singular": "index",
+      "plural": "indices"
+    },
+    "kendra.aws.upbound.io/QuerySuggestionsBlockList": {
+      "singular": "querysuggestionsblocklist",
+      "plural": "querysuggestionsblocklists"
+    },
+    "kendra.aws.upbound.io/Thesaurus": {
+      "singular": "thesaurus",
+      "plural": "thesaurus"
+    },
+    "keyspaces.aws.m.upbound.io/Keyspace": {
+      "singular": "keyspace",
+      "plural": "keyspaces"
+    },
+    "keyspaces.aws.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "keyspaces.aws.upbound.io/Keyspace": {
+      "singular": "keyspace",
+      "plural": "keyspaces"
+    },
+    "keyspaces.aws.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "kinesis.aws.m.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "kinesis.aws.m.upbound.io/StreamConsumer": {
+      "singular": "streamconsumer",
+      "plural": "streamconsumers"
+    },
+    "kinesis.aws.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "kinesis.aws.upbound.io/StreamConsumer": {
+      "singular": "streamconsumer",
+      "plural": "streamconsumers"
+    },
+    "kinesisanalytics.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "kinesisanalytics.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "kinesisanalyticsv2.aws.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "kinesisanalyticsv2.aws.m.upbound.io/ApplicationSnapshot": {
+      "singular": "applicationsnapshot",
+      "plural": "applicationsnapshots"
+    },
+    "kinesisanalyticsv2.aws.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "kinesisanalyticsv2.aws.upbound.io/ApplicationSnapshot": {
+      "singular": "applicationsnapshot",
+      "plural": "applicationsnapshots"
+    },
+    "kinesisvideo.aws.m.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "kinesisvideo.aws.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "kms.aws.m.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "kms.aws.m.upbound.io/Ciphertext": {
+      "singular": "ciphertext",
+      "plural": "ciphertexts"
+    },
+    "kms.aws.m.upbound.io/ExternalKey": {
+      "singular": "externalkey",
+      "plural": "externalkeys"
+    },
+    "kms.aws.m.upbound.io/Grant": {
+      "singular": "grant",
+      "plural": "grants"
+    },
+    "kms.aws.m.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "kms.aws.m.upbound.io/ReplicaExternalKey": {
+      "singular": "replicaexternalkey",
+      "plural": "replicaexternalkeys"
+    },
+    "kms.aws.m.upbound.io/ReplicaKey": {
+      "singular": "replicakey",
+      "plural": "replicakeys"
+    },
+    "kms.aws.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "kms.aws.upbound.io/Ciphertext": {
+      "singular": "ciphertext",
+      "plural": "ciphertexts"
+    },
+    "kms.aws.upbound.io/ExternalKey": {
+      "singular": "externalkey",
+      "plural": "externalkeys"
+    },
+    "kms.aws.upbound.io/Grant": {
+      "singular": "grant",
+      "plural": "grants"
+    },
+    "kms.aws.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "kms.aws.upbound.io/ReplicaExternalKey": {
+      "singular": "replicaexternalkey",
+      "plural": "replicaexternalkeys"
+    },
+    "kms.aws.upbound.io/ReplicaKey": {
+      "singular": "replicakey",
+      "plural": "replicakeys"
+    },
+    "lakeformation.aws.m.upbound.io/DataLakeSettings": {
+      "singular": "datalakesettings",
+      "plural": "datalakesettings"
+    },
+    "lakeformation.aws.m.upbound.io/Permissions": {
+      "singular": "permissions",
+      "plural": "permissions"
+    },
+    "lakeformation.aws.m.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "lakeformation.aws.upbound.io/DataLakeSettings": {
+      "singular": "datalakesettings",
+      "plural": "datalakesettings"
+    },
+    "lakeformation.aws.upbound.io/Permissions": {
+      "singular": "permissions",
+      "plural": "permissions"
+    },
+    "lakeformation.aws.upbound.io/Resource": {
+      "singular": "resource",
+      "plural": "resources"
+    },
+    "lambda.aws.m.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "lambda.aws.m.upbound.io/CodeSigningConfig": {
+      "singular": "codesigningconfig",
+      "plural": "codesigningconfigs"
+    },
+    "lambda.aws.m.upbound.io/EventSourceMapping": {
+      "singular": "eventsourcemapping",
+      "plural": "eventsourcemappings"
+    },
+    "lambda.aws.m.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "lambda.aws.m.upbound.io/FunctionEventInvokeConfig": {
+      "singular": "functioneventinvokeconfig",
+      "plural": "functioneventinvokeconfigs"
+    },
+    "lambda.aws.m.upbound.io/FunctionURL": {
+      "singular": "functionurl",
+      "plural": "functionurls"
+    },
+    "lambda.aws.m.upbound.io/Invocation": {
+      "singular": "invocation",
+      "plural": "invocations"
+    },
+    "lambda.aws.m.upbound.io/LayerVersion": {
+      "singular": "layerversion",
+      "plural": "layerversions"
+    },
+    "lambda.aws.m.upbound.io/LayerVersionPermission": {
+      "singular": "layerversionpermission",
+      "plural": "layerversionpermissions"
+    },
+    "lambda.aws.m.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "lambda.aws.m.upbound.io/ProvisionedConcurrencyConfig": {
+      "singular": "provisionedconcurrencyconfig",
+      "plural": "provisionedconcurrencyconfigs"
+    },
+    "lambda.aws.upbound.io/Alias": {
+      "singular": "alias",
+      "plural": "aliases"
+    },
+    "lambda.aws.upbound.io/CodeSigningConfig": {
+      "singular": "codesigningconfig",
+      "plural": "codesigningconfigs"
+    },
+    "lambda.aws.upbound.io/EventSourceMapping": {
+      "singular": "eventsourcemapping",
+      "plural": "eventsourcemappings"
+    },
+    "lambda.aws.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "lambda.aws.upbound.io/FunctionEventInvokeConfig": {
+      "singular": "functioneventinvokeconfig",
+      "plural": "functioneventinvokeconfigs"
+    },
+    "lambda.aws.upbound.io/FunctionURL": {
+      "singular": "functionurl",
+      "plural": "functionurls"
+    },
+    "lambda.aws.upbound.io/Invocation": {
+      "singular": "invocation",
+      "plural": "invocations"
+    },
+    "lambda.aws.upbound.io/LayerVersion": {
+      "singular": "layerversion",
+      "plural": "layerversions"
+    },
+    "lambda.aws.upbound.io/LayerVersionPermission": {
+      "singular": "layerversionpermission",
+      "plural": "layerversionpermissions"
+    },
+    "lambda.aws.upbound.io/Permission": {
+      "singular": "permission",
+      "plural": "permissions"
+    },
+    "lambda.aws.upbound.io/ProvisionedConcurrencyConfig": {
+      "singular": "provisionedconcurrencyconfig",
+      "plural": "provisionedconcurrencyconfigs"
+    },
+    "lexmodels.aws.m.upbound.io/Bot": {
+      "singular": "bot",
+      "plural": "bots"
+    },
+    "lexmodels.aws.m.upbound.io/BotAlias": {
+      "singular": "botalias",
+      "plural": "botaliases"
+    },
+    "lexmodels.aws.m.upbound.io/Intent": {
+      "singular": "intent",
+      "plural": "intents"
+    },
+    "lexmodels.aws.m.upbound.io/SlotType": {
+      "singular": "slottype",
+      "plural": "slottypes"
+    },
+    "lexmodels.aws.upbound.io/Bot": {
+      "singular": "bot",
+      "plural": "bots"
+    },
+    "lexmodels.aws.upbound.io/BotAlias": {
+      "singular": "botalias",
+      "plural": "botaliases"
+    },
+    "lexmodels.aws.upbound.io/Intent": {
+      "singular": "intent",
+      "plural": "intents"
+    },
+    "lexmodels.aws.upbound.io/SlotType": {
+      "singular": "slottype",
+      "plural": "slottypes"
+    },
+    "licensemanager.aws.m.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "licensemanager.aws.m.upbound.io/LicenseConfiguration": {
+      "singular": "licenseconfiguration",
+      "plural": "licenseconfigurations"
+    },
+    "licensemanager.aws.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "licensemanager.aws.upbound.io/LicenseConfiguration": {
+      "singular": "licenseconfiguration",
+      "plural": "licenseconfigurations"
+    },
+    "lightsail.aws.m.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "lightsail.aws.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "lightsail.aws.m.upbound.io/ContainerService": {
+      "singular": "containerservice",
+      "plural": "containerservices"
+    },
+    "lightsail.aws.m.upbound.io/Disk": {
+      "singular": "disk",
+      "plural": "disks"
+    },
+    "lightsail.aws.m.upbound.io/DiskAttachment": {
+      "singular": "diskattachment",
+      "plural": "diskattachments"
+    },
+    "lightsail.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "lightsail.aws.m.upbound.io/DomainEntry": {
+      "singular": "domainentry",
+      "plural": "domainentries"
+    },
+    "lightsail.aws.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "lightsail.aws.m.upbound.io/InstancePublicPorts": {
+      "singular": "instancepublicports",
+      "plural": "instancepublicports"
+    },
+    "lightsail.aws.m.upbound.io/KeyPair": {
+      "singular": "keypair",
+      "plural": "keypairs"
+    },
+    "lightsail.aws.m.upbound.io/LB": {
+      "singular": "lb",
+      "plural": "lbs"
+    },
+    "lightsail.aws.m.upbound.io/LBAttachment": {
+      "singular": "lbattachment",
+      "plural": "lbattachments"
+    },
+    "lightsail.aws.m.upbound.io/LBCertificate": {
+      "singular": "lbcertificate",
+      "plural": "lbcertificates"
+    },
+    "lightsail.aws.m.upbound.io/LBStickinessPolicy": {
+      "singular": "lbstickinesspolicy",
+      "plural": "lbstickinesspolicies"
+    },
+    "lightsail.aws.m.upbound.io/StaticIP": {
+      "singular": "staticip",
+      "plural": "staticips"
+    },
+    "lightsail.aws.m.upbound.io/StaticIPAttachment": {
+      "singular": "staticipattachment",
+      "plural": "staticipattachments"
+    },
+    "lightsail.aws.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "lightsail.aws.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "lightsail.aws.upbound.io/ContainerService": {
+      "singular": "containerservice",
+      "plural": "containerservices"
+    },
+    "lightsail.aws.upbound.io/Disk": {
+      "singular": "disk",
+      "plural": "disks"
+    },
+    "lightsail.aws.upbound.io/DiskAttachment": {
+      "singular": "diskattachment",
+      "plural": "diskattachments"
+    },
+    "lightsail.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "lightsail.aws.upbound.io/DomainEntry": {
+      "singular": "domainentry",
+      "plural": "domainentries"
+    },
+    "lightsail.aws.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "lightsail.aws.upbound.io/InstancePublicPorts": {
+      "singular": "instancepublicports",
+      "plural": "instancepublicports"
+    },
+    "lightsail.aws.upbound.io/KeyPair": {
+      "singular": "keypair",
+      "plural": "keypairs"
+    },
+    "lightsail.aws.upbound.io/LB": {
+      "singular": "lb",
+      "plural": "lbs"
+    },
+    "lightsail.aws.upbound.io/LBAttachment": {
+      "singular": "lbattachment",
+      "plural": "lbattachments"
+    },
+    "lightsail.aws.upbound.io/LBCertificate": {
+      "singular": "lbcertificate",
+      "plural": "lbcertificates"
+    },
+    "lightsail.aws.upbound.io/LBStickinessPolicy": {
+      "singular": "lbstickinesspolicy",
+      "plural": "lbstickinesspolicies"
+    },
+    "lightsail.aws.upbound.io/StaticIP": {
+      "singular": "staticip",
+      "plural": "staticips"
+    },
+    "lightsail.aws.upbound.io/StaticIPAttachment": {
+      "singular": "staticipattachment",
+      "plural": "staticipattachments"
+    },
+    "location.aws.m.upbound.io/GeofenceCollection": {
+      "singular": "geofencecollection",
+      "plural": "geofencecollections"
+    },
+    "location.aws.m.upbound.io/PlaceIndex": {
+      "singular": "placeindex",
+      "plural": "placeindices"
+    },
+    "location.aws.m.upbound.io/RouteCalculator": {
+      "singular": "routecalculator",
+      "plural": "routecalculators"
+    },
+    "location.aws.m.upbound.io/Tracker": {
+      "singular": "tracker",
+      "plural": "trackers"
+    },
+    "location.aws.m.upbound.io/TrackerAssociation": {
+      "singular": "trackerassociation",
+      "plural": "trackerassociations"
+    },
+    "location.aws.upbound.io/GeofenceCollection": {
+      "singular": "geofencecollection",
+      "plural": "geofencecollections"
+    },
+    "location.aws.upbound.io/PlaceIndex": {
+      "singular": "placeindex",
+      "plural": "placeindices"
+    },
+    "location.aws.upbound.io/RouteCalculator": {
+      "singular": "routecalculator",
+      "plural": "routecalculators"
+    },
+    "location.aws.upbound.io/Tracker": {
+      "singular": "tracker",
+      "plural": "trackers"
+    },
+    "location.aws.upbound.io/TrackerAssociation": {
+      "singular": "trackerassociation",
+      "plural": "trackerassociations"
+    },
+    "macie2.aws.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "macie2.aws.m.upbound.io/ClassificationJob": {
+      "singular": "classificationjob",
+      "plural": "classificationjobs"
+    },
+    "macie2.aws.m.upbound.io/CustomDataIdentifier": {
+      "singular": "customdataidentifier",
+      "plural": "customdataidentifiers"
+    },
+    "macie2.aws.m.upbound.io/FindingsFilter": {
+      "singular": "findingsfilter",
+      "plural": "findingsfilters"
+    },
+    "macie2.aws.m.upbound.io/InvitationAccepter": {
+      "singular": "invitationaccepter",
+      "plural": "invitationaccepters"
+    },
+    "macie2.aws.m.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "macie2.aws.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "macie2.aws.upbound.io/ClassificationJob": {
+      "singular": "classificationjob",
+      "plural": "classificationjobs"
+    },
+    "macie2.aws.upbound.io/CustomDataIdentifier": {
+      "singular": "customdataidentifier",
+      "plural": "customdataidentifiers"
+    },
+    "macie2.aws.upbound.io/FindingsFilter": {
+      "singular": "findingsfilter",
+      "plural": "findingsfilters"
+    },
+    "macie2.aws.upbound.io/InvitationAccepter": {
+      "singular": "invitationaccepter",
+      "plural": "invitationaccepters"
+    },
+    "macie2.aws.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "mediaconvert.aws.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "mediaconvert.aws.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "medialive.aws.m.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "medialive.aws.m.upbound.io/Input": {
+      "singular": "input",
+      "plural": "inputs"
+    },
+    "medialive.aws.m.upbound.io/InputSecurityGroup": {
+      "singular": "inputsecuritygroup",
+      "plural": "inputsecuritygroups"
+    },
+    "medialive.aws.m.upbound.io/Multiplex": {
+      "singular": "multiplex",
+      "plural": "multiplices"
+    },
+    "medialive.aws.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "medialive.aws.upbound.io/Input": {
+      "singular": "input",
+      "plural": "inputs"
+    },
+    "medialive.aws.upbound.io/InputSecurityGroup": {
+      "singular": "inputsecuritygroup",
+      "plural": "inputsecuritygroups"
+    },
+    "medialive.aws.upbound.io/Multiplex": {
+      "singular": "multiplex",
+      "plural": "multiplices"
+    },
+    "mediapackage.aws.m.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "mediapackage.aws.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "mediastore.aws.m.upbound.io/Container": {
+      "singular": "container",
+      "plural": "containers"
+    },
+    "mediastore.aws.m.upbound.io/ContainerPolicy": {
+      "singular": "containerpolicy",
+      "plural": "containerpolicies"
+    },
+    "mediastore.aws.upbound.io/Container": {
+      "singular": "container",
+      "plural": "containers"
+    },
+    "mediastore.aws.upbound.io/ContainerPolicy": {
+      "singular": "containerpolicy",
+      "plural": "containerpolicies"
+    },
+    "memorydb.aws.m.upbound.io/ACL": {
+      "singular": "acl",
+      "plural": "acls"
+    },
+    "memorydb.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "memorydb.aws.m.upbound.io/MultiRegionCluster": {
+      "singular": "multiregioncluster",
+      "plural": "multiregionclusters"
+    },
+    "memorydb.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "memorydb.aws.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "memorydb.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "memorydb.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "memorydb.aws.upbound.io/ACL": {
+      "singular": "acl",
+      "plural": "acls"
+    },
+    "memorydb.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "memorydb.aws.upbound.io/MultiRegionCluster": {
+      "singular": "multiregioncluster",
+      "plural": "multiregionclusters"
+    },
+    "memorydb.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "memorydb.aws.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "memorydb.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "memorydb.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "mq.aws.m.upbound.io/Broker": {
+      "singular": "broker",
+      "plural": "brokers"
+    },
+    "mq.aws.m.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "mq.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "mq.aws.upbound.io/Broker": {
+      "singular": "broker",
+      "plural": "brokers"
+    },
+    "mq.aws.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "mq.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "mwaa.aws.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "mwaa.aws.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "neptune.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "neptune.aws.m.upbound.io/ClusterEndpoint": {
+      "singular": "clusterendpoint",
+      "plural": "clusterendpoints"
+    },
+    "neptune.aws.m.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "neptune.aws.m.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "neptune.aws.m.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "neptune.aws.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "neptune.aws.m.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "neptune.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "neptune.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "neptune.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "neptune.aws.upbound.io/ClusterEndpoint": {
+      "singular": "clusterendpoint",
+      "plural": "clusterendpoints"
+    },
+    "neptune.aws.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "neptune.aws.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "neptune.aws.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "neptune.aws.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "neptune.aws.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "neptune.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "neptune.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "networkfirewall.aws.m.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "networkfirewall.aws.m.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "networkfirewall.aws.m.upbound.io/LoggingConfiguration": {
+      "singular": "loggingconfiguration",
+      "plural": "loggingconfigurations"
+    },
+    "networkfirewall.aws.m.upbound.io/RuleGroup": {
+      "singular": "rulegroup",
+      "plural": "rulegroups"
+    },
+    "networkfirewall.aws.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "networkfirewall.aws.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "networkfirewall.aws.upbound.io/LoggingConfiguration": {
+      "singular": "loggingconfiguration",
+      "plural": "loggingconfigurations"
+    },
+    "networkfirewall.aws.upbound.io/RuleGroup": {
+      "singular": "rulegroup",
+      "plural": "rulegroups"
+    },
+    "networkmanager.aws.m.upbound.io/AttachmentAccepter": {
+      "singular": "attachmentaccepter",
+      "plural": "attachmentaccepters"
+    },
+    "networkmanager.aws.m.upbound.io/ConnectAttachment": {
+      "singular": "connectattachment",
+      "plural": "connectattachments"
+    },
+    "networkmanager.aws.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "networkmanager.aws.m.upbound.io/CoreNetwork": {
+      "singular": "corenetwork",
+      "plural": "corenetworks"
+    },
+    "networkmanager.aws.m.upbound.io/CustomerGatewayAssociation": {
+      "singular": "customergatewayassociation",
+      "plural": "customergatewayassociations"
+    },
+    "networkmanager.aws.m.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "networkmanager.aws.m.upbound.io/GlobalNetwork": {
+      "singular": "globalnetwork",
+      "plural": "globalnetworks"
+    },
+    "networkmanager.aws.m.upbound.io/Link": {
+      "singular": "link",
+      "plural": "links"
+    },
+    "networkmanager.aws.m.upbound.io/LinkAssociation": {
+      "singular": "linkassociation",
+      "plural": "linkassociations"
+    },
+    "networkmanager.aws.m.upbound.io/Site": {
+      "singular": "site",
+      "plural": "sites"
+    },
+    "networkmanager.aws.m.upbound.io/TransitGatewayConnectPeerAssociation": {
+      "singular": "transitgatewayconnectpeerassociation",
+      "plural": "transitgatewayconnectpeerassociations"
+    },
+    "networkmanager.aws.m.upbound.io/TransitGatewayRegistration": {
+      "singular": "transitgatewayregistration",
+      "plural": "transitgatewayregistrations"
+    },
+    "networkmanager.aws.m.upbound.io/VPCAttachment": {
+      "singular": "vpcattachment",
+      "plural": "vpcattachments"
+    },
+    "networkmanager.aws.upbound.io/AttachmentAccepter": {
+      "singular": "attachmentaccepter",
+      "plural": "attachmentaccepters"
+    },
+    "networkmanager.aws.upbound.io/ConnectAttachment": {
+      "singular": "connectattachment",
+      "plural": "connectattachments"
+    },
+    "networkmanager.aws.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "networkmanager.aws.upbound.io/CoreNetwork": {
+      "singular": "corenetwork",
+      "plural": "corenetworks"
+    },
+    "networkmanager.aws.upbound.io/CustomerGatewayAssociation": {
+      "singular": "customergatewayassociation",
+      "plural": "customergatewayassociations"
+    },
+    "networkmanager.aws.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "networkmanager.aws.upbound.io/GlobalNetwork": {
+      "singular": "globalnetwork",
+      "plural": "globalnetworks"
+    },
+    "networkmanager.aws.upbound.io/Link": {
+      "singular": "link",
+      "plural": "links"
+    },
+    "networkmanager.aws.upbound.io/LinkAssociation": {
+      "singular": "linkassociation",
+      "plural": "linkassociations"
+    },
+    "networkmanager.aws.upbound.io/Site": {
+      "singular": "site",
+      "plural": "sites"
+    },
+    "networkmanager.aws.upbound.io/TransitGatewayConnectPeerAssociation": {
+      "singular": "transitgatewayconnectpeerassociation",
+      "plural": "transitgatewayconnectpeerassociations"
+    },
+    "networkmanager.aws.upbound.io/TransitGatewayRegistration": {
+      "singular": "transitgatewayregistration",
+      "plural": "transitgatewayregistrations"
+    },
+    "networkmanager.aws.upbound.io/VPCAttachment": {
+      "singular": "vpcattachment",
+      "plural": "vpcattachments"
+    },
+    "networkmonitor.aws.m.upbound.io/Monitor": {
+      "singular": "monitor",
+      "plural": "monitors"
+    },
+    "networkmonitor.aws.m.upbound.io/Probe": {
+      "singular": "probe",
+      "plural": "probes"
+    },
+    "networkmonitor.aws.upbound.io/Monitor": {
+      "singular": "monitor",
+      "plural": "monitors"
+    },
+    "networkmonitor.aws.upbound.io/Probe": {
+      "singular": "probe",
+      "plural": "probes"
+    },
+    "oam.aws.m.upbound.io/Sink": {
+      "singular": "sink",
+      "plural": "sinks"
+    },
+    "oam.aws.upbound.io/Sink": {
+      "singular": "sink",
+      "plural": "sinks"
+    },
+    "opensearch.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "opensearch.aws.m.upbound.io/DomainPolicy": {
+      "singular": "domainpolicy",
+      "plural": "domainpolicies"
+    },
+    "opensearch.aws.m.upbound.io/DomainSAMLOptions": {
+      "singular": "domainsamloptions",
+      "plural": "domainsamloptions"
+    },
+    "opensearch.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "opensearch.aws.upbound.io/DomainPolicy": {
+      "singular": "domainpolicy",
+      "plural": "domainpolicies"
+    },
+    "opensearch.aws.upbound.io/DomainSAMLOptions": {
+      "singular": "domainsamloptions",
+      "plural": "domainsamloptions"
+    },
+    "opensearchserverless.aws.m.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "opensearchserverless.aws.m.upbound.io/Collection": {
+      "singular": "collection",
+      "plural": "collections"
+    },
+    "opensearchserverless.aws.m.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "opensearchserverless.aws.m.upbound.io/SecurityConfig": {
+      "singular": "securityconfig",
+      "plural": "securityconfigs"
+    },
+    "opensearchserverless.aws.m.upbound.io/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies"
+    },
+    "opensearchserverless.aws.m.upbound.io/VPCEndpoint": {
+      "singular": "vpcendpoint",
+      "plural": "vpcendpoints"
+    },
+    "opensearchserverless.aws.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "opensearchserverless.aws.upbound.io/Collection": {
+      "singular": "collection",
+      "plural": "collections"
+    },
+    "opensearchserverless.aws.upbound.io/LifecyclePolicy": {
+      "singular": "lifecyclepolicy",
+      "plural": "lifecyclepolicies"
+    },
+    "opensearchserverless.aws.upbound.io/SecurityConfig": {
+      "singular": "securityconfig",
+      "plural": "securityconfigs"
+    },
+    "opensearchserverless.aws.upbound.io/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies"
+    },
+    "opensearchserverless.aws.upbound.io/VPCEndpoint": {
+      "singular": "vpcendpoint",
+      "plural": "vpcendpoints"
+    },
+    "organizations.aws.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "organizations.aws.m.upbound.io/DelegatedAdministrator": {
+      "singular": "delegatedadministrator",
+      "plural": "delegatedadministrators"
+    },
+    "organizations.aws.m.upbound.io/Organization": {
+      "singular": "organization",
+      "plural": "organizations"
+    },
+    "organizations.aws.m.upbound.io/OrganizationalUnit": {
+      "singular": "organizationalunit",
+      "plural": "organizationalunits"
+    },
+    "organizations.aws.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "organizations.aws.m.upbound.io/PolicyAttachment": {
+      "singular": "policyattachment",
+      "plural": "policyattachments"
+    },
+    "organizations.aws.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "organizations.aws.upbound.io/DelegatedAdministrator": {
+      "singular": "delegatedadministrator",
+      "plural": "delegatedadministrators"
+    },
+    "organizations.aws.upbound.io/Organization": {
+      "singular": "organization",
+      "plural": "organizations"
+    },
+    "organizations.aws.upbound.io/OrganizationalUnit": {
+      "singular": "organizationalunit",
+      "plural": "organizationalunits"
+    },
+    "organizations.aws.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "organizations.aws.upbound.io/PolicyAttachment": {
+      "singular": "policyattachment",
+      "plural": "policyattachments"
+    },
+    "osis.aws.m.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "osis.aws.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "pinpoint.aws.m.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "pinpoint.aws.m.upbound.io/SMSChannel": {
+      "singular": "smschannel",
+      "plural": "smschannels"
+    },
+    "pinpoint.aws.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "pinpoint.aws.upbound.io/SMSChannel": {
+      "singular": "smschannel",
+      "plural": "smschannels"
+    },
+    "pipes.aws.m.upbound.io/Pipe": {
+      "singular": "pipe",
+      "plural": "pipes"
+    },
+    "pipes.aws.upbound.io/Pipe": {
+      "singular": "pipe",
+      "plural": "pipes"
+    },
+    "qldb.aws.m.upbound.io/Ledger": {
+      "singular": "ledger",
+      "plural": "ledgers"
+    },
+    "qldb.aws.m.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "qldb.aws.upbound.io/Ledger": {
+      "singular": "ledger",
+      "plural": "ledgers"
+    },
+    "qldb.aws.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "quicksight.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "quicksight.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "quicksight.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "quicksight.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "ram.aws.m.upbound.io/PrincipalAssociation": {
+      "singular": "principalassociation",
+      "plural": "principalassociations"
+    },
+    "ram.aws.m.upbound.io/ResourceAssociation": {
+      "singular": "resourceassociation",
+      "plural": "resourceassociations"
+    },
+    "ram.aws.m.upbound.io/ResourceShare": {
+      "singular": "resourceshare",
+      "plural": "resourceshares"
+    },
+    "ram.aws.m.upbound.io/ResourceShareAccepter": {
+      "singular": "resourceshareaccepter",
+      "plural": "resourceshareaccepters"
+    },
+    "ram.aws.upbound.io/PrincipalAssociation": {
+      "singular": "principalassociation",
+      "plural": "principalassociations"
+    },
+    "ram.aws.upbound.io/ResourceAssociation": {
+      "singular": "resourceassociation",
+      "plural": "resourceassociations"
+    },
+    "ram.aws.upbound.io/ResourceShare": {
+      "singular": "resourceshare",
+      "plural": "resourceshares"
+    },
+    "ram.aws.upbound.io/ResourceShareAccepter": {
+      "singular": "resourceshareaccepter",
+      "plural": "resourceshareaccepters"
+    },
+    "rds.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "rds.aws.m.upbound.io/ClusterActivityStream": {
+      "singular": "clusteractivitystream",
+      "plural": "clusteractivitystreams"
+    },
+    "rds.aws.m.upbound.io/ClusterEndpoint": {
+      "singular": "clusterendpoint",
+      "plural": "clusterendpoints"
+    },
+    "rds.aws.m.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "rds.aws.m.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "rds.aws.m.upbound.io/ClusterRoleAssociation": {
+      "singular": "clusterroleassociation",
+      "plural": "clusterroleassociations"
+    },
+    "rds.aws.m.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "rds.aws.m.upbound.io/DBInstanceAutomatedBackupsReplication": {
+      "singular": "dbinstanceautomatedbackupsreplication",
+      "plural": "dbinstanceautomatedbackupsreplications"
+    },
+    "rds.aws.m.upbound.io/DBSnapshotCopy": {
+      "singular": "dbsnapshotcopy",
+      "plural": "dbsnapshotcopies"
+    },
+    "rds.aws.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "rds.aws.m.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "rds.aws.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "rds.aws.m.upbound.io/InstanceRoleAssociation": {
+      "singular": "instanceroleassociation",
+      "plural": "instanceroleassociations"
+    },
+    "rds.aws.m.upbound.io/InstanceState": {
+      "singular": "instancestate",
+      "plural": "instancestates"
+    },
+    "rds.aws.m.upbound.io/OptionGroup": {
+      "singular": "optiongroup",
+      "plural": "optiongroups"
+    },
+    "rds.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "rds.aws.m.upbound.io/Proxy": {
+      "singular": "proxy",
+      "plural": "proxies"
+    },
+    "rds.aws.m.upbound.io/ProxyDefaultTargetGroup": {
+      "singular": "proxydefaulttargetgroup",
+      "plural": "proxydefaulttargetgroups"
+    },
+    "rds.aws.m.upbound.io/ProxyEndpoint": {
+      "singular": "proxyendpoint",
+      "plural": "proxyendpoints"
+    },
+    "rds.aws.m.upbound.io/ProxyTarget": {
+      "singular": "proxytarget",
+      "plural": "proxytargets"
+    },
+    "rds.aws.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "rds.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "rds.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "rds.aws.upbound.io/ClusterActivityStream": {
+      "singular": "clusteractivitystream",
+      "plural": "clusteractivitystreams"
+    },
+    "rds.aws.upbound.io/ClusterEndpoint": {
+      "singular": "clusterendpoint",
+      "plural": "clusterendpoints"
+    },
+    "rds.aws.upbound.io/ClusterInstance": {
+      "singular": "clusterinstance",
+      "plural": "clusterinstances"
+    },
+    "rds.aws.upbound.io/ClusterParameterGroup": {
+      "singular": "clusterparametergroup",
+      "plural": "clusterparametergroups"
+    },
+    "rds.aws.upbound.io/ClusterRoleAssociation": {
+      "singular": "clusterroleassociation",
+      "plural": "clusterroleassociations"
+    },
+    "rds.aws.upbound.io/ClusterSnapshot": {
+      "singular": "clustersnapshot",
+      "plural": "clustersnapshots"
+    },
+    "rds.aws.upbound.io/DBInstanceAutomatedBackupsReplication": {
+      "singular": "dbinstanceautomatedbackupsreplication",
+      "plural": "dbinstanceautomatedbackupsreplications"
+    },
+    "rds.aws.upbound.io/DBSnapshotCopy": {
+      "singular": "dbsnapshotcopy",
+      "plural": "dbsnapshotcopies"
+    },
+    "rds.aws.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "rds.aws.upbound.io/GlobalCluster": {
+      "singular": "globalcluster",
+      "plural": "globalclusters"
+    },
+    "rds.aws.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "rds.aws.upbound.io/InstanceRoleAssociation": {
+      "singular": "instanceroleassociation",
+      "plural": "instanceroleassociations"
+    },
+    "rds.aws.upbound.io/InstanceState": {
+      "singular": "instancestate",
+      "plural": "instancestates"
+    },
+    "rds.aws.upbound.io/OptionGroup": {
+      "singular": "optiongroup",
+      "plural": "optiongroups"
+    },
+    "rds.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "rds.aws.upbound.io/Proxy": {
+      "singular": "proxy",
+      "plural": "proxies"
+    },
+    "rds.aws.upbound.io/ProxyDefaultTargetGroup": {
+      "singular": "proxydefaulttargetgroup",
+      "plural": "proxydefaulttargetgroups"
+    },
+    "rds.aws.upbound.io/ProxyEndpoint": {
+      "singular": "proxyendpoint",
+      "plural": "proxyendpoints"
+    },
+    "rds.aws.upbound.io/ProxyTarget": {
+      "singular": "proxytarget",
+      "plural": "proxytargets"
+    },
+    "rds.aws.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "rds.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "redshift.aws.m.upbound.io/AuthenticationProfile": {
+      "singular": "authenticationprofile",
+      "plural": "authenticationprofiles"
+    },
+    "redshift.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "redshift.aws.m.upbound.io/EndpointAccess": {
+      "singular": "endpointaccess",
+      "plural": "endpointaccesses"
+    },
+    "redshift.aws.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "redshift.aws.m.upbound.io/HSMClientCertificate": {
+      "singular": "hsmclientcertificate",
+      "plural": "hsmclientcertificates"
+    },
+    "redshift.aws.m.upbound.io/HSMConfiguration": {
+      "singular": "hsmconfiguration",
+      "plural": "hsmconfigurations"
+    },
+    "redshift.aws.m.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "redshift.aws.m.upbound.io/ScheduledAction": {
+      "singular": "scheduledaction",
+      "plural": "scheduledactions"
+    },
+    "redshift.aws.m.upbound.io/SnapshotCopyGrant": {
+      "singular": "snapshotcopygrant",
+      "plural": "snapshotcopygrants"
+    },
+    "redshift.aws.m.upbound.io/SnapshotSchedule": {
+      "singular": "snapshotschedule",
+      "plural": "snapshotschedules"
+    },
+    "redshift.aws.m.upbound.io/SnapshotScheduleAssociation": {
+      "singular": "snapshotscheduleassociation",
+      "plural": "snapshotscheduleassociations"
+    },
+    "redshift.aws.m.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "redshift.aws.m.upbound.io/UsageLimit": {
+      "singular": "usagelimit",
+      "plural": "usagelimits"
+    },
+    "redshift.aws.upbound.io/AuthenticationProfile": {
+      "singular": "authenticationprofile",
+      "plural": "authenticationprofiles"
+    },
+    "redshift.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "redshift.aws.upbound.io/EndpointAccess": {
+      "singular": "endpointaccess",
+      "plural": "endpointaccesses"
+    },
+    "redshift.aws.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "redshift.aws.upbound.io/HSMClientCertificate": {
+      "singular": "hsmclientcertificate",
+      "plural": "hsmclientcertificates"
+    },
+    "redshift.aws.upbound.io/HSMConfiguration": {
+      "singular": "hsmconfiguration",
+      "plural": "hsmconfigurations"
+    },
+    "redshift.aws.upbound.io/ParameterGroup": {
+      "singular": "parametergroup",
+      "plural": "parametergroups"
+    },
+    "redshift.aws.upbound.io/ScheduledAction": {
+      "singular": "scheduledaction",
+      "plural": "scheduledactions"
+    },
+    "redshift.aws.upbound.io/SnapshotCopyGrant": {
+      "singular": "snapshotcopygrant",
+      "plural": "snapshotcopygrants"
+    },
+    "redshift.aws.upbound.io/SnapshotSchedule": {
+      "singular": "snapshotschedule",
+      "plural": "snapshotschedules"
+    },
+    "redshift.aws.upbound.io/SnapshotScheduleAssociation": {
+      "singular": "snapshotscheduleassociation",
+      "plural": "snapshotscheduleassociations"
+    },
+    "redshift.aws.upbound.io/SubnetGroup": {
+      "singular": "subnetgroup",
+      "plural": "subnetgroups"
+    },
+    "redshift.aws.upbound.io/UsageLimit": {
+      "singular": "usagelimit",
+      "plural": "usagelimits"
+    },
+    "redshiftserverless.aws.m.upbound.io/EndpointAccess": {
+      "singular": "endpointaccess",
+      "plural": "endpointaccesses"
+    },
+    "redshiftserverless.aws.m.upbound.io/RedshiftServerlessNamespace": {
+      "singular": "redshiftserverlessnamespace",
+      "plural": "redshiftserverlessnamespaces"
+    },
+    "redshiftserverless.aws.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "redshiftserverless.aws.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "redshiftserverless.aws.m.upbound.io/UsageLimit": {
+      "singular": "usagelimit",
+      "plural": "usagelimits"
+    },
+    "redshiftserverless.aws.m.upbound.io/Workgroup": {
+      "singular": "workgroup",
+      "plural": "workgroups"
+    },
+    "redshiftserverless.aws.upbound.io/EndpointAccess": {
+      "singular": "endpointaccess",
+      "plural": "endpointaccesses"
+    },
+    "redshiftserverless.aws.upbound.io/RedshiftServerlessNamespace": {
+      "singular": "redshiftserverlessnamespace",
+      "plural": "redshiftserverlessnamespaces"
+    },
+    "redshiftserverless.aws.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "redshiftserverless.aws.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "redshiftserverless.aws.upbound.io/UsageLimit": {
+      "singular": "usagelimit",
+      "plural": "usagelimits"
+    },
+    "redshiftserverless.aws.upbound.io/Workgroup": {
+      "singular": "workgroup",
+      "plural": "workgroups"
+    },
+    "resourcegroups.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "resourcegroups.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "rolesanywhere.aws.m.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "rolesanywhere.aws.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "route53.aws.m.upbound.io/DelegationSet": {
+      "singular": "delegationset",
+      "plural": "delegationsets"
+    },
+    "route53.aws.m.upbound.io/HealthCheck": {
+      "singular": "healthcheck",
+      "plural": "healthchecks"
+    },
+    "route53.aws.m.upbound.io/HostedZoneDNSSEC": {
+      "singular": "hostedzonednssec",
+      "plural": "hostedzonednssecs"
+    },
+    "route53.aws.m.upbound.io/QueryLog": {
+      "singular": "querylog",
+      "plural": "querylogs"
+    },
+    "route53.aws.m.upbound.io/Record": {
+      "singular": "record",
+      "plural": "records"
+    },
+    "route53.aws.m.upbound.io/ResolverConfig": {
+      "singular": "resolverconfig",
+      "plural": "resolverconfigs"
+    },
+    "route53.aws.m.upbound.io/TrafficPolicy": {
+      "singular": "trafficpolicy",
+      "plural": "trafficpolicies"
+    },
+    "route53.aws.m.upbound.io/TrafficPolicyInstance": {
+      "singular": "trafficpolicyinstance",
+      "plural": "trafficpolicyinstances"
+    },
+    "route53.aws.m.upbound.io/VPCAssociationAuthorization": {
+      "singular": "vpcassociationauthorization",
+      "plural": "vpcassociationauthorizations"
+    },
+    "route53.aws.m.upbound.io/Zone": {
+      "singular": "zone",
+      "plural": "zones"
+    },
+    "route53.aws.m.upbound.io/ZoneAssociation": {
+      "singular": "zoneassociation",
+      "plural": "zoneassociations"
+    },
+    "route53.aws.upbound.io/DelegationSet": {
+      "singular": "delegationset",
+      "plural": "delegationsets"
+    },
+    "route53.aws.upbound.io/HealthCheck": {
+      "singular": "healthcheck",
+      "plural": "healthchecks"
+    },
+    "route53.aws.upbound.io/HostedZoneDNSSEC": {
+      "singular": "hostedzonednssec",
+      "plural": "hostedzonednssecs"
+    },
+    "route53.aws.upbound.io/QueryLog": {
+      "singular": "querylog",
+      "plural": "querylogs"
+    },
+    "route53.aws.upbound.io/Record": {
+      "singular": "record",
+      "plural": "records"
+    },
+    "route53.aws.upbound.io/ResolverConfig": {
+      "singular": "resolverconfig",
+      "plural": "resolverconfigs"
+    },
+    "route53.aws.upbound.io/TrafficPolicy": {
+      "singular": "trafficpolicy",
+      "plural": "trafficpolicies"
+    },
+    "route53.aws.upbound.io/TrafficPolicyInstance": {
+      "singular": "trafficpolicyinstance",
+      "plural": "trafficpolicyinstances"
+    },
+    "route53.aws.upbound.io/VPCAssociationAuthorization": {
+      "singular": "vpcassociationauthorization",
+      "plural": "vpcassociationauthorizations"
+    },
+    "route53.aws.upbound.io/Zone": {
+      "singular": "zone",
+      "plural": "zones"
+    },
+    "route53.aws.upbound.io/ZoneAssociation": {
+      "singular": "zoneassociation",
+      "plural": "zoneassociations"
+    },
+    "route53profiles.aws.m.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "route53profiles.aws.m.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "route53profiles.aws.m.upbound.io/ResourceAssociation": {
+      "singular": "resourceassociation",
+      "plural": "resourceassociations"
+    },
+    "route53profiles.aws.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "route53profiles.aws.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "route53profiles.aws.upbound.io/ResourceAssociation": {
+      "singular": "resourceassociation",
+      "plural": "resourceassociations"
+    },
+    "route53recoverycontrolconfig.aws.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "route53recoverycontrolconfig.aws.m.upbound.io/ControlPanel": {
+      "singular": "controlpanel",
+      "plural": "controlpanels"
+    },
+    "route53recoverycontrolconfig.aws.m.upbound.io/RoutingControl": {
+      "singular": "routingcontrol",
+      "plural": "routingcontrols"
+    },
+    "route53recoverycontrolconfig.aws.m.upbound.io/SafetyRule": {
+      "singular": "safetyrule",
+      "plural": "safetyrules"
+    },
+    "route53recoverycontrolconfig.aws.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "route53recoverycontrolconfig.aws.upbound.io/ControlPanel": {
+      "singular": "controlpanel",
+      "plural": "controlpanels"
+    },
+    "route53recoverycontrolconfig.aws.upbound.io/RoutingControl": {
+      "singular": "routingcontrol",
+      "plural": "routingcontrols"
+    },
+    "route53recoverycontrolconfig.aws.upbound.io/SafetyRule": {
+      "singular": "safetyrule",
+      "plural": "safetyrules"
+    },
+    "route53recoveryreadiness.aws.m.upbound.io/Cell": {
+      "singular": "cell",
+      "plural": "cells"
+    },
+    "route53recoveryreadiness.aws.m.upbound.io/ReadinessCheck": {
+      "singular": "readinesscheck",
+      "plural": "readinesschecks"
+    },
+    "route53recoveryreadiness.aws.m.upbound.io/RecoveryGroup": {
+      "singular": "recoverygroup",
+      "plural": "recoverygroups"
+    },
+    "route53recoveryreadiness.aws.m.upbound.io/ResourceSet": {
+      "singular": "resourceset",
+      "plural": "resourcesets"
+    },
+    "route53recoveryreadiness.aws.upbound.io/Cell": {
+      "singular": "cell",
+      "plural": "cells"
+    },
+    "route53recoveryreadiness.aws.upbound.io/ReadinessCheck": {
+      "singular": "readinesscheck",
+      "plural": "readinesschecks"
+    },
+    "route53recoveryreadiness.aws.upbound.io/RecoveryGroup": {
+      "singular": "recoverygroup",
+      "plural": "recoverygroups"
+    },
+    "route53recoveryreadiness.aws.upbound.io/ResourceSet": {
+      "singular": "resourceset",
+      "plural": "resourcesets"
+    },
+    "route53resolver.aws.m.upbound.io/DNSSECConfig": {
+      "singular": "dnssecconfig",
+      "plural": "dnssecconfigs"
+    },
+    "route53resolver.aws.m.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "route53resolver.aws.m.upbound.io/QueryLogConfig": {
+      "singular": "querylogconfig",
+      "plural": "querylogconfigs"
+    },
+    "route53resolver.aws.m.upbound.io/QueryLogConfigAssociation": {
+      "singular": "querylogconfigassociation",
+      "plural": "querylogconfigassociations"
+    },
+    "route53resolver.aws.m.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "route53resolver.aws.m.upbound.io/RuleAssociation": {
+      "singular": "ruleassociation",
+      "plural": "ruleassociations"
+    },
+    "route53resolver.aws.upbound.io/DNSSECConfig": {
+      "singular": "dnssecconfig",
+      "plural": "dnssecconfigs"
+    },
+    "route53resolver.aws.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "route53resolver.aws.upbound.io/QueryLogConfig": {
+      "singular": "querylogconfig",
+      "plural": "querylogconfigs"
+    },
+    "route53resolver.aws.upbound.io/QueryLogConfigAssociation": {
+      "singular": "querylogconfigassociation",
+      "plural": "querylogconfigassociations"
+    },
+    "route53resolver.aws.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "route53resolver.aws.upbound.io/RuleAssociation": {
+      "singular": "ruleassociation",
+      "plural": "ruleassociations"
+    },
+    "rum.aws.m.upbound.io/AppMonitor": {
+      "singular": "appmonitor",
+      "plural": "appmonitors"
+    },
+    "rum.aws.m.upbound.io/MetricsDestination": {
+      "singular": "metricsdestination",
+      "plural": "metricsdestinations"
+    },
+    "rum.aws.upbound.io/AppMonitor": {
+      "singular": "appmonitor",
+      "plural": "appmonitors"
+    },
+    "rum.aws.upbound.io/MetricsDestination": {
+      "singular": "metricsdestination",
+      "plural": "metricsdestinations"
+    },
+    "s3.aws.m.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "s3.aws.m.upbound.io/BucketACL": {
+      "singular": "bucketacl",
+      "plural": "bucketacls"
+    },
+    "s3.aws.m.upbound.io/BucketAbac": {
+      "singular": "bucketabac",
+      "plural": "bucketabacs"
+    },
+    "s3.aws.m.upbound.io/BucketAccelerateConfiguration": {
+      "singular": "bucketaccelerateconfiguration",
+      "plural": "bucketaccelerateconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketAnalyticsConfiguration": {
+      "singular": "bucketanalyticsconfiguration",
+      "plural": "bucketanalyticsconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketCorsConfiguration": {
+      "singular": "bucketcorsconfiguration",
+      "plural": "bucketcorsconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketIntelligentTieringConfiguration": {
+      "singular": "bucketintelligenttieringconfiguration",
+      "plural": "bucketintelligenttieringconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketInventory": {
+      "singular": "bucketinventory",
+      "plural": "bucketinventories"
+    },
+    "s3.aws.m.upbound.io/BucketLifecycleConfiguration": {
+      "singular": "bucketlifecycleconfiguration",
+      "plural": "bucketlifecycleconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketLogging": {
+      "singular": "bucketlogging",
+      "plural": "bucketloggings"
+    },
+    "s3.aws.m.upbound.io/BucketMetric": {
+      "singular": "bucketmetric",
+      "plural": "bucketmetrics"
+    },
+    "s3.aws.m.upbound.io/BucketNotification": {
+      "singular": "bucketnotification",
+      "plural": "bucketnotifications"
+    },
+    "s3.aws.m.upbound.io/BucketObject": {
+      "singular": "bucketobject",
+      "plural": "bucketobjects"
+    },
+    "s3.aws.m.upbound.io/BucketObjectLockConfiguration": {
+      "singular": "bucketobjectlockconfiguration",
+      "plural": "bucketobjectlockconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketOwnershipControls": {
+      "singular": "bucketownershipcontrols",
+      "plural": "bucketownershipcontrols"
+    },
+    "s3.aws.m.upbound.io/BucketPolicy": {
+      "singular": "bucketpolicy",
+      "plural": "bucketpolicies"
+    },
+    "s3.aws.m.upbound.io/BucketPublicAccessBlock": {
+      "singular": "bucketpublicaccessblock",
+      "plural": "bucketpublicaccessblocks"
+    },
+    "s3.aws.m.upbound.io/BucketReplicationConfiguration": {
+      "singular": "bucketreplicationconfiguration",
+      "plural": "bucketreplicationconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketRequestPaymentConfiguration": {
+      "singular": "bucketrequestpaymentconfiguration",
+      "plural": "bucketrequestpaymentconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketServerSideEncryptionConfiguration": {
+      "singular": "bucketserversideencryptionconfiguration",
+      "plural": "bucketserversideencryptionconfigurations"
+    },
+    "s3.aws.m.upbound.io/BucketVersioning": {
+      "singular": "bucketversioning",
+      "plural": "bucketversionings"
+    },
+    "s3.aws.m.upbound.io/BucketWebsiteConfiguration": {
+      "singular": "bucketwebsiteconfiguration",
+      "plural": "bucketwebsiteconfigurations"
+    },
+    "s3.aws.m.upbound.io/DirectoryBucket": {
+      "singular": "directorybucket",
+      "plural": "directorybuckets"
+    },
+    "s3.aws.m.upbound.io/Object": {
+      "singular": "object",
+      "plural": "objects"
+    },
+    "s3.aws.m.upbound.io/ObjectCopy": {
+      "singular": "objectcopy",
+      "plural": "objectcopies"
+    },
+    "s3.aws.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "s3.aws.upbound.io/BucketACL": {
+      "singular": "bucketacl",
+      "plural": "bucketacls"
+    },
+    "s3.aws.upbound.io/BucketAbac": {
+      "singular": "bucketabac",
+      "plural": "bucketabacs"
+    },
+    "s3.aws.upbound.io/BucketAccelerateConfiguration": {
+      "singular": "bucketaccelerateconfiguration",
+      "plural": "bucketaccelerateconfigurations"
+    },
+    "s3.aws.upbound.io/BucketAnalyticsConfiguration": {
+      "singular": "bucketanalyticsconfiguration",
+      "plural": "bucketanalyticsconfigurations"
+    },
+    "s3.aws.upbound.io/BucketCorsConfiguration": {
+      "singular": "bucketcorsconfiguration",
+      "plural": "bucketcorsconfigurations"
+    },
+    "s3.aws.upbound.io/BucketIntelligentTieringConfiguration": {
+      "singular": "bucketintelligenttieringconfiguration",
+      "plural": "bucketintelligenttieringconfigurations"
+    },
+    "s3.aws.upbound.io/BucketInventory": {
+      "singular": "bucketinventory",
+      "plural": "bucketinventories"
+    },
+    "s3.aws.upbound.io/BucketLifecycleConfiguration": {
+      "singular": "bucketlifecycleconfiguration",
+      "plural": "bucketlifecycleconfigurations"
+    },
+    "s3.aws.upbound.io/BucketLogging": {
+      "singular": "bucketlogging",
+      "plural": "bucketloggings"
+    },
+    "s3.aws.upbound.io/BucketMetric": {
+      "singular": "bucketmetric",
+      "plural": "bucketmetrics"
+    },
+    "s3.aws.upbound.io/BucketNotification": {
+      "singular": "bucketnotification",
+      "plural": "bucketnotifications"
+    },
+    "s3.aws.upbound.io/BucketObject": {
+      "singular": "bucketobject",
+      "plural": "bucketobjects"
+    },
+    "s3.aws.upbound.io/BucketObjectLockConfiguration": {
+      "singular": "bucketobjectlockconfiguration",
+      "plural": "bucketobjectlockconfigurations"
+    },
+    "s3.aws.upbound.io/BucketOwnershipControls": {
+      "singular": "bucketownershipcontrols",
+      "plural": "bucketownershipcontrols"
+    },
+    "s3.aws.upbound.io/BucketPolicy": {
+      "singular": "bucketpolicy",
+      "plural": "bucketpolicies"
+    },
+    "s3.aws.upbound.io/BucketPublicAccessBlock": {
+      "singular": "bucketpublicaccessblock",
+      "plural": "bucketpublicaccessblocks"
+    },
+    "s3.aws.upbound.io/BucketReplicationConfiguration": {
+      "singular": "bucketreplicationconfiguration",
+      "plural": "bucketreplicationconfigurations"
+    },
+    "s3.aws.upbound.io/BucketRequestPaymentConfiguration": {
+      "singular": "bucketrequestpaymentconfiguration",
+      "plural": "bucketrequestpaymentconfigurations"
+    },
+    "s3.aws.upbound.io/BucketServerSideEncryptionConfiguration": {
+      "singular": "bucketserversideencryptionconfiguration",
+      "plural": "bucketserversideencryptionconfigurations"
+    },
+    "s3.aws.upbound.io/BucketVersioning": {
+      "singular": "bucketversioning",
+      "plural": "bucketversionings"
+    },
+    "s3.aws.upbound.io/BucketWebsiteConfiguration": {
+      "singular": "bucketwebsiteconfiguration",
+      "plural": "bucketwebsiteconfigurations"
+    },
+    "s3.aws.upbound.io/DirectoryBucket": {
+      "singular": "directorybucket",
+      "plural": "directorybuckets"
+    },
+    "s3.aws.upbound.io/Object": {
+      "singular": "object",
+      "plural": "objects"
+    },
+    "s3.aws.upbound.io/ObjectCopy": {
+      "singular": "objectcopy",
+      "plural": "objectcopies"
+    },
+    "s3control.aws.m.upbound.io/AccessPoint": {
+      "singular": "accesspoint",
+      "plural": "accesspoints"
+    },
+    "s3control.aws.m.upbound.io/AccessPointPolicy": {
+      "singular": "accesspointpolicy",
+      "plural": "accesspointpolicies"
+    },
+    "s3control.aws.m.upbound.io/AccountPublicAccessBlock": {
+      "singular": "accountpublicaccessblock",
+      "plural": "accountpublicaccessblocks"
+    },
+    "s3control.aws.m.upbound.io/MultiRegionAccessPoint": {
+      "singular": "multiregionaccesspoint",
+      "plural": "multiregionaccesspoints"
+    },
+    "s3control.aws.m.upbound.io/MultiRegionAccessPointPolicy": {
+      "singular": "multiregionaccesspointpolicy",
+      "plural": "multiregionaccesspointpolicies"
+    },
+    "s3control.aws.m.upbound.io/ObjectLambdaAccessPoint": {
+      "singular": "objectlambdaaccesspoint",
+      "plural": "objectlambdaaccesspoints"
+    },
+    "s3control.aws.m.upbound.io/ObjectLambdaAccessPointPolicy": {
+      "singular": "objectlambdaaccesspointpolicy",
+      "plural": "objectlambdaaccesspointpolicies"
+    },
+    "s3control.aws.m.upbound.io/StorageLensConfiguration": {
+      "singular": "storagelensconfiguration",
+      "plural": "storagelensconfigurations"
+    },
+    "s3control.aws.upbound.io/AccessPoint": {
+      "singular": "accesspoint",
+      "plural": "accesspoints"
+    },
+    "s3control.aws.upbound.io/AccessPointPolicy": {
+      "singular": "accesspointpolicy",
+      "plural": "accesspointpolicies"
+    },
+    "s3control.aws.upbound.io/AccountPublicAccessBlock": {
+      "singular": "accountpublicaccessblock",
+      "plural": "accountpublicaccessblocks"
+    },
+    "s3control.aws.upbound.io/MultiRegionAccessPoint": {
+      "singular": "multiregionaccesspoint",
+      "plural": "multiregionaccesspoints"
+    },
+    "s3control.aws.upbound.io/MultiRegionAccessPointPolicy": {
+      "singular": "multiregionaccesspointpolicy",
+      "plural": "multiregionaccesspointpolicies"
+    },
+    "s3control.aws.upbound.io/ObjectLambdaAccessPoint": {
+      "singular": "objectlambdaaccesspoint",
+      "plural": "objectlambdaaccesspoints"
+    },
+    "s3control.aws.upbound.io/ObjectLambdaAccessPointPolicy": {
+      "singular": "objectlambdaaccesspointpolicy",
+      "plural": "objectlambdaaccesspointpolicies"
+    },
+    "s3control.aws.upbound.io/StorageLensConfiguration": {
+      "singular": "storagelensconfiguration",
+      "plural": "storagelensconfigurations"
+    },
+    "s3vectors.aws.m.upbound.io/Index": {
+      "singular": "index",
+      "plural": "indices"
+    },
+    "s3vectors.aws.m.upbound.io/VectorBucket": {
+      "singular": "vectorbucket",
+      "plural": "vectorbuckets"
+    },
+    "s3vectors.aws.m.upbound.io/VectorBucketPolicy": {
+      "singular": "vectorbucketpolicy",
+      "plural": "vectorbucketpolicies"
+    },
+    "s3vectors.aws.upbound.io/Index": {
+      "singular": "index",
+      "plural": "indices"
+    },
+    "s3vectors.aws.upbound.io/VectorBucket": {
+      "singular": "vectorbucket",
+      "plural": "vectorbuckets"
+    },
+    "s3vectors.aws.upbound.io/VectorBucketPolicy": {
+      "singular": "vectorbucketpolicy",
+      "plural": "vectorbucketpolicies"
+    },
+    "sagemaker.aws.m.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "sagemaker.aws.m.upbound.io/AppImageConfig": {
+      "singular": "appimageconfig",
+      "plural": "appimageconfigs"
+    },
+    "sagemaker.aws.m.upbound.io/CodeRepository": {
+      "singular": "coderepository",
+      "plural": "coderepositories"
+    },
+    "sagemaker.aws.m.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "sagemaker.aws.m.upbound.io/DeviceFleet": {
+      "singular": "devicefleet",
+      "plural": "devicefleet"
+    },
+    "sagemaker.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "sagemaker.aws.m.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "sagemaker.aws.m.upbound.io/EndpointConfiguration": {
+      "singular": "endpointconfiguration",
+      "plural": "endpointconfigurations"
+    },
+    "sagemaker.aws.m.upbound.io/FeatureGroup": {
+      "singular": "featuregroup",
+      "plural": "featuregroups"
+    },
+    "sagemaker.aws.m.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "sagemaker.aws.m.upbound.io/ImageVersion": {
+      "singular": "imageversion",
+      "plural": "imageversions"
+    },
+    "sagemaker.aws.m.upbound.io/MlflowTrackingServer": {
+      "singular": "mlflowtrackingserver",
+      "plural": "mlflowtrackingservers"
+    },
+    "sagemaker.aws.m.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "sagemaker.aws.m.upbound.io/ModelPackageGroup": {
+      "singular": "modelpackagegroup",
+      "plural": "modelpackagegroups"
+    },
+    "sagemaker.aws.m.upbound.io/ModelPackageGroupPolicy": {
+      "singular": "modelpackagegrouppolicy",
+      "plural": "modelpackagegrouppolicies"
+    },
+    "sagemaker.aws.m.upbound.io/NotebookInstance": {
+      "singular": "notebookinstance",
+      "plural": "notebookinstances"
+    },
+    "sagemaker.aws.m.upbound.io/NotebookInstanceLifecycleConfiguration": {
+      "singular": "notebookinstancelifecycleconfiguration",
+      "plural": "notebookinstancelifecycleconfigurations"
+    },
+    "sagemaker.aws.m.upbound.io/ServicecatalogPortfolioStatus": {
+      "singular": "servicecatalogportfoliostatus",
+      "plural": "servicecatalogportfoliostatuses"
+    },
+    "sagemaker.aws.m.upbound.io/Space": {
+      "singular": "space",
+      "plural": "spaces"
+    },
+    "sagemaker.aws.m.upbound.io/StudioLifecycleConfig": {
+      "singular": "studiolifecycleconfig",
+      "plural": "studiolifecycleconfigs"
+    },
+    "sagemaker.aws.m.upbound.io/UserProfile": {
+      "singular": "userprofile",
+      "plural": "userprofiles"
+    },
+    "sagemaker.aws.m.upbound.io/Workforce": {
+      "singular": "workforce",
+      "plural": "workforces"
+    },
+    "sagemaker.aws.m.upbound.io/Workteam": {
+      "singular": "workteam",
+      "plural": "workteams"
+    },
+    "sagemaker.aws.upbound.io/App": {
+      "singular": "app",
+      "plural": "apps"
+    },
+    "sagemaker.aws.upbound.io/AppImageConfig": {
+      "singular": "appimageconfig",
+      "plural": "appimageconfigs"
+    },
+    "sagemaker.aws.upbound.io/CodeRepository": {
+      "singular": "coderepository",
+      "plural": "coderepositories"
+    },
+    "sagemaker.aws.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "sagemaker.aws.upbound.io/DeviceFleet": {
+      "singular": "devicefleet",
+      "plural": "devicefleet"
+    },
+    "sagemaker.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "sagemaker.aws.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "sagemaker.aws.upbound.io/EndpointConfiguration": {
+      "singular": "endpointconfiguration",
+      "plural": "endpointconfigurations"
+    },
+    "sagemaker.aws.upbound.io/FeatureGroup": {
+      "singular": "featuregroup",
+      "plural": "featuregroups"
+    },
+    "sagemaker.aws.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "sagemaker.aws.upbound.io/ImageVersion": {
+      "singular": "imageversion",
+      "plural": "imageversions"
+    },
+    "sagemaker.aws.upbound.io/MlflowTrackingServer": {
+      "singular": "mlflowtrackingserver",
+      "plural": "mlflowtrackingservers"
+    },
+    "sagemaker.aws.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "sagemaker.aws.upbound.io/ModelPackageGroup": {
+      "singular": "modelpackagegroup",
+      "plural": "modelpackagegroups"
+    },
+    "sagemaker.aws.upbound.io/ModelPackageGroupPolicy": {
+      "singular": "modelpackagegrouppolicy",
+      "plural": "modelpackagegrouppolicies"
+    },
+    "sagemaker.aws.upbound.io/NotebookInstance": {
+      "singular": "notebookinstance",
+      "plural": "notebookinstances"
+    },
+    "sagemaker.aws.upbound.io/NotebookInstanceLifecycleConfiguration": {
+      "singular": "notebookinstancelifecycleconfiguration",
+      "plural": "notebookinstancelifecycleconfigurations"
+    },
+    "sagemaker.aws.upbound.io/ServicecatalogPortfolioStatus": {
+      "singular": "servicecatalogportfoliostatus",
+      "plural": "servicecatalogportfoliostatuses"
+    },
+    "sagemaker.aws.upbound.io/Space": {
+      "singular": "space",
+      "plural": "spaces"
+    },
+    "sagemaker.aws.upbound.io/StudioLifecycleConfig": {
+      "singular": "studiolifecycleconfig",
+      "plural": "studiolifecycleconfigs"
+    },
+    "sagemaker.aws.upbound.io/UserProfile": {
+      "singular": "userprofile",
+      "plural": "userprofiles"
+    },
+    "sagemaker.aws.upbound.io/Workforce": {
+      "singular": "workforce",
+      "plural": "workforces"
+    },
+    "sagemaker.aws.upbound.io/Workteam": {
+      "singular": "workteam",
+      "plural": "workteams"
+    },
+    "scheduler.aws.m.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "scheduler.aws.m.upbound.io/ScheduleGroup": {
+      "singular": "schedulegroup",
+      "plural": "schedulegroups"
+    },
+    "scheduler.aws.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "scheduler.aws.upbound.io/ScheduleGroup": {
+      "singular": "schedulegroup",
+      "plural": "schedulegroups"
+    },
+    "schemas.aws.m.upbound.io/Discoverer": {
+      "singular": "discoverer",
+      "plural": "discoverers"
+    },
+    "schemas.aws.m.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "schemas.aws.m.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "schemas.aws.upbound.io/Discoverer": {
+      "singular": "discoverer",
+      "plural": "discoverers"
+    },
+    "schemas.aws.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "schemas.aws.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "secretsmanager.aws.m.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "secretsmanager.aws.m.upbound.io/SecretPolicy": {
+      "singular": "secretpolicy",
+      "plural": "secretpolicies"
+    },
+    "secretsmanager.aws.m.upbound.io/SecretRotation": {
+      "singular": "secretrotation",
+      "plural": "secretrotations"
+    },
+    "secretsmanager.aws.m.upbound.io/SecretVersion": {
+      "singular": "secretversion",
+      "plural": "secretversions"
+    },
+    "secretsmanager.aws.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "secretsmanager.aws.upbound.io/SecretPolicy": {
+      "singular": "secretpolicy",
+      "plural": "secretpolicies"
+    },
+    "secretsmanager.aws.upbound.io/SecretRotation": {
+      "singular": "secretrotation",
+      "plural": "secretrotations"
+    },
+    "secretsmanager.aws.upbound.io/SecretVersion": {
+      "singular": "secretversion",
+      "plural": "secretversions"
+    },
+    "securityhub.aws.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "securityhub.aws.m.upbound.io/ActionTarget": {
+      "singular": "actiontarget",
+      "plural": "actiontargets"
+    },
+    "securityhub.aws.m.upbound.io/FindingAggregator": {
+      "singular": "findingaggregator",
+      "plural": "findingaggregators"
+    },
+    "securityhub.aws.m.upbound.io/Insight": {
+      "singular": "insight",
+      "plural": "insights"
+    },
+    "securityhub.aws.m.upbound.io/InviteAccepter": {
+      "singular": "inviteaccepter",
+      "plural": "inviteaccepters"
+    },
+    "securityhub.aws.m.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "securityhub.aws.m.upbound.io/ProductSubscription": {
+      "singular": "productsubscription",
+      "plural": "productsubscriptions"
+    },
+    "securityhub.aws.m.upbound.io/StandardsSubscription": {
+      "singular": "standardssubscription",
+      "plural": "standardssubscriptions"
+    },
+    "securityhub.aws.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "securityhub.aws.upbound.io/ActionTarget": {
+      "singular": "actiontarget",
+      "plural": "actiontargets"
+    },
+    "securityhub.aws.upbound.io/FindingAggregator": {
+      "singular": "findingaggregator",
+      "plural": "findingaggregators"
+    },
+    "securityhub.aws.upbound.io/Insight": {
+      "singular": "insight",
+      "plural": "insights"
+    },
+    "securityhub.aws.upbound.io/InviteAccepter": {
+      "singular": "inviteaccepter",
+      "plural": "inviteaccepters"
+    },
+    "securityhub.aws.upbound.io/Member": {
+      "singular": "member",
+      "plural": "members"
+    },
+    "securityhub.aws.upbound.io/ProductSubscription": {
+      "singular": "productsubscription",
+      "plural": "productsubscriptions"
+    },
+    "securityhub.aws.upbound.io/StandardsSubscription": {
+      "singular": "standardssubscription",
+      "plural": "standardssubscriptions"
+    },
+    "serverlessrepo.aws.m.upbound.io/CloudFormationStack": {
+      "singular": "cloudformationstack",
+      "plural": "cloudformationstacks"
+    },
+    "serverlessrepo.aws.upbound.io/CloudFormationStack": {
+      "singular": "cloudformationstack",
+      "plural": "cloudformationstacks"
+    },
+    "servicecatalog.aws.m.upbound.io/BudgetResourceAssociation": {
+      "singular": "budgetresourceassociation",
+      "plural": "budgetresourceassociations"
+    },
+    "servicecatalog.aws.m.upbound.io/Constraint": {
+      "singular": "constraint",
+      "plural": "constraints"
+    },
+    "servicecatalog.aws.m.upbound.io/Portfolio": {
+      "singular": "portfolio",
+      "plural": "portfolios"
+    },
+    "servicecatalog.aws.m.upbound.io/PortfolioShare": {
+      "singular": "portfolioshare",
+      "plural": "portfolioshares"
+    },
+    "servicecatalog.aws.m.upbound.io/PrincipalPortfolioAssociation": {
+      "singular": "principalportfolioassociation",
+      "plural": "principalportfolioassociations"
+    },
+    "servicecatalog.aws.m.upbound.io/Product": {
+      "singular": "product",
+      "plural": "products"
+    },
+    "servicecatalog.aws.m.upbound.io/ProductPortfolioAssociation": {
+      "singular": "productportfolioassociation",
+      "plural": "productportfolioassociations"
+    },
+    "servicecatalog.aws.m.upbound.io/ProvisioningArtifact": {
+      "singular": "provisioningartifact",
+      "plural": "provisioningartifacts"
+    },
+    "servicecatalog.aws.m.upbound.io/ServiceAction": {
+      "singular": "serviceaction",
+      "plural": "serviceactions"
+    },
+    "servicecatalog.aws.m.upbound.io/TagOption": {
+      "singular": "tagoption",
+      "plural": "tagoptions"
+    },
+    "servicecatalog.aws.m.upbound.io/TagOptionResourceAssociation": {
+      "singular": "tagoptionresourceassociation",
+      "plural": "tagoptionresourceassociations"
+    },
+    "servicecatalog.aws.upbound.io/BudgetResourceAssociation": {
+      "singular": "budgetresourceassociation",
+      "plural": "budgetresourceassociations"
+    },
+    "servicecatalog.aws.upbound.io/Constraint": {
+      "singular": "constraint",
+      "plural": "constraints"
+    },
+    "servicecatalog.aws.upbound.io/Portfolio": {
+      "singular": "portfolio",
+      "plural": "portfolios"
+    },
+    "servicecatalog.aws.upbound.io/PortfolioShare": {
+      "singular": "portfolioshare",
+      "plural": "portfolioshares"
+    },
+    "servicecatalog.aws.upbound.io/PrincipalPortfolioAssociation": {
+      "singular": "principalportfolioassociation",
+      "plural": "principalportfolioassociations"
+    },
+    "servicecatalog.aws.upbound.io/Product": {
+      "singular": "product",
+      "plural": "products"
+    },
+    "servicecatalog.aws.upbound.io/ProductPortfolioAssociation": {
+      "singular": "productportfolioassociation",
+      "plural": "productportfolioassociations"
+    },
+    "servicecatalog.aws.upbound.io/ProvisioningArtifact": {
+      "singular": "provisioningartifact",
+      "plural": "provisioningartifacts"
+    },
+    "servicecatalog.aws.upbound.io/ServiceAction": {
+      "singular": "serviceaction",
+      "plural": "serviceactions"
+    },
+    "servicecatalog.aws.upbound.io/TagOption": {
+      "singular": "tagoption",
+      "plural": "tagoptions"
+    },
+    "servicecatalog.aws.upbound.io/TagOptionResourceAssociation": {
+      "singular": "tagoptionresourceassociation",
+      "plural": "tagoptionresourceassociations"
+    },
+    "servicediscovery.aws.m.upbound.io/HTTPNamespace": {
+      "singular": "httpnamespace",
+      "plural": "httpnamespaces"
+    },
+    "servicediscovery.aws.m.upbound.io/PrivateDNSNamespace": {
+      "singular": "privatednsnamespace",
+      "plural": "privatednsnamespaces"
+    },
+    "servicediscovery.aws.m.upbound.io/PublicDNSNamespace": {
+      "singular": "publicdnsnamespace",
+      "plural": "publicdnsnamespaces"
+    },
+    "servicediscovery.aws.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "servicediscovery.aws.upbound.io/HTTPNamespace": {
+      "singular": "httpnamespace",
+      "plural": "httpnamespaces"
+    },
+    "servicediscovery.aws.upbound.io/PrivateDNSNamespace": {
+      "singular": "privatednsnamespace",
+      "plural": "privatednsnamespaces"
+    },
+    "servicediscovery.aws.upbound.io/PublicDNSNamespace": {
+      "singular": "publicdnsnamespace",
+      "plural": "publicdnsnamespaces"
+    },
+    "servicediscovery.aws.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "servicequotas.aws.m.upbound.io/ServiceQuota": {
+      "singular": "servicequota",
+      "plural": "servicequotas"
+    },
+    "servicequotas.aws.upbound.io/ServiceQuota": {
+      "singular": "servicequota",
+      "plural": "servicequotas"
+    },
+    "ses.aws.m.upbound.io/ActiveReceiptRuleSet": {
+      "singular": "activereceiptruleset",
+      "plural": "activereceiptrulesets"
+    },
+    "ses.aws.m.upbound.io/ConfigurationSet": {
+      "singular": "configurationset",
+      "plural": "configurationsets"
+    },
+    "ses.aws.m.upbound.io/DomainDKIM": {
+      "singular": "domaindkim",
+      "plural": "domaindkims"
+    },
+    "ses.aws.m.upbound.io/DomainIdentity": {
+      "singular": "domainidentity",
+      "plural": "domainidentities"
+    },
+    "ses.aws.m.upbound.io/DomainMailFrom": {
+      "singular": "domainmailfrom",
+      "plural": "domainmailfroms"
+    },
+    "ses.aws.m.upbound.io/EmailIdentity": {
+      "singular": "emailidentity",
+      "plural": "emailidentities"
+    },
+    "ses.aws.m.upbound.io/EventDestination": {
+      "singular": "eventdestination",
+      "plural": "eventdestinations"
+    },
+    "ses.aws.m.upbound.io/IdentityNotificationTopic": {
+      "singular": "identitynotificationtopic",
+      "plural": "identitynotificationtopics"
+    },
+    "ses.aws.m.upbound.io/IdentityPolicy": {
+      "singular": "identitypolicy",
+      "plural": "identitypolicies"
+    },
+    "ses.aws.m.upbound.io/ReceiptFilter": {
+      "singular": "receiptfilter",
+      "plural": "receiptfilters"
+    },
+    "ses.aws.m.upbound.io/ReceiptRule": {
+      "singular": "receiptrule",
+      "plural": "receiptrules"
+    },
+    "ses.aws.m.upbound.io/ReceiptRuleSet": {
+      "singular": "receiptruleset",
+      "plural": "receiptrulesets"
+    },
+    "ses.aws.m.upbound.io/Template": {
+      "singular": "template",
+      "plural": "templates"
+    },
+    "ses.aws.upbound.io/ActiveReceiptRuleSet": {
+      "singular": "activereceiptruleset",
+      "plural": "activereceiptrulesets"
+    },
+    "ses.aws.upbound.io/ConfigurationSet": {
+      "singular": "configurationset",
+      "plural": "configurationsets"
+    },
+    "ses.aws.upbound.io/DomainDKIM": {
+      "singular": "domaindkim",
+      "plural": "domaindkims"
+    },
+    "ses.aws.upbound.io/DomainIdentity": {
+      "singular": "domainidentity",
+      "plural": "domainidentities"
+    },
+    "ses.aws.upbound.io/DomainMailFrom": {
+      "singular": "domainmailfrom",
+      "plural": "domainmailfroms"
+    },
+    "ses.aws.upbound.io/EmailIdentity": {
+      "singular": "emailidentity",
+      "plural": "emailidentities"
+    },
+    "ses.aws.upbound.io/EventDestination": {
+      "singular": "eventdestination",
+      "plural": "eventdestinations"
+    },
+    "ses.aws.upbound.io/IdentityNotificationTopic": {
+      "singular": "identitynotificationtopic",
+      "plural": "identitynotificationtopics"
+    },
+    "ses.aws.upbound.io/IdentityPolicy": {
+      "singular": "identitypolicy",
+      "plural": "identitypolicies"
+    },
+    "ses.aws.upbound.io/ReceiptFilter": {
+      "singular": "receiptfilter",
+      "plural": "receiptfilters"
+    },
+    "ses.aws.upbound.io/ReceiptRule": {
+      "singular": "receiptrule",
+      "plural": "receiptrules"
+    },
+    "ses.aws.upbound.io/ReceiptRuleSet": {
+      "singular": "receiptruleset",
+      "plural": "receiptrulesets"
+    },
+    "ses.aws.upbound.io/Template": {
+      "singular": "template",
+      "plural": "templates"
+    },
+    "sesv2.aws.m.upbound.io/ConfigurationSet": {
+      "singular": "configurationset",
+      "plural": "configurationsets"
+    },
+    "sesv2.aws.m.upbound.io/ConfigurationSetEventDestination": {
+      "singular": "configurationseteventdestination",
+      "plural": "configurationseteventdestinations"
+    },
+    "sesv2.aws.m.upbound.io/DedicatedIPPool": {
+      "singular": "dedicatedippool",
+      "plural": "dedicatedippools"
+    },
+    "sesv2.aws.m.upbound.io/EmailIdentity": {
+      "singular": "emailidentity",
+      "plural": "emailidentities"
+    },
+    "sesv2.aws.m.upbound.io/EmailIdentityFeedbackAttributes": {
+      "singular": "emailidentityfeedbackattributes",
+      "plural": "emailidentityfeedbackattributes"
+    },
+    "sesv2.aws.m.upbound.io/EmailIdentityMailFromAttributes": {
+      "singular": "emailidentitymailfromattributes",
+      "plural": "emailidentitymailfromattributes"
+    },
+    "sesv2.aws.upbound.io/ConfigurationSet": {
+      "singular": "configurationset",
+      "plural": "configurationsets"
+    },
+    "sesv2.aws.upbound.io/ConfigurationSetEventDestination": {
+      "singular": "configurationseteventdestination",
+      "plural": "configurationseteventdestinations"
+    },
+    "sesv2.aws.upbound.io/DedicatedIPPool": {
+      "singular": "dedicatedippool",
+      "plural": "dedicatedippools"
+    },
+    "sesv2.aws.upbound.io/EmailIdentity": {
+      "singular": "emailidentity",
+      "plural": "emailidentities"
+    },
+    "sesv2.aws.upbound.io/EmailIdentityFeedbackAttributes": {
+      "singular": "emailidentityfeedbackattributes",
+      "plural": "emailidentityfeedbackattributes"
+    },
+    "sesv2.aws.upbound.io/EmailIdentityMailFromAttributes": {
+      "singular": "emailidentitymailfromattributes",
+      "plural": "emailidentitymailfromattributes"
+    },
+    "sfn.aws.m.upbound.io/Activity": {
+      "singular": "activity",
+      "plural": "activities"
+    },
+    "sfn.aws.m.upbound.io/StateMachine": {
+      "singular": "statemachine",
+      "plural": "statemachines"
+    },
+    "sfn.aws.upbound.io/Activity": {
+      "singular": "activity",
+      "plural": "activities"
+    },
+    "sfn.aws.upbound.io/StateMachine": {
+      "singular": "statemachine",
+      "plural": "statemachines"
+    },
+    "signer.aws.m.upbound.io/SigningJob": {
+      "singular": "signingjob",
+      "plural": "signingjobs"
+    },
+    "signer.aws.m.upbound.io/SigningProfile": {
+      "singular": "signingprofile",
+      "plural": "signingprofiles"
+    },
+    "signer.aws.m.upbound.io/SigningProfilePermission": {
+      "singular": "signingprofilepermission",
+      "plural": "signingprofilepermissions"
+    },
+    "signer.aws.upbound.io/SigningJob": {
+      "singular": "signingjob",
+      "plural": "signingjobs"
+    },
+    "signer.aws.upbound.io/SigningProfile": {
+      "singular": "signingprofile",
+      "plural": "signingprofiles"
+    },
+    "signer.aws.upbound.io/SigningProfilePermission": {
+      "singular": "signingprofilepermission",
+      "plural": "signingprofilepermissions"
+    },
+    "sns.aws.m.upbound.io/PlatformApplication": {
+      "singular": "platformapplication",
+      "plural": "platformapplications"
+    },
+    "sns.aws.m.upbound.io/SMSPreferences": {
+      "singular": "smspreferences",
+      "plural": "smspreferences"
+    },
+    "sns.aws.m.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "sns.aws.m.upbound.io/TopicPolicy": {
+      "singular": "topicpolicy",
+      "plural": "topicpolicies"
+    },
+    "sns.aws.m.upbound.io/TopicSubscription": {
+      "singular": "topicsubscription",
+      "plural": "topicsubscriptions"
+    },
+    "sns.aws.upbound.io/PlatformApplication": {
+      "singular": "platformapplication",
+      "plural": "platformapplications"
+    },
+    "sns.aws.upbound.io/SMSPreferences": {
+      "singular": "smspreferences",
+      "plural": "smspreferences"
+    },
+    "sns.aws.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "sns.aws.upbound.io/TopicPolicy": {
+      "singular": "topicpolicy",
+      "plural": "topicpolicies"
+    },
+    "sns.aws.upbound.io/TopicSubscription": {
+      "singular": "topicsubscription",
+      "plural": "topicsubscriptions"
+    },
+    "sqs.aws.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "sqs.aws.m.upbound.io/QueuePolicy": {
+      "singular": "queuepolicy",
+      "plural": "queuepolicies"
+    },
+    "sqs.aws.m.upbound.io/QueueRedriveAllowPolicy": {
+      "singular": "queueredriveallowpolicy",
+      "plural": "queueredriveallowpolicies"
+    },
+    "sqs.aws.m.upbound.io/QueueRedrivePolicy": {
+      "singular": "queueredrivepolicy",
+      "plural": "queueredrivepolicies"
+    },
+    "sqs.aws.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "sqs.aws.upbound.io/QueuePolicy": {
+      "singular": "queuepolicy",
+      "plural": "queuepolicies"
+    },
+    "sqs.aws.upbound.io/QueueRedriveAllowPolicy": {
+      "singular": "queueredriveallowpolicy",
+      "plural": "queueredriveallowpolicies"
+    },
+    "sqs.aws.upbound.io/QueueRedrivePolicy": {
+      "singular": "queueredrivepolicy",
+      "plural": "queueredrivepolicies"
+    },
+    "ssm.aws.m.upbound.io/Activation": {
+      "singular": "activation",
+      "plural": "activations"
+    },
+    "ssm.aws.m.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "ssm.aws.m.upbound.io/DefaultPatchBaseline": {
+      "singular": "defaultpatchbaseline",
+      "plural": "defaultpatchbaselines"
+    },
+    "ssm.aws.m.upbound.io/Document": {
+      "singular": "document",
+      "plural": "documents"
+    },
+    "ssm.aws.m.upbound.io/MaintenanceWindow": {
+      "singular": "maintenancewindow",
+      "plural": "maintenancewindows"
+    },
+    "ssm.aws.m.upbound.io/MaintenanceWindowTarget": {
+      "singular": "maintenancewindowtarget",
+      "plural": "maintenancewindowtargets"
+    },
+    "ssm.aws.m.upbound.io/MaintenanceWindowTask": {
+      "singular": "maintenancewindowtask",
+      "plural": "maintenancewindowtasks"
+    },
+    "ssm.aws.m.upbound.io/Parameter": {
+      "singular": "parameter",
+      "plural": "parameters"
+    },
+    "ssm.aws.m.upbound.io/PatchBaseline": {
+      "singular": "patchbaseline",
+      "plural": "patchbaselines"
+    },
+    "ssm.aws.m.upbound.io/PatchGroup": {
+      "singular": "patchgroup",
+      "plural": "patchgroups"
+    },
+    "ssm.aws.m.upbound.io/ResourceDataSync": {
+      "singular": "resourcedatasync",
+      "plural": "resourcedatasyncs"
+    },
+    "ssm.aws.m.upbound.io/ServiceSetting": {
+      "singular": "servicesetting",
+      "plural": "servicesettings"
+    },
+    "ssm.aws.upbound.io/Activation": {
+      "singular": "activation",
+      "plural": "activations"
+    },
+    "ssm.aws.upbound.io/Association": {
+      "singular": "association",
+      "plural": "associations"
+    },
+    "ssm.aws.upbound.io/DefaultPatchBaseline": {
+      "singular": "defaultpatchbaseline",
+      "plural": "defaultpatchbaselines"
+    },
+    "ssm.aws.upbound.io/Document": {
+      "singular": "document",
+      "plural": "documents"
+    },
+    "ssm.aws.upbound.io/MaintenanceWindow": {
+      "singular": "maintenancewindow",
+      "plural": "maintenancewindows"
+    },
+    "ssm.aws.upbound.io/MaintenanceWindowTarget": {
+      "singular": "maintenancewindowtarget",
+      "plural": "maintenancewindowtargets"
+    },
+    "ssm.aws.upbound.io/MaintenanceWindowTask": {
+      "singular": "maintenancewindowtask",
+      "plural": "maintenancewindowtasks"
+    },
+    "ssm.aws.upbound.io/Parameter": {
+      "singular": "parameter",
+      "plural": "parameters"
+    },
+    "ssm.aws.upbound.io/PatchBaseline": {
+      "singular": "patchbaseline",
+      "plural": "patchbaselines"
+    },
+    "ssm.aws.upbound.io/PatchGroup": {
+      "singular": "patchgroup",
+      "plural": "patchgroups"
+    },
+    "ssm.aws.upbound.io/ResourceDataSync": {
+      "singular": "resourcedatasync",
+      "plural": "resourcedatasyncs"
+    },
+    "ssm.aws.upbound.io/ServiceSetting": {
+      "singular": "servicesetting",
+      "plural": "servicesettings"
+    },
+    "ssoadmin.aws.m.upbound.io/AccountAssignment": {
+      "singular": "accountassignment",
+      "plural": "accountassignments"
+    },
+    "ssoadmin.aws.m.upbound.io/CustomerManagedPolicyAttachment": {
+      "singular": "customermanagedpolicyattachment",
+      "plural": "customermanagedpolicyattachments"
+    },
+    "ssoadmin.aws.m.upbound.io/InstanceAccessControlAttributes": {
+      "singular": "instanceaccesscontrolattributes",
+      "plural": "instanceaccesscontrolattributes"
+    },
+    "ssoadmin.aws.m.upbound.io/ManagedPolicyAttachment": {
+      "singular": "managedpolicyattachment",
+      "plural": "managedpolicyattachments"
+    },
+    "ssoadmin.aws.m.upbound.io/PermissionSet": {
+      "singular": "permissionset",
+      "plural": "permissionsets"
+    },
+    "ssoadmin.aws.m.upbound.io/PermissionSetInlinePolicy": {
+      "singular": "permissionsetinlinepolicy",
+      "plural": "permissionsetinlinepolicies"
+    },
+    "ssoadmin.aws.m.upbound.io/PermissionsBoundaryAttachment": {
+      "singular": "permissionsboundaryattachment",
+      "plural": "permissionsboundaryattachments"
+    },
+    "ssoadmin.aws.upbound.io/AccountAssignment": {
+      "singular": "accountassignment",
+      "plural": "accountassignments"
+    },
+    "ssoadmin.aws.upbound.io/CustomerManagedPolicyAttachment": {
+      "singular": "customermanagedpolicyattachment",
+      "plural": "customermanagedpolicyattachments"
+    },
+    "ssoadmin.aws.upbound.io/InstanceAccessControlAttributes": {
+      "singular": "instanceaccesscontrolattributes",
+      "plural": "instanceaccesscontrolattributes"
+    },
+    "ssoadmin.aws.upbound.io/ManagedPolicyAttachment": {
+      "singular": "managedpolicyattachment",
+      "plural": "managedpolicyattachments"
+    },
+    "ssoadmin.aws.upbound.io/PermissionSet": {
+      "singular": "permissionset",
+      "plural": "permissionsets"
+    },
+    "ssoadmin.aws.upbound.io/PermissionSetInlinePolicy": {
+      "singular": "permissionsetinlinepolicy",
+      "plural": "permissionsetinlinepolicies"
+    },
+    "ssoadmin.aws.upbound.io/PermissionsBoundaryAttachment": {
+      "singular": "permissionsboundaryattachment",
+      "plural": "permissionsboundaryattachments"
+    },
+    "swf.aws.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "swf.aws.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "timestreaminfluxdb.aws.m.upbound.io/DBCluster": {
+      "singular": "dbcluster",
+      "plural": "dbclusters"
+    },
+    "timestreaminfluxdb.aws.m.upbound.io/DBInstance": {
+      "singular": "dbinstance",
+      "plural": "dbinstances"
+    },
+    "timestreaminfluxdb.aws.upbound.io/DBCluster": {
+      "singular": "dbcluster",
+      "plural": "dbclusters"
+    },
+    "timestreaminfluxdb.aws.upbound.io/DBInstance": {
+      "singular": "dbinstance",
+      "plural": "dbinstances"
+    },
+    "timestreamwrite.aws.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "timestreamwrite.aws.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "timestreamwrite.aws.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "timestreamwrite.aws.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "transcribe.aws.m.upbound.io/LanguageModel": {
+      "singular": "languagemodel",
+      "plural": "languagemodels"
+    },
+    "transcribe.aws.m.upbound.io/Vocabulary": {
+      "singular": "vocabulary",
+      "plural": "vocabularies"
+    },
+    "transcribe.aws.m.upbound.io/VocabularyFilter": {
+      "singular": "vocabularyfilter",
+      "plural": "vocabularyfilters"
+    },
+    "transcribe.aws.upbound.io/LanguageModel": {
+      "singular": "languagemodel",
+      "plural": "languagemodels"
+    },
+    "transcribe.aws.upbound.io/Vocabulary": {
+      "singular": "vocabulary",
+      "plural": "vocabularies"
+    },
+    "transcribe.aws.upbound.io/VocabularyFilter": {
+      "singular": "vocabularyfilter",
+      "plural": "vocabularyfilters"
+    },
+    "transfer.aws.m.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "transfer.aws.m.upbound.io/SSHKey": {
+      "singular": "sshkey",
+      "plural": "sshkeys"
+    },
+    "transfer.aws.m.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "transfer.aws.m.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "transfer.aws.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "transfer.aws.m.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    },
+    "transfer.aws.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "transfer.aws.upbound.io/SSHKey": {
+      "singular": "sshkey",
+      "plural": "sshkeys"
+    },
+    "transfer.aws.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "transfer.aws.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "transfer.aws.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "transfer.aws.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    },
+    "verifiedaccess.aws.m.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "verifiedaccess.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "verifiedaccess.aws.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "verifiedaccess.aws.m.upbound.io/InstanceLoggingConfiguration": {
+      "singular": "instanceloggingconfiguration",
+      "plural": "instanceloggingconfigurations"
+    },
+    "verifiedaccess.aws.m.upbound.io/InstanceTrustProviderAttachment": {
+      "singular": "instancetrustproviderattachment",
+      "plural": "instancetrustproviderattachments"
+    },
+    "verifiedaccess.aws.m.upbound.io/TrustProvider": {
+      "singular": "trustprovider",
+      "plural": "trustproviders"
+    },
+    "verifiedaccess.aws.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "verifiedaccess.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "verifiedaccess.aws.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "verifiedaccess.aws.upbound.io/InstanceLoggingConfiguration": {
+      "singular": "instanceloggingconfiguration",
+      "plural": "instanceloggingconfigurations"
+    },
+    "verifiedaccess.aws.upbound.io/InstanceTrustProviderAttachment": {
+      "singular": "instancetrustproviderattachment",
+      "plural": "instancetrustproviderattachments"
+    },
+    "verifiedaccess.aws.upbound.io/TrustProvider": {
+      "singular": "trustprovider",
+      "plural": "trustproviders"
+    },
+    "vpc.aws.m.upbound.io/NetworkPerformanceMetricSubscription": {
+      "singular": "networkperformancemetricsubscription",
+      "plural": "networkperformancemetricsubscriptions"
+    },
+    "vpc.aws.upbound.io/NetworkPerformanceMetricSubscription": {
+      "singular": "networkperformancemetricsubscription",
+      "plural": "networkperformancemetricsubscriptions"
+    },
+    "vpclattice.aws.m.upbound.io/AccessLogSubscription": {
+      "singular": "accesslogsubscription",
+      "plural": "accesslogsubscriptions"
+    },
+    "vpclattice.aws.m.upbound.io/AuthPolicy": {
+      "singular": "authpolicy",
+      "plural": "authpolicies"
+    },
+    "vpclattice.aws.m.upbound.io/Listener": {
+      "singular": "listener",
+      "plural": "listeners"
+    },
+    "vpclattice.aws.m.upbound.io/ListenerRule": {
+      "singular": "listenerrule",
+      "plural": "listenerrules"
+    },
+    "vpclattice.aws.m.upbound.io/ResourceConfiguration": {
+      "singular": "resourceconfiguration",
+      "plural": "resourceconfigurations"
+    },
+    "vpclattice.aws.m.upbound.io/ResourceGateway": {
+      "singular": "resourcegateway",
+      "plural": "resourcegateways"
+    },
+    "vpclattice.aws.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "vpclattice.aws.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "vpclattice.aws.m.upbound.io/ServiceNetwork": {
+      "singular": "servicenetwork",
+      "plural": "servicenetworks"
+    },
+    "vpclattice.aws.m.upbound.io/ServiceNetworkResourceAssociation": {
+      "singular": "servicenetworkresourceassociation",
+      "plural": "servicenetworkresourceassociations"
+    },
+    "vpclattice.aws.m.upbound.io/ServiceNetworkServiceAssociation": {
+      "singular": "servicenetworkserviceassociation",
+      "plural": "servicenetworkserviceassociations"
+    },
+    "vpclattice.aws.m.upbound.io/ServiceNetworkVPCAssociation": {
+      "singular": "servicenetworkvpcassociation",
+      "plural": "servicenetworkvpcassociations"
+    },
+    "vpclattice.aws.m.upbound.io/TargetGroup": {
+      "singular": "targetgroup",
+      "plural": "targetgroups"
+    },
+    "vpclattice.aws.m.upbound.io/TargetGroupAttachment": {
+      "singular": "targetgroupattachment",
+      "plural": "targetgroupattachments"
+    },
+    "vpclattice.aws.upbound.io/AccessLogSubscription": {
+      "singular": "accesslogsubscription",
+      "plural": "accesslogsubscriptions"
+    },
+    "vpclattice.aws.upbound.io/AuthPolicy": {
+      "singular": "authpolicy",
+      "plural": "authpolicies"
+    },
+    "vpclattice.aws.upbound.io/Listener": {
+      "singular": "listener",
+      "plural": "listeners"
+    },
+    "vpclattice.aws.upbound.io/ListenerRule": {
+      "singular": "listenerrule",
+      "plural": "listenerrules"
+    },
+    "vpclattice.aws.upbound.io/ResourceConfiguration": {
+      "singular": "resourceconfiguration",
+      "plural": "resourceconfigurations"
+    },
+    "vpclattice.aws.upbound.io/ResourceGateway": {
+      "singular": "resourcegateway",
+      "plural": "resourcegateways"
+    },
+    "vpclattice.aws.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "vpclattice.aws.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "vpclattice.aws.upbound.io/ServiceNetwork": {
+      "singular": "servicenetwork",
+      "plural": "servicenetworks"
+    },
+    "vpclattice.aws.upbound.io/ServiceNetworkResourceAssociation": {
+      "singular": "servicenetworkresourceassociation",
+      "plural": "servicenetworkresourceassociations"
+    },
+    "vpclattice.aws.upbound.io/ServiceNetworkServiceAssociation": {
+      "singular": "servicenetworkserviceassociation",
+      "plural": "servicenetworkserviceassociations"
+    },
+    "vpclattice.aws.upbound.io/ServiceNetworkVPCAssociation": {
+      "singular": "servicenetworkvpcassociation",
+      "plural": "servicenetworkvpcassociations"
+    },
+    "vpclattice.aws.upbound.io/TargetGroup": {
+      "singular": "targetgroup",
+      "plural": "targetgroups"
+    },
+    "vpclattice.aws.upbound.io/TargetGroupAttachment": {
+      "singular": "targetgroupattachment",
+      "plural": "targetgroupattachments"
+    },
+    "waf.aws.m.upbound.io/ByteMatchSet": {
+      "singular": "bytematchset",
+      "plural": "bytematchsets"
+    },
+    "waf.aws.m.upbound.io/GeoMatchSet": {
+      "singular": "geomatchset",
+      "plural": "geomatchsets"
+    },
+    "waf.aws.m.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "waf.aws.m.upbound.io/RateBasedRule": {
+      "singular": "ratebasedrule",
+      "plural": "ratebasedrules"
+    },
+    "waf.aws.m.upbound.io/RegexMatchSet": {
+      "singular": "regexmatchset",
+      "plural": "regexmatchsets"
+    },
+    "waf.aws.m.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "waf.aws.m.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "waf.aws.m.upbound.io/SQLInjectionMatchSet": {
+      "singular": "sqlinjectionmatchset",
+      "plural": "sqlinjectionmatchsets"
+    },
+    "waf.aws.m.upbound.io/SizeConstraintSet": {
+      "singular": "sizeconstraintset",
+      "plural": "sizeconstraintsets"
+    },
+    "waf.aws.m.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "waf.aws.m.upbound.io/XSSMatchSet": {
+      "singular": "xssmatchset",
+      "plural": "xssmatchsets"
+    },
+    "waf.aws.upbound.io/ByteMatchSet": {
+      "singular": "bytematchset",
+      "plural": "bytematchsets"
+    },
+    "waf.aws.upbound.io/GeoMatchSet": {
+      "singular": "geomatchset",
+      "plural": "geomatchsets"
+    },
+    "waf.aws.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "waf.aws.upbound.io/RateBasedRule": {
+      "singular": "ratebasedrule",
+      "plural": "ratebasedrules"
+    },
+    "waf.aws.upbound.io/RegexMatchSet": {
+      "singular": "regexmatchset",
+      "plural": "regexmatchsets"
+    },
+    "waf.aws.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "waf.aws.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "waf.aws.upbound.io/SQLInjectionMatchSet": {
+      "singular": "sqlinjectionmatchset",
+      "plural": "sqlinjectionmatchsets"
+    },
+    "waf.aws.upbound.io/SizeConstraintSet": {
+      "singular": "sizeconstraintset",
+      "plural": "sizeconstraintsets"
+    },
+    "waf.aws.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "waf.aws.upbound.io/XSSMatchSet": {
+      "singular": "xssmatchset",
+      "plural": "xssmatchsets"
+    },
+    "wafregional.aws.m.upbound.io/ByteMatchSet": {
+      "singular": "bytematchset",
+      "plural": "bytematchsets"
+    },
+    "wafregional.aws.m.upbound.io/GeoMatchSet": {
+      "singular": "geomatchset",
+      "plural": "geomatchsets"
+    },
+    "wafregional.aws.m.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "wafregional.aws.m.upbound.io/RateBasedRule": {
+      "singular": "ratebasedrule",
+      "plural": "ratebasedrules"
+    },
+    "wafregional.aws.m.upbound.io/RegexMatchSet": {
+      "singular": "regexmatchset",
+      "plural": "regexmatchsets"
+    },
+    "wafregional.aws.m.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "wafregional.aws.m.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "wafregional.aws.m.upbound.io/SQLInjectionMatchSet": {
+      "singular": "sqlinjectionmatchset",
+      "plural": "sqlinjectionmatchsets"
+    },
+    "wafregional.aws.m.upbound.io/SizeConstraintSet": {
+      "singular": "sizeconstraintset",
+      "plural": "sizeconstraintsets"
+    },
+    "wafregional.aws.m.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "wafregional.aws.m.upbound.io/XSSMatchSet": {
+      "singular": "xssmatchset",
+      "plural": "xssmatchsets"
+    },
+    "wafregional.aws.upbound.io/ByteMatchSet": {
+      "singular": "bytematchset",
+      "plural": "bytematchsets"
+    },
+    "wafregional.aws.upbound.io/GeoMatchSet": {
+      "singular": "geomatchset",
+      "plural": "geomatchsets"
+    },
+    "wafregional.aws.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "wafregional.aws.upbound.io/RateBasedRule": {
+      "singular": "ratebasedrule",
+      "plural": "ratebasedrules"
+    },
+    "wafregional.aws.upbound.io/RegexMatchSet": {
+      "singular": "regexmatchset",
+      "plural": "regexmatchsets"
+    },
+    "wafregional.aws.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "wafregional.aws.upbound.io/Rule": {
+      "singular": "rule",
+      "plural": "rules"
+    },
+    "wafregional.aws.upbound.io/SQLInjectionMatchSet": {
+      "singular": "sqlinjectionmatchset",
+      "plural": "sqlinjectionmatchsets"
+    },
+    "wafregional.aws.upbound.io/SizeConstraintSet": {
+      "singular": "sizeconstraintset",
+      "plural": "sizeconstraintsets"
+    },
+    "wafregional.aws.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "wafregional.aws.upbound.io/XSSMatchSet": {
+      "singular": "xssmatchset",
+      "plural": "xssmatchsets"
+    },
+    "wafv2.aws.m.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "wafv2.aws.m.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "wafv2.aws.m.upbound.io/RuleGroup": {
+      "singular": "rulegroup",
+      "plural": "rulegroups"
+    },
+    "wafv2.aws.m.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "wafv2.aws.m.upbound.io/WebACLAssociation": {
+      "singular": "webaclassociation",
+      "plural": "webaclassociations"
+    },
+    "wafv2.aws.m.upbound.io/WebACLLoggingConfiguration": {
+      "singular": "webaclloggingconfiguration",
+      "plural": "webaclloggingconfigurations"
+    },
+    "wafv2.aws.m.upbound.io/WebACLRuleGroupAssociation": {
+      "singular": "webaclrulegroupassociation",
+      "plural": "webaclrulegroupassociations"
+    },
+    "wafv2.aws.upbound.io/IPSet": {
+      "singular": "ipset",
+      "plural": "ipsets"
+    },
+    "wafv2.aws.upbound.io/RegexPatternSet": {
+      "singular": "regexpatternset",
+      "plural": "regexpatternsets"
+    },
+    "wafv2.aws.upbound.io/RuleGroup": {
+      "singular": "rulegroup",
+      "plural": "rulegroups"
+    },
+    "wafv2.aws.upbound.io/WebACL": {
+      "singular": "webacl",
+      "plural": "webacls"
+    },
+    "wafv2.aws.upbound.io/WebACLAssociation": {
+      "singular": "webaclassociation",
+      "plural": "webaclassociations"
+    },
+    "wafv2.aws.upbound.io/WebACLLoggingConfiguration": {
+      "singular": "webaclloggingconfiguration",
+      "plural": "webaclloggingconfigurations"
+    },
+    "wafv2.aws.upbound.io/WebACLRuleGroupAssociation": {
+      "singular": "webaclrulegroupassociation",
+      "plural": "webaclrulegroupassociations"
+    },
+    "workspaces.aws.m.upbound.io/Directory": {
+      "singular": "directory",
+      "plural": "directories"
+    },
+    "workspaces.aws.m.upbound.io/IPGroup": {
+      "singular": "ipgroup",
+      "plural": "ipgroups"
+    },
+    "workspaces.aws.upbound.io/Directory": {
+      "singular": "directory",
+      "plural": "directories"
+    },
+    "workspaces.aws.upbound.io/IPGroup": {
+      "singular": "ipgroup",
+      "plural": "ipgroups"
+    },
+    "xray.aws.m.upbound.io/EncryptionConfig": {
+      "singular": "encryptionconfig",
+      "plural": "encryptionconfigs"
+    },
+    "xray.aws.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "xray.aws.m.upbound.io/SamplingRule": {
+      "singular": "samplingrule",
+      "plural": "samplingrules"
+    },
+    "xray.aws.upbound.io/EncryptionConfig": {
+      "singular": "encryptionconfig",
+      "plural": "encryptionconfigs"
+    },
+    "xray.aws.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "xray.aws.upbound.io/SamplingRule": {
+      "singular": "samplingrule",
+      "plural": "samplingrules"
+    }
+  },
   "files": [
     "catalog/accessanalyzer.aws.m.upbound.io/analyzer_v1beta1.fields.txt",
     "catalog/accessanalyzer.aws.m.upbound.io/analyzer_v1beta1.json",

--- a/build/history/provider-upjet-azure.json
+++ b/build/history/provider-upjet-azure.json
@@ -2,8 +2,8 @@
   "name": "provider-upjet-azure",
   "repo": "crossplane-contrib/provider-upjet-azure",
   "version": "v2.6.0",
-  "builtAt": "2026-07-05T14:58:42.386Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:33.305Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "alertsmanagement.azure.m.upbound.io/MonitorAlertProcessingRuleActionGroup",
     "alertsmanagement.azure.m.upbound.io/MonitorAlertProcessingRuleSuppression",
@@ -1529,6 +1529,6100 @@
     "web.azure.upbound.io/WindowsWebApp",
     "web.azure.upbound.io/WindowsWebAppSlot"
   ],
+  "resources": {
+    "alertsmanagement.azure.m.upbound.io/MonitorAlertProcessingRuleActionGroup": {
+      "singular": "monitoralertprocessingruleactiongroup",
+      "plural": "monitoralertprocessingruleactiongroups"
+    },
+    "alertsmanagement.azure.m.upbound.io/MonitorAlertProcessingRuleSuppression": {
+      "singular": "monitoralertprocessingrulesuppression",
+      "plural": "monitoralertprocessingrulesuppressions"
+    },
+    "alertsmanagement.azure.m.upbound.io/MonitorAlertPrometheusRuleGroup": {
+      "singular": "monitoralertprometheusrulegroup",
+      "plural": "monitoralertprometheusrulegroups"
+    },
+    "alertsmanagement.azure.m.upbound.io/MonitorSmartDetectorAlertRule": {
+      "singular": "monitorsmartdetectoralertrule",
+      "plural": "monitorsmartdetectoralertrules"
+    },
+    "alertsmanagement.azure.upbound.io/MonitorAlertProcessingRuleActionGroup": {
+      "singular": "monitoralertprocessingruleactiongroup",
+      "plural": "monitoralertprocessingruleactiongroups"
+    },
+    "alertsmanagement.azure.upbound.io/MonitorAlertProcessingRuleSuppression": {
+      "singular": "monitoralertprocessingrulesuppression",
+      "plural": "monitoralertprocessingrulesuppressions"
+    },
+    "alertsmanagement.azure.upbound.io/MonitorAlertPrometheusRuleGroup": {
+      "singular": "monitoralertprometheusrulegroup",
+      "plural": "monitoralertprometheusrulegroups"
+    },
+    "alertsmanagement.azure.upbound.io/MonitorSmartDetectorAlertRule": {
+      "singular": "monitorsmartdetectoralertrule",
+      "plural": "monitorsmartdetectoralertrules"
+    },
+    "analysisservices.azure.m.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "analysisservices.azure.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "apimanagement.azure.m.upbound.io/API": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apimanagement.azure.m.upbound.io/APIDiagnostic": {
+      "singular": "apidiagnostic",
+      "plural": "apidiagnostics"
+    },
+    "apimanagement.azure.m.upbound.io/APIOperation": {
+      "singular": "apioperation",
+      "plural": "apioperations"
+    },
+    "apimanagement.azure.m.upbound.io/APIOperationPolicy": {
+      "singular": "apioperationpolicy",
+      "plural": "apioperationpolicies"
+    },
+    "apimanagement.azure.m.upbound.io/APIOperationTag": {
+      "singular": "apioperationtag",
+      "plural": "apioperationtags"
+    },
+    "apimanagement.azure.m.upbound.io/APIPolicy": {
+      "singular": "apipolicy",
+      "plural": "apipolicies"
+    },
+    "apimanagement.azure.m.upbound.io/APIRelease": {
+      "singular": "apirelease",
+      "plural": "apireleases"
+    },
+    "apimanagement.azure.m.upbound.io/APISchema": {
+      "singular": "apischema",
+      "plural": "apischemas"
+    },
+    "apimanagement.azure.m.upbound.io/APITag": {
+      "singular": "apitag",
+      "plural": "apitags"
+    },
+    "apimanagement.azure.m.upbound.io/APIVersionSet": {
+      "singular": "apiversionset",
+      "plural": "apiversionsets"
+    },
+    "apimanagement.azure.m.upbound.io/AuthorizationServer": {
+      "singular": "authorizationserver",
+      "plural": "authorizationservers"
+    },
+    "apimanagement.azure.m.upbound.io/Backend": {
+      "singular": "backend",
+      "plural": "backends"
+    },
+    "apimanagement.azure.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "apimanagement.azure.m.upbound.io/CustomDomain": {
+      "singular": "customdomain",
+      "plural": "customdomains"
+    },
+    "apimanagement.azure.m.upbound.io/Diagnostic": {
+      "singular": "diagnostic",
+      "plural": "diagnostics"
+    },
+    "apimanagement.azure.m.upbound.io/EmailTemplate": {
+      "singular": "emailtemplate",
+      "plural": "emailtemplates"
+    },
+    "apimanagement.azure.m.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "apimanagement.azure.m.upbound.io/GatewayAPI": {
+      "singular": "gatewayapi",
+      "plural": "gatewayapis"
+    },
+    "apimanagement.azure.m.upbound.io/GlobalSchema": {
+      "singular": "globalschema",
+      "plural": "globalschemas"
+    },
+    "apimanagement.azure.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "apimanagement.azure.m.upbound.io/IdentityProviderAAD": {
+      "singular": "identityprovideraad",
+      "plural": "identityprovideraads"
+    },
+    "apimanagement.azure.m.upbound.io/IdentityProviderFacebook": {
+      "singular": "identityproviderfacebook",
+      "plural": "identityproviderfacebooks"
+    },
+    "apimanagement.azure.m.upbound.io/IdentityProviderGoogle": {
+      "singular": "identityprovidergoogle",
+      "plural": "identityprovidergoogles"
+    },
+    "apimanagement.azure.m.upbound.io/IdentityProviderMicrosoft": {
+      "singular": "identityprovidermicrosoft",
+      "plural": "identityprovidermicrosofts"
+    },
+    "apimanagement.azure.m.upbound.io/IdentityProviderTwitter": {
+      "singular": "identityprovidertwitter",
+      "plural": "identityprovidertwitters"
+    },
+    "apimanagement.azure.m.upbound.io/Logger": {
+      "singular": "logger",
+      "plural": "loggers"
+    },
+    "apimanagement.azure.m.upbound.io/Management": {
+      "singular": "management",
+      "plural": "managements"
+    },
+    "apimanagement.azure.m.upbound.io/NamedValue": {
+      "singular": "namedvalue",
+      "plural": "namedvalues"
+    },
+    "apimanagement.azure.m.upbound.io/NotificationRecipientEmail": {
+      "singular": "notificationrecipientemail",
+      "plural": "notificationrecipientemails"
+    },
+    "apimanagement.azure.m.upbound.io/NotificationRecipientUser": {
+      "singular": "notificationrecipientuser",
+      "plural": "notificationrecipientusers"
+    },
+    "apimanagement.azure.m.upbound.io/OpenIDConnectProvider": {
+      "singular": "openidconnectprovider",
+      "plural": "openidconnectproviders"
+    },
+    "apimanagement.azure.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "apimanagement.azure.m.upbound.io/PolicyFragment": {
+      "singular": "policyfragment",
+      "plural": "policyfragments"
+    },
+    "apimanagement.azure.m.upbound.io/Product": {
+      "singular": "product",
+      "plural": "products"
+    },
+    "apimanagement.azure.m.upbound.io/ProductAPI": {
+      "singular": "productapi",
+      "plural": "productapis"
+    },
+    "apimanagement.azure.m.upbound.io/ProductGroup": {
+      "singular": "productgroup",
+      "plural": "productgroups"
+    },
+    "apimanagement.azure.m.upbound.io/ProductPolicy": {
+      "singular": "productpolicy",
+      "plural": "productpolicies"
+    },
+    "apimanagement.azure.m.upbound.io/ProductTag": {
+      "singular": "producttag",
+      "plural": "producttags"
+    },
+    "apimanagement.azure.m.upbound.io/RedisCache": {
+      "singular": "rediscache",
+      "plural": "rediscaches"
+    },
+    "apimanagement.azure.m.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "apimanagement.azure.m.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "apimanagement.azure.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "apimanagement.azure.upbound.io/API": {
+      "singular": "api",
+      "plural": "apis"
+    },
+    "apimanagement.azure.upbound.io/APIDiagnostic": {
+      "singular": "apidiagnostic",
+      "plural": "apidiagnostics"
+    },
+    "apimanagement.azure.upbound.io/APIOperation": {
+      "singular": "apioperation",
+      "plural": "apioperations"
+    },
+    "apimanagement.azure.upbound.io/APIOperationPolicy": {
+      "singular": "apioperationpolicy",
+      "plural": "apioperationpolicies"
+    },
+    "apimanagement.azure.upbound.io/APIOperationTag": {
+      "singular": "apioperationtag",
+      "plural": "apioperationtags"
+    },
+    "apimanagement.azure.upbound.io/APIPolicy": {
+      "singular": "apipolicy",
+      "plural": "apipolicies"
+    },
+    "apimanagement.azure.upbound.io/APIRelease": {
+      "singular": "apirelease",
+      "plural": "apireleases"
+    },
+    "apimanagement.azure.upbound.io/APISchema": {
+      "singular": "apischema",
+      "plural": "apischemas"
+    },
+    "apimanagement.azure.upbound.io/APITag": {
+      "singular": "apitag",
+      "plural": "apitags"
+    },
+    "apimanagement.azure.upbound.io/APIVersionSet": {
+      "singular": "apiversionset",
+      "plural": "apiversionsets"
+    },
+    "apimanagement.azure.upbound.io/AuthorizationServer": {
+      "singular": "authorizationserver",
+      "plural": "authorizationservers"
+    },
+    "apimanagement.azure.upbound.io/Backend": {
+      "singular": "backend",
+      "plural": "backends"
+    },
+    "apimanagement.azure.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "apimanagement.azure.upbound.io/CustomDomain": {
+      "singular": "customdomain",
+      "plural": "customdomains"
+    },
+    "apimanagement.azure.upbound.io/Diagnostic": {
+      "singular": "diagnostic",
+      "plural": "diagnostics"
+    },
+    "apimanagement.azure.upbound.io/EmailTemplate": {
+      "singular": "emailtemplate",
+      "plural": "emailtemplates"
+    },
+    "apimanagement.azure.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "apimanagement.azure.upbound.io/GatewayAPI": {
+      "singular": "gatewayapi",
+      "plural": "gatewayapis"
+    },
+    "apimanagement.azure.upbound.io/GlobalSchema": {
+      "singular": "globalschema",
+      "plural": "globalschemas"
+    },
+    "apimanagement.azure.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "apimanagement.azure.upbound.io/IdentityProviderAAD": {
+      "singular": "identityprovideraad",
+      "plural": "identityprovideraads"
+    },
+    "apimanagement.azure.upbound.io/IdentityProviderFacebook": {
+      "singular": "identityproviderfacebook",
+      "plural": "identityproviderfacebooks"
+    },
+    "apimanagement.azure.upbound.io/IdentityProviderGoogle": {
+      "singular": "identityprovidergoogle",
+      "plural": "identityprovidergoogles"
+    },
+    "apimanagement.azure.upbound.io/IdentityProviderMicrosoft": {
+      "singular": "identityprovidermicrosoft",
+      "plural": "identityprovidermicrosofts"
+    },
+    "apimanagement.azure.upbound.io/IdentityProviderTwitter": {
+      "singular": "identityprovidertwitter",
+      "plural": "identityprovidertwitters"
+    },
+    "apimanagement.azure.upbound.io/Logger": {
+      "singular": "logger",
+      "plural": "loggers"
+    },
+    "apimanagement.azure.upbound.io/Management": {
+      "singular": "management",
+      "plural": "managements"
+    },
+    "apimanagement.azure.upbound.io/NamedValue": {
+      "singular": "namedvalue",
+      "plural": "namedvalues"
+    },
+    "apimanagement.azure.upbound.io/NotificationRecipientEmail": {
+      "singular": "notificationrecipientemail",
+      "plural": "notificationrecipientemails"
+    },
+    "apimanagement.azure.upbound.io/NotificationRecipientUser": {
+      "singular": "notificationrecipientuser",
+      "plural": "notificationrecipientusers"
+    },
+    "apimanagement.azure.upbound.io/OpenIDConnectProvider": {
+      "singular": "openidconnectprovider",
+      "plural": "openidconnectproviders"
+    },
+    "apimanagement.azure.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "apimanagement.azure.upbound.io/PolicyFragment": {
+      "singular": "policyfragment",
+      "plural": "policyfragments"
+    },
+    "apimanagement.azure.upbound.io/Product": {
+      "singular": "product",
+      "plural": "products"
+    },
+    "apimanagement.azure.upbound.io/ProductAPI": {
+      "singular": "productapi",
+      "plural": "productapis"
+    },
+    "apimanagement.azure.upbound.io/ProductGroup": {
+      "singular": "productgroup",
+      "plural": "productgroups"
+    },
+    "apimanagement.azure.upbound.io/ProductPolicy": {
+      "singular": "productpolicy",
+      "plural": "productpolicies"
+    },
+    "apimanagement.azure.upbound.io/ProductTag": {
+      "singular": "producttag",
+      "plural": "producttags"
+    },
+    "apimanagement.azure.upbound.io/RedisCache": {
+      "singular": "rediscache",
+      "plural": "rediscaches"
+    },
+    "apimanagement.azure.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "apimanagement.azure.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "apimanagement.azure.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "appconfiguration.azure.m.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "appconfiguration.azure.m.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "appconfiguration.azure.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "appconfiguration.azure.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAPIPortal": {
+      "singular": "springcloudapiportal",
+      "plural": "springcloudapiportals"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAPIPortalCustomDomain": {
+      "singular": "springcloudapiportalcustomdomain",
+      "plural": "springcloudapiportalcustomdomains"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAccelerator": {
+      "singular": "springcloudaccelerator",
+      "plural": "springcloudaccelerators"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudActiveDeployment": {
+      "singular": "springcloudactivedeployment",
+      "plural": "springcloudactivedeployments"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudApp": {
+      "singular": "springcloudapp",
+      "plural": "springcloudapps"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAppCosmosDBAssociation": {
+      "singular": "springcloudappcosmosdbassociation",
+      "plural": "springcloudappcosmosdbassociations"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAppMySQLAssociation": {
+      "singular": "springcloudappmysqlassociation",
+      "plural": "springcloudappmysqlassociations"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudAppRedisAssociation": {
+      "singular": "springcloudappredisassociation",
+      "plural": "springcloudappredisassociations"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudBuildDeployment": {
+      "singular": "springcloudbuilddeployment",
+      "plural": "springcloudbuilddeployments"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudBuildPackBinding": {
+      "singular": "springcloudbuildpackbinding",
+      "plural": "springcloudbuildpackbindings"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudBuilder": {
+      "singular": "springcloudbuilder",
+      "plural": "springcloudbuilders"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudCertificate": {
+      "singular": "springcloudcertificate",
+      "plural": "springcloudcertificates"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudConfigurationService": {
+      "singular": "springcloudconfigurationservice",
+      "plural": "springcloudconfigurationservices"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudContainerDeployment": {
+      "singular": "springcloudcontainerdeployment",
+      "plural": "springcloudcontainerdeployments"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudCustomDomain": {
+      "singular": "springcloudcustomdomain",
+      "plural": "springcloudcustomdomains"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudCustomizedAccelerator": {
+      "singular": "springcloudcustomizedaccelerator",
+      "plural": "springcloudcustomizedaccelerators"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudDevToolPortal": {
+      "singular": "springclouddevtoolportal",
+      "plural": "springclouddevtoolportals"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudGateway": {
+      "singular": "springcloudgateway",
+      "plural": "springcloudgateways"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudGatewayCustomDomain": {
+      "singular": "springcloudgatewaycustomdomain",
+      "plural": "springcloudgatewaycustomdomains"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudJavaDeployment": {
+      "singular": "springcloudjavadeployment",
+      "plural": "springcloudjavadeployments"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudService": {
+      "singular": "springcloudservice",
+      "plural": "springcloudservices"
+    },
+    "appplatform.azure.m.upbound.io/SpringCloudStorage": {
+      "singular": "springcloudstorage",
+      "plural": "springcloudstorages"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAPIPortal": {
+      "singular": "springcloudapiportal",
+      "plural": "springcloudapiportals"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAPIPortalCustomDomain": {
+      "singular": "springcloudapiportalcustomdomain",
+      "plural": "springcloudapiportalcustomdomains"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAccelerator": {
+      "singular": "springcloudaccelerator",
+      "plural": "springcloudaccelerators"
+    },
+    "appplatform.azure.upbound.io/SpringCloudActiveDeployment": {
+      "singular": "springcloudactivedeployment",
+      "plural": "springcloudactivedeployments"
+    },
+    "appplatform.azure.upbound.io/SpringCloudApp": {
+      "singular": "springcloudapp",
+      "plural": "springcloudapps"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAppCosmosDBAssociation": {
+      "singular": "springcloudappcosmosdbassociation",
+      "plural": "springcloudappcosmosdbassociations"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAppMySQLAssociation": {
+      "singular": "springcloudappmysqlassociation",
+      "plural": "springcloudappmysqlassociations"
+    },
+    "appplatform.azure.upbound.io/SpringCloudAppRedisAssociation": {
+      "singular": "springcloudappredisassociation",
+      "plural": "springcloudappredisassociations"
+    },
+    "appplatform.azure.upbound.io/SpringCloudBuildDeployment": {
+      "singular": "springcloudbuilddeployment",
+      "plural": "springcloudbuilddeployments"
+    },
+    "appplatform.azure.upbound.io/SpringCloudBuildPackBinding": {
+      "singular": "springcloudbuildpackbinding",
+      "plural": "springcloudbuildpackbindings"
+    },
+    "appplatform.azure.upbound.io/SpringCloudBuilder": {
+      "singular": "springcloudbuilder",
+      "plural": "springcloudbuilders"
+    },
+    "appplatform.azure.upbound.io/SpringCloudCertificate": {
+      "singular": "springcloudcertificate",
+      "plural": "springcloudcertificates"
+    },
+    "appplatform.azure.upbound.io/SpringCloudConfigurationService": {
+      "singular": "springcloudconfigurationservice",
+      "plural": "springcloudconfigurationservices"
+    },
+    "appplatform.azure.upbound.io/SpringCloudContainerDeployment": {
+      "singular": "springcloudcontainerdeployment",
+      "plural": "springcloudcontainerdeployments"
+    },
+    "appplatform.azure.upbound.io/SpringCloudCustomDomain": {
+      "singular": "springcloudcustomdomain",
+      "plural": "springcloudcustomdomains"
+    },
+    "appplatform.azure.upbound.io/SpringCloudCustomizedAccelerator": {
+      "singular": "springcloudcustomizedaccelerator",
+      "plural": "springcloudcustomizedaccelerators"
+    },
+    "appplatform.azure.upbound.io/SpringCloudDevToolPortal": {
+      "singular": "springclouddevtoolportal",
+      "plural": "springclouddevtoolportals"
+    },
+    "appplatform.azure.upbound.io/SpringCloudGateway": {
+      "singular": "springcloudgateway",
+      "plural": "springcloudgateways"
+    },
+    "appplatform.azure.upbound.io/SpringCloudGatewayCustomDomain": {
+      "singular": "springcloudgatewaycustomdomain",
+      "plural": "springcloudgatewaycustomdomains"
+    },
+    "appplatform.azure.upbound.io/SpringCloudJavaDeployment": {
+      "singular": "springcloudjavadeployment",
+      "plural": "springcloudjavadeployments"
+    },
+    "appplatform.azure.upbound.io/SpringCloudService": {
+      "singular": "springcloudservice",
+      "plural": "springcloudservices"
+    },
+    "appplatform.azure.upbound.io/SpringCloudStorage": {
+      "singular": "springcloudstorage",
+      "plural": "springcloudstorages"
+    },
+    "attestation.azure.m.upbound.io/Provider": {
+      "singular": "provider",
+      "plural": "providers"
+    },
+    "attestation.azure.upbound.io/Provider": {
+      "singular": "provider",
+      "plural": "providers"
+    },
+    "authorization.azure.m.upbound.io/ManagementGroupPolicyAssignment": {
+      "singular": "managementgrouppolicyassignment",
+      "plural": "managementgrouppolicyassignments"
+    },
+    "authorization.azure.m.upbound.io/ManagementGroupPolicyExemption": {
+      "singular": "managementgrouppolicyexemption",
+      "plural": "managementgrouppolicyexemptions"
+    },
+    "authorization.azure.m.upbound.io/ManagementLock": {
+      "singular": "managementlock",
+      "plural": "managementlocks"
+    },
+    "authorization.azure.m.upbound.io/PimActiveRoleAssignment": {
+      "singular": "pimactiveroleassignment",
+      "plural": "pimactiveroleassignments"
+    },
+    "authorization.azure.m.upbound.io/PimEligibleRoleAssignment": {
+      "singular": "pimeligibleroleassignment",
+      "plural": "pimeligibleroleassignments"
+    },
+    "authorization.azure.m.upbound.io/PolicyDefinition": {
+      "singular": "policydefinition",
+      "plural": "policydefinitions"
+    },
+    "authorization.azure.m.upbound.io/PolicySetDefinition": {
+      "singular": "policysetdefinition",
+      "plural": "policysetdefinitions"
+    },
+    "authorization.azure.m.upbound.io/ResourceGroupPolicyAssignment": {
+      "singular": "resourcegrouppolicyassignment",
+      "plural": "resourcegrouppolicyassignments"
+    },
+    "authorization.azure.m.upbound.io/ResourceGroupPolicyExemption": {
+      "singular": "resourcegrouppolicyexemption",
+      "plural": "resourcegrouppolicyexemptions"
+    },
+    "authorization.azure.m.upbound.io/ResourcePolicyAssignment": {
+      "singular": "resourcepolicyassignment",
+      "plural": "resourcepolicyassignments"
+    },
+    "authorization.azure.m.upbound.io/ResourcePolicyExemption": {
+      "singular": "resourcepolicyexemption",
+      "plural": "resourcepolicyexemptions"
+    },
+    "authorization.azure.m.upbound.io/RoleAssignment": {
+      "singular": "roleassignment",
+      "plural": "roleassignments"
+    },
+    "authorization.azure.m.upbound.io/RoleDefinition": {
+      "singular": "roledefinition",
+      "plural": "roledefinitions"
+    },
+    "authorization.azure.m.upbound.io/RoleManagementPolicy": {
+      "singular": "rolemanagementpolicy",
+      "plural": "rolemanagementpolicies"
+    },
+    "authorization.azure.m.upbound.io/SubscriptionPolicyAssignment": {
+      "singular": "subscriptionpolicyassignment",
+      "plural": "subscriptionpolicyassignments"
+    },
+    "authorization.azure.m.upbound.io/SubscriptionPolicyExemption": {
+      "singular": "subscriptionpolicyexemption",
+      "plural": "subscriptionpolicyexemptions"
+    },
+    "authorization.azure.m.upbound.io/TrustedAccessRoleBinding": {
+      "singular": "trustedaccessrolebinding",
+      "plural": "trustedaccessrolebindings"
+    },
+    "authorization.azure.upbound.io/ManagementGroupPolicyAssignment": {
+      "singular": "managementgrouppolicyassignment",
+      "plural": "managementgrouppolicyassignments"
+    },
+    "authorization.azure.upbound.io/ManagementGroupPolicyExemption": {
+      "singular": "managementgrouppolicyexemption",
+      "plural": "managementgrouppolicyexemptions"
+    },
+    "authorization.azure.upbound.io/ManagementLock": {
+      "singular": "managementlock",
+      "plural": "managementlocks"
+    },
+    "authorization.azure.upbound.io/PimActiveRoleAssignment": {
+      "singular": "pimactiveroleassignment",
+      "plural": "pimactiveroleassignments"
+    },
+    "authorization.azure.upbound.io/PimEligibleRoleAssignment": {
+      "singular": "pimeligibleroleassignment",
+      "plural": "pimeligibleroleassignments"
+    },
+    "authorization.azure.upbound.io/PolicyDefinition": {
+      "singular": "policydefinition",
+      "plural": "policydefinitions"
+    },
+    "authorization.azure.upbound.io/PolicySetDefinition": {
+      "singular": "policysetdefinition",
+      "plural": "policysetdefinitions"
+    },
+    "authorization.azure.upbound.io/ResourceGroupPolicyAssignment": {
+      "singular": "resourcegrouppolicyassignment",
+      "plural": "resourcegrouppolicyassignments"
+    },
+    "authorization.azure.upbound.io/ResourceGroupPolicyExemption": {
+      "singular": "resourcegrouppolicyexemption",
+      "plural": "resourcegrouppolicyexemptions"
+    },
+    "authorization.azure.upbound.io/ResourcePolicyAssignment": {
+      "singular": "resourcepolicyassignment",
+      "plural": "resourcepolicyassignments"
+    },
+    "authorization.azure.upbound.io/ResourcePolicyExemption": {
+      "singular": "resourcepolicyexemption",
+      "plural": "resourcepolicyexemptions"
+    },
+    "authorization.azure.upbound.io/RoleAssignment": {
+      "singular": "roleassignment",
+      "plural": "roleassignments"
+    },
+    "authorization.azure.upbound.io/RoleDefinition": {
+      "singular": "roledefinition",
+      "plural": "roledefinitions"
+    },
+    "authorization.azure.upbound.io/RoleManagementPolicy": {
+      "singular": "rolemanagementpolicy",
+      "plural": "rolemanagementpolicies"
+    },
+    "authorization.azure.upbound.io/SubscriptionPolicyAssignment": {
+      "singular": "subscriptionpolicyassignment",
+      "plural": "subscriptionpolicyassignments"
+    },
+    "authorization.azure.upbound.io/SubscriptionPolicyExemption": {
+      "singular": "subscriptionpolicyexemption",
+      "plural": "subscriptionpolicyexemptions"
+    },
+    "authorization.azure.upbound.io/TrustedAccessRoleBinding": {
+      "singular": "trustedaccessrolebinding",
+      "plural": "trustedaccessrolebindings"
+    },
+    "automation.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "automation.azure.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "automation.azure.m.upbound.io/ConnectionClassicCertificate": {
+      "singular": "connectionclassiccertificate",
+      "plural": "connectionclassiccertificates"
+    },
+    "automation.azure.m.upbound.io/ConnectionType": {
+      "singular": "connectiontype",
+      "plural": "connectiontypes"
+    },
+    "automation.azure.m.upbound.io/Credential": {
+      "singular": "credential",
+      "plural": "credentials"
+    },
+    "automation.azure.m.upbound.io/HybridRunBookWorkerGroup": {
+      "singular": "hybridrunbookworkergroup",
+      "plural": "hybridrunbookworkergroups"
+    },
+    "automation.azure.m.upbound.io/Module": {
+      "singular": "module",
+      "plural": "modules"
+    },
+    "automation.azure.m.upbound.io/RunBook": {
+      "singular": "runbook",
+      "plural": "runbooks"
+    },
+    "automation.azure.m.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "automation.azure.m.upbound.io/VariableBool": {
+      "singular": "variablebool",
+      "plural": "variablebools"
+    },
+    "automation.azure.m.upbound.io/VariableDateTime": {
+      "singular": "variabledatetime",
+      "plural": "variabledatetimes"
+    },
+    "automation.azure.m.upbound.io/VariableInt": {
+      "singular": "variableint",
+      "plural": "variableints"
+    },
+    "automation.azure.m.upbound.io/VariableString": {
+      "singular": "variablestring",
+      "plural": "variablestrings"
+    },
+    "automation.azure.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "automation.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "automation.azure.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "automation.azure.upbound.io/ConnectionClassicCertificate": {
+      "singular": "connectionclassiccertificate",
+      "plural": "connectionclassiccertificates"
+    },
+    "automation.azure.upbound.io/ConnectionType": {
+      "singular": "connectiontype",
+      "plural": "connectiontypes"
+    },
+    "automation.azure.upbound.io/Credential": {
+      "singular": "credential",
+      "plural": "credentials"
+    },
+    "automation.azure.upbound.io/HybridRunBookWorkerGroup": {
+      "singular": "hybridrunbookworkergroup",
+      "plural": "hybridrunbookworkergroups"
+    },
+    "automation.azure.upbound.io/Module": {
+      "singular": "module",
+      "plural": "modules"
+    },
+    "automation.azure.upbound.io/RunBook": {
+      "singular": "runbook",
+      "plural": "runbooks"
+    },
+    "automation.azure.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "automation.azure.upbound.io/VariableBool": {
+      "singular": "variablebool",
+      "plural": "variablebools"
+    },
+    "automation.azure.upbound.io/VariableDateTime": {
+      "singular": "variabledatetime",
+      "plural": "variabledatetimes"
+    },
+    "automation.azure.upbound.io/VariableInt": {
+      "singular": "variableint",
+      "plural": "variableints"
+    },
+    "automation.azure.upbound.io/VariableString": {
+      "singular": "variablestring",
+      "plural": "variablestrings"
+    },
+    "automation.azure.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "azure.m.upbound.io/ClusterProviderConfig": {
+      "singular": "clusterproviderconfig",
+      "plural": "clusterproviderconfigs"
+    },
+    "azure.m.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "azure.m.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "azure.m.upbound.io/ResourceGroup": {
+      "singular": "resourcegroup",
+      "plural": "resourcegroups"
+    },
+    "azure.m.upbound.io/ResourceProviderRegistration": {
+      "singular": "resourceproviderregistration",
+      "plural": "resourceproviderregistrations"
+    },
+    "azure.m.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "azure.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "azure.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "azure.upbound.io/ResourceGroup": {
+      "singular": "resourcegroup",
+      "plural": "resourcegroups"
+    },
+    "azure.upbound.io/ResourceProviderRegistration": {
+      "singular": "resourceproviderregistration",
+      "plural": "resourceproviderregistrations"
+    },
+    "azure.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "azurestackhci.azure.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "azurestackhci.azure.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "botservice.azure.m.upbound.io/BotChannelAlexa": {
+      "singular": "botchannelalexa",
+      "plural": "botchannelalexas"
+    },
+    "botservice.azure.m.upbound.io/BotChannelDirectLine": {
+      "singular": "botchanneldirectline",
+      "plural": "botchanneldirectlines"
+    },
+    "botservice.azure.m.upbound.io/BotChannelLine": {
+      "singular": "botchannelline",
+      "plural": "botchannellines"
+    },
+    "botservice.azure.m.upbound.io/BotChannelMSTeams": {
+      "singular": "botchannelmsteams",
+      "plural": "botchannelmsteams"
+    },
+    "botservice.azure.m.upbound.io/BotChannelSMS": {
+      "singular": "botchannelsms",
+      "plural": "botchannelsms"
+    },
+    "botservice.azure.m.upbound.io/BotChannelSlack": {
+      "singular": "botchannelslack",
+      "plural": "botchannelslacks"
+    },
+    "botservice.azure.m.upbound.io/BotChannelWebChat": {
+      "singular": "botchannelwebchat",
+      "plural": "botchannelwebchats"
+    },
+    "botservice.azure.m.upbound.io/BotChannelsRegistration": {
+      "singular": "botchannelsregistration",
+      "plural": "botchannelsregistrations"
+    },
+    "botservice.azure.m.upbound.io/BotConnection": {
+      "singular": "botconnection",
+      "plural": "botconnections"
+    },
+    "botservice.azure.m.upbound.io/BotWebApp": {
+      "singular": "botwebapp",
+      "plural": "botwebapps"
+    },
+    "botservice.azure.upbound.io/BotChannelAlexa": {
+      "singular": "botchannelalexa",
+      "plural": "botchannelalexas"
+    },
+    "botservice.azure.upbound.io/BotChannelDirectLine": {
+      "singular": "botchanneldirectline",
+      "plural": "botchanneldirectlines"
+    },
+    "botservice.azure.upbound.io/BotChannelLine": {
+      "singular": "botchannelline",
+      "plural": "botchannellines"
+    },
+    "botservice.azure.upbound.io/BotChannelMSTeams": {
+      "singular": "botchannelmsteams",
+      "plural": "botchannelmsteams"
+    },
+    "botservice.azure.upbound.io/BotChannelSMS": {
+      "singular": "botchannelsms",
+      "plural": "botchannelsms"
+    },
+    "botservice.azure.upbound.io/BotChannelSlack": {
+      "singular": "botchannelslack",
+      "plural": "botchannelslacks"
+    },
+    "botservice.azure.upbound.io/BotChannelWebChat": {
+      "singular": "botchannelwebchat",
+      "plural": "botchannelwebchats"
+    },
+    "botservice.azure.upbound.io/BotChannelsRegistration": {
+      "singular": "botchannelsregistration",
+      "plural": "botchannelsregistrations"
+    },
+    "botservice.azure.upbound.io/BotConnection": {
+      "singular": "botconnection",
+      "plural": "botconnections"
+    },
+    "botservice.azure.upbound.io/BotWebApp": {
+      "singular": "botwebapp",
+      "plural": "botwebapps"
+    },
+    "cache.azure.m.upbound.io/ManagedRedis": {
+      "singular": "managedredis",
+      "plural": "managedredis"
+    },
+    "cache.azure.m.upbound.io/RedisCache": {
+      "singular": "rediscache",
+      "plural": "rediscaches"
+    },
+    "cache.azure.m.upbound.io/RedisCacheAccessPolicy": {
+      "singular": "rediscacheaccesspolicy",
+      "plural": "rediscacheaccesspolicies"
+    },
+    "cache.azure.m.upbound.io/RedisCacheAccessPolicyAssignment": {
+      "singular": "rediscacheaccesspolicyassignment",
+      "plural": "rediscacheaccesspolicyassignments"
+    },
+    "cache.azure.m.upbound.io/RedisEnterpriseCluster": {
+      "singular": "redisenterprisecluster",
+      "plural": "redisenterpriseclusters"
+    },
+    "cache.azure.m.upbound.io/RedisEnterpriseDatabase": {
+      "singular": "redisenterprisedatabase",
+      "plural": "redisenterprisedatabases"
+    },
+    "cache.azure.m.upbound.io/RedisFirewallRule": {
+      "singular": "redisfirewallrule",
+      "plural": "redisfirewallrules"
+    },
+    "cache.azure.m.upbound.io/RedisLinkedServer": {
+      "singular": "redislinkedserver",
+      "plural": "redislinkedservers"
+    },
+    "cache.azure.upbound.io/ManagedRedis": {
+      "singular": "managedredis",
+      "plural": "managedredis"
+    },
+    "cache.azure.upbound.io/RedisCache": {
+      "singular": "rediscache",
+      "plural": "rediscaches"
+    },
+    "cache.azure.upbound.io/RedisCacheAccessPolicy": {
+      "singular": "rediscacheaccesspolicy",
+      "plural": "rediscacheaccesspolicies"
+    },
+    "cache.azure.upbound.io/RedisCacheAccessPolicyAssignment": {
+      "singular": "rediscacheaccesspolicyassignment",
+      "plural": "rediscacheaccesspolicyassignments"
+    },
+    "cache.azure.upbound.io/RedisEnterpriseCluster": {
+      "singular": "redisenterprisecluster",
+      "plural": "redisenterpriseclusters"
+    },
+    "cache.azure.upbound.io/RedisEnterpriseDatabase": {
+      "singular": "redisenterprisedatabase",
+      "plural": "redisenterprisedatabases"
+    },
+    "cache.azure.upbound.io/RedisFirewallRule": {
+      "singular": "redisfirewallrule",
+      "plural": "redisfirewallrules"
+    },
+    "cache.azure.upbound.io/RedisLinkedServer": {
+      "singular": "redislinkedserver",
+      "plural": "redislinkedservers"
+    },
+    "cdn.azure.m.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorCustomDomain": {
+      "singular": "frontdoorcustomdomain",
+      "plural": "frontdoorcustomdomains"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorCustomDomainAssociation": {
+      "singular": "frontdoorcustomdomainassociation",
+      "plural": "frontdoorcustomdomainassociations"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorEndpoint": {
+      "singular": "frontdoorendpoint",
+      "plural": "frontdoorendpoints"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorFirewallPolicy": {
+      "singular": "frontdoorfirewallpolicy",
+      "plural": "frontdoorfirewallpolicies"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorOrigin": {
+      "singular": "frontdoororigin",
+      "plural": "frontdoororigins"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorOriginGroup": {
+      "singular": "frontdoororigingroup",
+      "plural": "frontdoororigingroups"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorProfile": {
+      "singular": "frontdoorprofile",
+      "plural": "frontdoorprofiles"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorRoute": {
+      "singular": "frontdoorroute",
+      "plural": "frontdoorroutes"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorRule": {
+      "singular": "frontdoorrule",
+      "plural": "frontdoorrules"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorRuleSet": {
+      "singular": "frontdoorruleset",
+      "plural": "frontdoorrulesets"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorSecret": {
+      "singular": "frontdoorsecret",
+      "plural": "frontdoorsecrets"
+    },
+    "cdn.azure.m.upbound.io/FrontdoorSecurityPolicy": {
+      "singular": "frontdoorsecuritypolicy",
+      "plural": "frontdoorsecuritypolicies"
+    },
+    "cdn.azure.m.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "cdn.azure.upbound.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "cdn.azure.upbound.io/FrontdoorCustomDomain": {
+      "singular": "frontdoorcustomdomain",
+      "plural": "frontdoorcustomdomains"
+    },
+    "cdn.azure.upbound.io/FrontdoorCustomDomainAssociation": {
+      "singular": "frontdoorcustomdomainassociation",
+      "plural": "frontdoorcustomdomainassociations"
+    },
+    "cdn.azure.upbound.io/FrontdoorEndpoint": {
+      "singular": "frontdoorendpoint",
+      "plural": "frontdoorendpoints"
+    },
+    "cdn.azure.upbound.io/FrontdoorFirewallPolicy": {
+      "singular": "frontdoorfirewallpolicy",
+      "plural": "frontdoorfirewallpolicies"
+    },
+    "cdn.azure.upbound.io/FrontdoorOrigin": {
+      "singular": "frontdoororigin",
+      "plural": "frontdoororigins"
+    },
+    "cdn.azure.upbound.io/FrontdoorOriginGroup": {
+      "singular": "frontdoororigingroup",
+      "plural": "frontdoororigingroups"
+    },
+    "cdn.azure.upbound.io/FrontdoorProfile": {
+      "singular": "frontdoorprofile",
+      "plural": "frontdoorprofiles"
+    },
+    "cdn.azure.upbound.io/FrontdoorRoute": {
+      "singular": "frontdoorroute",
+      "plural": "frontdoorroutes"
+    },
+    "cdn.azure.upbound.io/FrontdoorRule": {
+      "singular": "frontdoorrule",
+      "plural": "frontdoorrules"
+    },
+    "cdn.azure.upbound.io/FrontdoorRuleSet": {
+      "singular": "frontdoorruleset",
+      "plural": "frontdoorrulesets"
+    },
+    "cdn.azure.upbound.io/FrontdoorSecret": {
+      "singular": "frontdoorsecret",
+      "plural": "frontdoorsecrets"
+    },
+    "cdn.azure.upbound.io/FrontdoorSecurityPolicy": {
+      "singular": "frontdoorsecuritypolicy",
+      "plural": "frontdoorsecuritypolicies"
+    },
+    "cdn.azure.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "certificateregistration.azure.m.upbound.io/AppServiceCertificateOrder": {
+      "singular": "appservicecertificateorder",
+      "plural": "appservicecertificateorders"
+    },
+    "certificateregistration.azure.upbound.io/AppServiceCertificateOrder": {
+      "singular": "appservicecertificateorder",
+      "plural": "appservicecertificateorders"
+    },
+    "cognitiveservices.azure.m.upbound.io/AIServices": {
+      "singular": "aiservices",
+      "plural": "aiservices"
+    },
+    "cognitiveservices.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "cognitiveservices.azure.m.upbound.io/AccountRaiBlocklist": {
+      "singular": "accountraiblocklist",
+      "plural": "accountraiblocklists"
+    },
+    "cognitiveservices.azure.m.upbound.io/AccountRaiPolicy": {
+      "singular": "accountraipolicy",
+      "plural": "accountraipolicies"
+    },
+    "cognitiveservices.azure.m.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "cognitiveservices.azure.upbound.io/AIServices": {
+      "singular": "aiservices",
+      "plural": "aiservices"
+    },
+    "cognitiveservices.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "cognitiveservices.azure.upbound.io/AccountRaiBlocklist": {
+      "singular": "accountraiblocklist",
+      "plural": "accountraiblocklists"
+    },
+    "cognitiveservices.azure.upbound.io/AccountRaiPolicy": {
+      "singular": "accountraipolicy",
+      "plural": "accountraipolicies"
+    },
+    "cognitiveservices.azure.upbound.io/Deployment": {
+      "singular": "deployment",
+      "plural": "deployments"
+    },
+    "communication.azure.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "communication.azure.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "compute.azure.m.upbound.io/AvailabilitySet": {
+      "singular": "availabilityset",
+      "plural": "availabilitysets"
+    },
+    "compute.azure.m.upbound.io/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "compute.azure.m.upbound.io/CapacityReservationGroup": {
+      "singular": "capacityreservationgroup",
+      "plural": "capacityreservationgroups"
+    },
+    "compute.azure.m.upbound.io/DedicatedHost": {
+      "singular": "dedicatedhost",
+      "plural": "dedicatedhosts"
+    },
+    "compute.azure.m.upbound.io/DiskAccess": {
+      "singular": "diskaccess",
+      "plural": "diskaccesses"
+    },
+    "compute.azure.m.upbound.io/DiskEncryptionSet": {
+      "singular": "diskencryptionset",
+      "plural": "diskencryptionsets"
+    },
+    "compute.azure.m.upbound.io/GalleryApplication": {
+      "singular": "galleryapplication",
+      "plural": "galleryapplications"
+    },
+    "compute.azure.m.upbound.io/GalleryApplicationVersion": {
+      "singular": "galleryapplicationversion",
+      "plural": "galleryapplicationversions"
+    },
+    "compute.azure.m.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "compute.azure.m.upbound.io/LinuxVirtualMachine": {
+      "singular": "linuxvirtualmachine",
+      "plural": "linuxvirtualmachines"
+    },
+    "compute.azure.m.upbound.io/LinuxVirtualMachineScaleSet": {
+      "singular": "linuxvirtualmachinescaleset",
+      "plural": "linuxvirtualmachinescalesets"
+    },
+    "compute.azure.m.upbound.io/ManagedDisk": {
+      "singular": "manageddisk",
+      "plural": "manageddisks"
+    },
+    "compute.azure.m.upbound.io/ManagedDiskSASToken": {
+      "singular": "manageddisksastoken",
+      "plural": "manageddisksastokens"
+    },
+    "compute.azure.m.upbound.io/OrchestratedVirtualMachineScaleSet": {
+      "singular": "orchestratedvirtualmachinescaleset",
+      "plural": "orchestratedvirtualmachinescalesets"
+    },
+    "compute.azure.m.upbound.io/ProximityPlacementGroup": {
+      "singular": "proximityplacementgroup",
+      "plural": "proximityplacementgroups"
+    },
+    "compute.azure.m.upbound.io/SSHPublicKey": {
+      "singular": "sshpublickey",
+      "plural": "sshpublickeys"
+    },
+    "compute.azure.m.upbound.io/SharedImage": {
+      "singular": "sharedimage",
+      "plural": "sharedimages"
+    },
+    "compute.azure.m.upbound.io/SharedImageGallery": {
+      "singular": "sharedimagegallery",
+      "plural": "sharedimagegalleries"
+    },
+    "compute.azure.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "compute.azure.m.upbound.io/VirtualMachineDataDiskAttachment": {
+      "singular": "virtualmachinedatadiskattachment",
+      "plural": "virtualmachinedatadiskattachments"
+    },
+    "compute.azure.m.upbound.io/VirtualMachineExtension": {
+      "singular": "virtualmachineextension",
+      "plural": "virtualmachineextensions"
+    },
+    "compute.azure.m.upbound.io/VirtualMachineRunCommand": {
+      "singular": "virtualmachineruncommand",
+      "plural": "virtualmachineruncommands"
+    },
+    "compute.azure.m.upbound.io/VirtualMachineScaleSetStandbyPool": {
+      "singular": "virtualmachinescalesetstandbypool",
+      "plural": "virtualmachinescalesetstandbypools"
+    },
+    "compute.azure.m.upbound.io/WindowsVirtualMachine": {
+      "singular": "windowsvirtualmachine",
+      "plural": "windowsvirtualmachines"
+    },
+    "compute.azure.m.upbound.io/WindowsVirtualMachineScaleSet": {
+      "singular": "windowsvirtualmachinescaleset",
+      "plural": "windowsvirtualmachinescalesets"
+    },
+    "compute.azure.upbound.io/AvailabilitySet": {
+      "singular": "availabilityset",
+      "plural": "availabilitysets"
+    },
+    "compute.azure.upbound.io/CapacityReservation": {
+      "singular": "capacityreservation",
+      "plural": "capacityreservations"
+    },
+    "compute.azure.upbound.io/CapacityReservationGroup": {
+      "singular": "capacityreservationgroup",
+      "plural": "capacityreservationgroups"
+    },
+    "compute.azure.upbound.io/DedicatedHost": {
+      "singular": "dedicatedhost",
+      "plural": "dedicatedhosts"
+    },
+    "compute.azure.upbound.io/DiskAccess": {
+      "singular": "diskaccess",
+      "plural": "diskaccesses"
+    },
+    "compute.azure.upbound.io/DiskEncryptionSet": {
+      "singular": "diskencryptionset",
+      "plural": "diskencryptionsets"
+    },
+    "compute.azure.upbound.io/GalleryApplication": {
+      "singular": "galleryapplication",
+      "plural": "galleryapplications"
+    },
+    "compute.azure.upbound.io/GalleryApplicationVersion": {
+      "singular": "galleryapplicationversion",
+      "plural": "galleryapplicationversions"
+    },
+    "compute.azure.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "compute.azure.upbound.io/LinuxVirtualMachine": {
+      "singular": "linuxvirtualmachine",
+      "plural": "linuxvirtualmachines"
+    },
+    "compute.azure.upbound.io/LinuxVirtualMachineScaleSet": {
+      "singular": "linuxvirtualmachinescaleset",
+      "plural": "linuxvirtualmachinescalesets"
+    },
+    "compute.azure.upbound.io/ManagedDisk": {
+      "singular": "manageddisk",
+      "plural": "manageddisks"
+    },
+    "compute.azure.upbound.io/ManagedDiskSASToken": {
+      "singular": "manageddisksastoken",
+      "plural": "manageddisksastokens"
+    },
+    "compute.azure.upbound.io/OrchestratedVirtualMachineScaleSet": {
+      "singular": "orchestratedvirtualmachinescaleset",
+      "plural": "orchestratedvirtualmachinescalesets"
+    },
+    "compute.azure.upbound.io/ProximityPlacementGroup": {
+      "singular": "proximityplacementgroup",
+      "plural": "proximityplacementgroups"
+    },
+    "compute.azure.upbound.io/SSHPublicKey": {
+      "singular": "sshpublickey",
+      "plural": "sshpublickeys"
+    },
+    "compute.azure.upbound.io/SharedImage": {
+      "singular": "sharedimage",
+      "plural": "sharedimages"
+    },
+    "compute.azure.upbound.io/SharedImageGallery": {
+      "singular": "sharedimagegallery",
+      "plural": "sharedimagegalleries"
+    },
+    "compute.azure.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "compute.azure.upbound.io/VirtualMachineDataDiskAttachment": {
+      "singular": "virtualmachinedatadiskattachment",
+      "plural": "virtualmachinedatadiskattachments"
+    },
+    "compute.azure.upbound.io/VirtualMachineExtension": {
+      "singular": "virtualmachineextension",
+      "plural": "virtualmachineextensions"
+    },
+    "compute.azure.upbound.io/VirtualMachineRunCommand": {
+      "singular": "virtualmachineruncommand",
+      "plural": "virtualmachineruncommands"
+    },
+    "compute.azure.upbound.io/VirtualMachineScaleSetStandbyPool": {
+      "singular": "virtualmachinescalesetstandbypool",
+      "plural": "virtualmachinescalesetstandbypools"
+    },
+    "compute.azure.upbound.io/WindowsVirtualMachine": {
+      "singular": "windowsvirtualmachine",
+      "plural": "windowsvirtualmachines"
+    },
+    "compute.azure.upbound.io/WindowsVirtualMachineScaleSet": {
+      "singular": "windowsvirtualmachinescaleset",
+      "plural": "windowsvirtualmachinescalesets"
+    },
+    "confidentialledger.azure.m.upbound.io/Ledger": {
+      "singular": "ledger",
+      "plural": "ledgers"
+    },
+    "confidentialledger.azure.upbound.io/Ledger": {
+      "singular": "ledger",
+      "plural": "ledgers"
+    },
+    "consumption.azure.m.upbound.io/BudgetManagementGroup": {
+      "singular": "budgetmanagementgroup",
+      "plural": "budgetmanagementgroups"
+    },
+    "consumption.azure.m.upbound.io/BudgetResourceGroup": {
+      "singular": "budgetresourcegroup",
+      "plural": "budgetresourcegroups"
+    },
+    "consumption.azure.m.upbound.io/BudgetSubscription": {
+      "singular": "budgetsubscription",
+      "plural": "budgetsubscriptions"
+    },
+    "consumption.azure.upbound.io/BudgetManagementGroup": {
+      "singular": "budgetmanagementgroup",
+      "plural": "budgetmanagementgroups"
+    },
+    "consumption.azure.upbound.io/BudgetResourceGroup": {
+      "singular": "budgetresourcegroup",
+      "plural": "budgetresourcegroups"
+    },
+    "consumption.azure.upbound.io/BudgetSubscription": {
+      "singular": "budgetsubscription",
+      "plural": "budgetsubscriptions"
+    },
+    "containerapp.azure.m.upbound.io/ContainerApp": {
+      "singular": "containerapp",
+      "plural": "containerapps"
+    },
+    "containerapp.azure.m.upbound.io/ContainerJob": {
+      "singular": "containerjob",
+      "plural": "containerjobs"
+    },
+    "containerapp.azure.m.upbound.io/CustomDomain": {
+      "singular": "customdomain",
+      "plural": "customdomains"
+    },
+    "containerapp.azure.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "containerapp.azure.m.upbound.io/EnvironmentCertificate": {
+      "singular": "environmentcertificate",
+      "plural": "environmentcertificates"
+    },
+    "containerapp.azure.m.upbound.io/EnvironmentCustomDomain": {
+      "singular": "environmentcustomdomain",
+      "plural": "environmentcustomdomains"
+    },
+    "containerapp.azure.m.upbound.io/EnvironmentDaprComponent": {
+      "singular": "environmentdaprcomponent",
+      "plural": "environmentdaprcomponents"
+    },
+    "containerapp.azure.m.upbound.io/EnvironmentStorage": {
+      "singular": "environmentstorage",
+      "plural": "environmentstorages"
+    },
+    "containerapp.azure.upbound.io/ContainerApp": {
+      "singular": "containerapp",
+      "plural": "containerapps"
+    },
+    "containerapp.azure.upbound.io/ContainerJob": {
+      "singular": "containerjob",
+      "plural": "containerjobs"
+    },
+    "containerapp.azure.upbound.io/CustomDomain": {
+      "singular": "customdomain",
+      "plural": "customdomains"
+    },
+    "containerapp.azure.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "containerapp.azure.upbound.io/EnvironmentCertificate": {
+      "singular": "environmentcertificate",
+      "plural": "environmentcertificates"
+    },
+    "containerapp.azure.upbound.io/EnvironmentCustomDomain": {
+      "singular": "environmentcustomdomain",
+      "plural": "environmentcustomdomains"
+    },
+    "containerapp.azure.upbound.io/EnvironmentDaprComponent": {
+      "singular": "environmentdaprcomponent",
+      "plural": "environmentdaprcomponents"
+    },
+    "containerapp.azure.upbound.io/EnvironmentStorage": {
+      "singular": "environmentstorage",
+      "plural": "environmentstorages"
+    },
+    "containerregistry.azure.m.upbound.io/AgentPool": {
+      "singular": "agentpool",
+      "plural": "agentpools"
+    },
+    "containerregistry.azure.m.upbound.io/CacheRule": {
+      "singular": "cacherule",
+      "plural": "cacherules"
+    },
+    "containerregistry.azure.m.upbound.io/ContainerConnectedRegistry": {
+      "singular": "containerconnectedregistry",
+      "plural": "containerconnectedregistries"
+    },
+    "containerregistry.azure.m.upbound.io/CredentialSet": {
+      "singular": "credentialset",
+      "plural": "credentialsets"
+    },
+    "containerregistry.azure.m.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "containerregistry.azure.m.upbound.io/ScopeMap": {
+      "singular": "scopemap",
+      "plural": "scopemaps"
+    },
+    "containerregistry.azure.m.upbound.io/Token": {
+      "singular": "token",
+      "plural": "tokens"
+    },
+    "containerregistry.azure.m.upbound.io/TokenPassword": {
+      "singular": "tokenpassword",
+      "plural": "tokenpasswords"
+    },
+    "containerregistry.azure.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "containerregistry.azure.upbound.io/AgentPool": {
+      "singular": "agentpool",
+      "plural": "agentpools"
+    },
+    "containerregistry.azure.upbound.io/CacheRule": {
+      "singular": "cacherule",
+      "plural": "cacherules"
+    },
+    "containerregistry.azure.upbound.io/ContainerConnectedRegistry": {
+      "singular": "containerconnectedregistry",
+      "plural": "containerconnectedregistries"
+    },
+    "containerregistry.azure.upbound.io/CredentialSet": {
+      "singular": "credentialset",
+      "plural": "credentialsets"
+    },
+    "containerregistry.azure.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "containerregistry.azure.upbound.io/ScopeMap": {
+      "singular": "scopemap",
+      "plural": "scopemaps"
+    },
+    "containerregistry.azure.upbound.io/Token": {
+      "singular": "token",
+      "plural": "tokens"
+    },
+    "containerregistry.azure.upbound.io/TokenPassword": {
+      "singular": "tokenpassword",
+      "plural": "tokenpasswords"
+    },
+    "containerregistry.azure.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "containerservice.azure.m.upbound.io/KubernetesCluster": {
+      "singular": "kubernetescluster",
+      "plural": "kubernetesclusters"
+    },
+    "containerservice.azure.m.upbound.io/KubernetesClusterExtension": {
+      "singular": "kubernetesclusterextension",
+      "plural": "kubernetesclusterextensions"
+    },
+    "containerservice.azure.m.upbound.io/KubernetesClusterNodePool": {
+      "singular": "kubernetesclusternodepool",
+      "plural": "kubernetesclusternodepools"
+    },
+    "containerservice.azure.m.upbound.io/KubernetesFleetManager": {
+      "singular": "kubernetesfleetmanager",
+      "plural": "kubernetesfleetmanagers"
+    },
+    "containerservice.azure.upbound.io/KubernetesCluster": {
+      "singular": "kubernetescluster",
+      "plural": "kubernetesclusters"
+    },
+    "containerservice.azure.upbound.io/KubernetesClusterExtension": {
+      "singular": "kubernetesclusterextension",
+      "plural": "kubernetesclusterextensions"
+    },
+    "containerservice.azure.upbound.io/KubernetesClusterNodePool": {
+      "singular": "kubernetesclusternodepool",
+      "plural": "kubernetesclusternodepools"
+    },
+    "containerservice.azure.upbound.io/KubernetesFleetManager": {
+      "singular": "kubernetesfleetmanager",
+      "plural": "kubernetesfleetmanagers"
+    },
+    "cosmosdb.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "cosmosdb.azure.m.upbound.io/CassandraCluster": {
+      "singular": "cassandracluster",
+      "plural": "cassandraclusters"
+    },
+    "cosmosdb.azure.m.upbound.io/CassandraDatacenter": {
+      "singular": "cassandradatacenter",
+      "plural": "cassandradatacenters"
+    },
+    "cosmosdb.azure.m.upbound.io/CassandraKeySpace": {
+      "singular": "cassandrakeyspace",
+      "plural": "cassandrakeyspaces"
+    },
+    "cosmosdb.azure.m.upbound.io/CassandraTable": {
+      "singular": "cassandratable",
+      "plural": "cassandratables"
+    },
+    "cosmosdb.azure.m.upbound.io/GremlinDatabase": {
+      "singular": "gremlindatabase",
+      "plural": "gremlindatabases"
+    },
+    "cosmosdb.azure.m.upbound.io/GremlinGraph": {
+      "singular": "gremlingraph",
+      "plural": "gremlingraphs"
+    },
+    "cosmosdb.azure.m.upbound.io/MongoCluster": {
+      "singular": "mongocluster",
+      "plural": "mongoclusters"
+    },
+    "cosmosdb.azure.m.upbound.io/MongoCollection": {
+      "singular": "mongocollection",
+      "plural": "mongocollections"
+    },
+    "cosmosdb.azure.m.upbound.io/MongoDatabase": {
+      "singular": "mongodatabase",
+      "plural": "mongodatabases"
+    },
+    "cosmosdb.azure.m.upbound.io/MongoRoleDefinition": {
+      "singular": "mongoroledefinition",
+      "plural": "mongoroledefinitions"
+    },
+    "cosmosdb.azure.m.upbound.io/MongoUserDefinition": {
+      "singular": "mongouserdefinition",
+      "plural": "mongouserdefinitions"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLContainer": {
+      "singular": "sqlcontainer",
+      "plural": "sqlcontainers"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLDatabase": {
+      "singular": "sqldatabase",
+      "plural": "sqldatabases"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLDedicatedGateway": {
+      "singular": "sqldedicatedgateway",
+      "plural": "sqldedicatedgateways"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLFunction": {
+      "singular": "sqlfunction",
+      "plural": "sqlfunctions"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLRoleAssignment": {
+      "singular": "sqlroleassignment",
+      "plural": "sqlroleassignments"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLRoleDefinition": {
+      "singular": "sqlroledefinition",
+      "plural": "sqlroledefinitions"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLStoredProcedure": {
+      "singular": "sqlstoredprocedure",
+      "plural": "sqlstoredprocedures"
+    },
+    "cosmosdb.azure.m.upbound.io/SQLTrigger": {
+      "singular": "sqltrigger",
+      "plural": "sqltriggers"
+    },
+    "cosmosdb.azure.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "cosmosdb.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "cosmosdb.azure.upbound.io/CassandraCluster": {
+      "singular": "cassandracluster",
+      "plural": "cassandraclusters"
+    },
+    "cosmosdb.azure.upbound.io/CassandraDatacenter": {
+      "singular": "cassandradatacenter",
+      "plural": "cassandradatacenters"
+    },
+    "cosmosdb.azure.upbound.io/CassandraKeySpace": {
+      "singular": "cassandrakeyspace",
+      "plural": "cassandrakeyspaces"
+    },
+    "cosmosdb.azure.upbound.io/CassandraTable": {
+      "singular": "cassandratable",
+      "plural": "cassandratables"
+    },
+    "cosmosdb.azure.upbound.io/GremlinDatabase": {
+      "singular": "gremlindatabase",
+      "plural": "gremlindatabases"
+    },
+    "cosmosdb.azure.upbound.io/GremlinGraph": {
+      "singular": "gremlingraph",
+      "plural": "gremlingraphs"
+    },
+    "cosmosdb.azure.upbound.io/MongoCluster": {
+      "singular": "mongocluster",
+      "plural": "mongoclusters"
+    },
+    "cosmosdb.azure.upbound.io/MongoCollection": {
+      "singular": "mongocollection",
+      "plural": "mongocollections"
+    },
+    "cosmosdb.azure.upbound.io/MongoDatabase": {
+      "singular": "mongodatabase",
+      "plural": "mongodatabases"
+    },
+    "cosmosdb.azure.upbound.io/MongoRoleDefinition": {
+      "singular": "mongoroledefinition",
+      "plural": "mongoroledefinitions"
+    },
+    "cosmosdb.azure.upbound.io/MongoUserDefinition": {
+      "singular": "mongouserdefinition",
+      "plural": "mongouserdefinitions"
+    },
+    "cosmosdb.azure.upbound.io/SQLContainer": {
+      "singular": "sqlcontainer",
+      "plural": "sqlcontainers"
+    },
+    "cosmosdb.azure.upbound.io/SQLDatabase": {
+      "singular": "sqldatabase",
+      "plural": "sqldatabases"
+    },
+    "cosmosdb.azure.upbound.io/SQLDedicatedGateway": {
+      "singular": "sqldedicatedgateway",
+      "plural": "sqldedicatedgateways"
+    },
+    "cosmosdb.azure.upbound.io/SQLFunction": {
+      "singular": "sqlfunction",
+      "plural": "sqlfunctions"
+    },
+    "cosmosdb.azure.upbound.io/SQLRoleAssignment": {
+      "singular": "sqlroleassignment",
+      "plural": "sqlroleassignments"
+    },
+    "cosmosdb.azure.upbound.io/SQLRoleDefinition": {
+      "singular": "sqlroledefinition",
+      "plural": "sqlroledefinitions"
+    },
+    "cosmosdb.azure.upbound.io/SQLStoredProcedure": {
+      "singular": "sqlstoredprocedure",
+      "plural": "sqlstoredprocedures"
+    },
+    "cosmosdb.azure.upbound.io/SQLTrigger": {
+      "singular": "sqltrigger",
+      "plural": "sqltriggers"
+    },
+    "cosmosdb.azure.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "costmanagement.azure.m.upbound.io/CostAnomalyAlert": {
+      "singular": "costanomalyalert",
+      "plural": "costanomalyalerts"
+    },
+    "costmanagement.azure.m.upbound.io/ResourceGroupCostManagementExport": {
+      "singular": "resourcegroupcostmanagementexport",
+      "plural": "resourcegroupcostmanagementexports"
+    },
+    "costmanagement.azure.m.upbound.io/SubscriptionCostManagementExport": {
+      "singular": "subscriptioncostmanagementexport",
+      "plural": "subscriptioncostmanagementexports"
+    },
+    "costmanagement.azure.upbound.io/CostAnomalyAlert": {
+      "singular": "costanomalyalert",
+      "plural": "costanomalyalerts"
+    },
+    "costmanagement.azure.upbound.io/ResourceGroupCostManagementExport": {
+      "singular": "resourcegroupcostmanagementexport",
+      "plural": "resourcegroupcostmanagementexports"
+    },
+    "costmanagement.azure.upbound.io/SubscriptionCostManagementExport": {
+      "singular": "subscriptioncostmanagementexport",
+      "plural": "subscriptioncostmanagementexports"
+    },
+    "customproviders.azure.m.upbound.io/CustomProvider": {
+      "singular": "customprovider",
+      "plural": "customproviders"
+    },
+    "customproviders.azure.upbound.io/CustomProvider": {
+      "singular": "customprovider",
+      "plural": "customproviders"
+    },
+    "dashboard.azure.m.upbound.io/Grafana": {
+      "singular": "grafana",
+      "plural": "grafanas"
+    },
+    "dashboard.azure.m.upbound.io/GrafanaManagedPrivateEndpoint": {
+      "singular": "grafanamanagedprivateendpoint",
+      "plural": "grafanamanagedprivateendpoints"
+    },
+    "dashboard.azure.upbound.io/Grafana": {
+      "singular": "grafana",
+      "plural": "grafanas"
+    },
+    "dashboard.azure.upbound.io/GrafanaManagedPrivateEndpoint": {
+      "singular": "grafanamanagedprivateendpoint",
+      "plural": "grafanamanagedprivateendpoints"
+    },
+    "databoxedge.azure.m.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "databoxedge.azure.upbound.io/Device": {
+      "singular": "device",
+      "plural": "devices"
+    },
+    "databricks.azure.m.upbound.io/AccessConnector": {
+      "singular": "accessconnector",
+      "plural": "accessconnectors"
+    },
+    "databricks.azure.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "databricks.azure.m.upbound.io/WorkspaceRootDbfsCustomerManagedKey": {
+      "singular": "workspacerootdbfscustomermanagedkey",
+      "plural": "workspacerootdbfscustomermanagedkeys"
+    },
+    "databricks.azure.upbound.io/AccessConnector": {
+      "singular": "accessconnector",
+      "plural": "accessconnectors"
+    },
+    "databricks.azure.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "databricks.azure.upbound.io/WorkspaceRootDbfsCustomerManagedKey": {
+      "singular": "workspacerootdbfscustomermanagedkey",
+      "plural": "workspacerootdbfscustomermanagedkeys"
+    },
+    "datafactory.azure.m.upbound.io/CustomDataSet": {
+      "singular": "customdataset",
+      "plural": "customdatasets"
+    },
+    "datafactory.azure.m.upbound.io/DataFlow": {
+      "singular": "dataflow",
+      "plural": "dataflows"
+    },
+    "datafactory.azure.m.upbound.io/DataSetAzureBlob": {
+      "singular": "datasetazureblob",
+      "plural": "datasetazureblobs"
+    },
+    "datafactory.azure.m.upbound.io/DataSetBinary": {
+      "singular": "datasetbinary",
+      "plural": "datasetbinaries"
+    },
+    "datafactory.azure.m.upbound.io/DataSetCosmosDBSQLAPI": {
+      "singular": "datasetcosmosdbsqlapi",
+      "plural": "datasetcosmosdbsqlapis"
+    },
+    "datafactory.azure.m.upbound.io/DataSetDelimitedText": {
+      "singular": "datasetdelimitedtext",
+      "plural": "datasetdelimitedtexts"
+    },
+    "datafactory.azure.m.upbound.io/DataSetHTTP": {
+      "singular": "datasethttp",
+      "plural": "datasethttps"
+    },
+    "datafactory.azure.m.upbound.io/DataSetJSON": {
+      "singular": "datasetjson",
+      "plural": "datasetjsons"
+    },
+    "datafactory.azure.m.upbound.io/DataSetMySQL": {
+      "singular": "datasetmysql",
+      "plural": "datasetmysqls"
+    },
+    "datafactory.azure.m.upbound.io/DataSetParquet": {
+      "singular": "datasetparquet",
+      "plural": "datasetparquets"
+    },
+    "datafactory.azure.m.upbound.io/DataSetPostgreSQL": {
+      "singular": "datasetpostgresql",
+      "plural": "datasetpostgresqls"
+    },
+    "datafactory.azure.m.upbound.io/DataSetSQLServerTable": {
+      "singular": "datasetsqlservertable",
+      "plural": "datasetsqlservertables"
+    },
+    "datafactory.azure.m.upbound.io/DataSetSnowflake": {
+      "singular": "datasetsnowflake",
+      "plural": "datasetsnowflakes"
+    },
+    "datafactory.azure.m.upbound.io/Factory": {
+      "singular": "factory",
+      "plural": "factories"
+    },
+    "datafactory.azure.m.upbound.io/IntegrationRuntimeAzure": {
+      "singular": "integrationruntimeazure",
+      "plural": "integrationruntimeazures"
+    },
+    "datafactory.azure.m.upbound.io/IntegrationRuntimeAzureSSIS": {
+      "singular": "integrationruntimeazuressis",
+      "plural": "integrationruntimeazuressis"
+    },
+    "datafactory.azure.m.upbound.io/IntegrationRuntimeSelfHosted": {
+      "singular": "integrationruntimeselfhosted",
+      "plural": "integrationruntimeselfhosteds"
+    },
+    "datafactory.azure.m.upbound.io/LinkedCustomService": {
+      "singular": "linkedcustomservice",
+      "plural": "linkedcustomservices"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureBlobStorage": {
+      "singular": "linkedserviceazureblobstorage",
+      "plural": "linkedserviceazureblobstorages"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureDatabricks": {
+      "singular": "linkedserviceazuredatabricks",
+      "plural": "linkedserviceazuredatabricks"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureFileStorage": {
+      "singular": "linkedserviceazurefilestorage",
+      "plural": "linkedserviceazurefilestorages"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureFunction": {
+      "singular": "linkedserviceazurefunction",
+      "plural": "linkedserviceazurefunctions"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureSQLDatabase": {
+      "singular": "linkedserviceazuresqldatabase",
+      "plural": "linkedserviceazuresqldatabases"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureSearch": {
+      "singular": "linkedserviceazuresearch",
+      "plural": "linkedserviceazuresearches"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceAzureTableStorage": {
+      "singular": "linkedserviceazuretablestorage",
+      "plural": "linkedserviceazuretablestorages"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceCosmosDB": {
+      "singular": "linkedservicecosmosdb",
+      "plural": "linkedservicecosmosdbs"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceCosmosDBMongoapi": {
+      "singular": "linkedservicecosmosdbmongoapi",
+      "plural": "linkedservicecosmosdbmongoapis"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceDataLakeStorageGen2": {
+      "singular": "linkedservicedatalakestoragegen2",
+      "plural": "linkedservicedatalakestoragegen2s"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceKeyVault": {
+      "singular": "linkedservicekeyvault",
+      "plural": "linkedservicekeyvaults"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceKusto": {
+      "singular": "linkedservicekusto",
+      "plural": "linkedservicekustoes"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceMySQL": {
+      "singular": "linkedservicemysql",
+      "plural": "linkedservicemysqls"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceOData": {
+      "singular": "linkedserviceodata",
+      "plural": "linkedserviceodata"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceOdbc": {
+      "singular": "linkedserviceodbc",
+      "plural": "linkedserviceodbcs"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServicePostgreSQL": {
+      "singular": "linkedservicepostgresql",
+      "plural": "linkedservicepostgresqls"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceSFTP": {
+      "singular": "linkedservicesftp",
+      "plural": "linkedservicesftps"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceSQLServer": {
+      "singular": "linkedservicesqlserver",
+      "plural": "linkedservicesqlservers"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceSnowflake": {
+      "singular": "linkedservicesnowflake",
+      "plural": "linkedservicesnowflakes"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceSynapse": {
+      "singular": "linkedservicesynapse",
+      "plural": "linkedservicesynapses"
+    },
+    "datafactory.azure.m.upbound.io/LinkedServiceWeb": {
+      "singular": "linkedserviceweb",
+      "plural": "linkedservicewebs"
+    },
+    "datafactory.azure.m.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "datafactory.azure.m.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "datafactory.azure.m.upbound.io/TriggerBlobEvent": {
+      "singular": "triggerblobevent",
+      "plural": "triggerblobevents"
+    },
+    "datafactory.azure.m.upbound.io/TriggerCustomEvent": {
+      "singular": "triggercustomevent",
+      "plural": "triggercustomevents"
+    },
+    "datafactory.azure.m.upbound.io/TriggerSchedule": {
+      "singular": "triggerschedule",
+      "plural": "triggerschedules"
+    },
+    "datafactory.azure.upbound.io/CustomDataSet": {
+      "singular": "customdataset",
+      "plural": "customdatasets"
+    },
+    "datafactory.azure.upbound.io/DataFlow": {
+      "singular": "dataflow",
+      "plural": "dataflows"
+    },
+    "datafactory.azure.upbound.io/DataSetAzureBlob": {
+      "singular": "datasetazureblob",
+      "plural": "datasetazureblobs"
+    },
+    "datafactory.azure.upbound.io/DataSetBinary": {
+      "singular": "datasetbinary",
+      "plural": "datasetbinaries"
+    },
+    "datafactory.azure.upbound.io/DataSetCosmosDBSQLAPI": {
+      "singular": "datasetcosmosdbsqlapi",
+      "plural": "datasetcosmosdbsqlapis"
+    },
+    "datafactory.azure.upbound.io/DataSetDelimitedText": {
+      "singular": "datasetdelimitedtext",
+      "plural": "datasetdelimitedtexts"
+    },
+    "datafactory.azure.upbound.io/DataSetHTTP": {
+      "singular": "datasethttp",
+      "plural": "datasethttps"
+    },
+    "datafactory.azure.upbound.io/DataSetJSON": {
+      "singular": "datasetjson",
+      "plural": "datasetjsons"
+    },
+    "datafactory.azure.upbound.io/DataSetMySQL": {
+      "singular": "datasetmysql",
+      "plural": "datasetmysqls"
+    },
+    "datafactory.azure.upbound.io/DataSetParquet": {
+      "singular": "datasetparquet",
+      "plural": "datasetparquets"
+    },
+    "datafactory.azure.upbound.io/DataSetPostgreSQL": {
+      "singular": "datasetpostgresql",
+      "plural": "datasetpostgresqls"
+    },
+    "datafactory.azure.upbound.io/DataSetSQLServerTable": {
+      "singular": "datasetsqlservertable",
+      "plural": "datasetsqlservertables"
+    },
+    "datafactory.azure.upbound.io/DataSetSnowflake": {
+      "singular": "datasetsnowflake",
+      "plural": "datasetsnowflakes"
+    },
+    "datafactory.azure.upbound.io/Factory": {
+      "singular": "factory",
+      "plural": "factories"
+    },
+    "datafactory.azure.upbound.io/IntegrationRuntimeAzure": {
+      "singular": "integrationruntimeazure",
+      "plural": "integrationruntimeazures"
+    },
+    "datafactory.azure.upbound.io/IntegrationRuntimeAzureSSIS": {
+      "singular": "integrationruntimeazuressis",
+      "plural": "integrationruntimeazuressis"
+    },
+    "datafactory.azure.upbound.io/IntegrationRuntimeSelfHosted": {
+      "singular": "integrationruntimeselfhosted",
+      "plural": "integrationruntimeselfhosteds"
+    },
+    "datafactory.azure.upbound.io/LinkedCustomService": {
+      "singular": "linkedcustomservice",
+      "plural": "linkedcustomservices"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureBlobStorage": {
+      "singular": "linkedserviceazureblobstorage",
+      "plural": "linkedserviceazureblobstorages"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureDatabricks": {
+      "singular": "linkedserviceazuredatabricks",
+      "plural": "linkedserviceazuredatabricks"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureFileStorage": {
+      "singular": "linkedserviceazurefilestorage",
+      "plural": "linkedserviceazurefilestorages"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureFunction": {
+      "singular": "linkedserviceazurefunction",
+      "plural": "linkedserviceazurefunctions"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureSQLDatabase": {
+      "singular": "linkedserviceazuresqldatabase",
+      "plural": "linkedserviceazuresqldatabases"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureSearch": {
+      "singular": "linkedserviceazuresearch",
+      "plural": "linkedserviceazuresearches"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceAzureTableStorage": {
+      "singular": "linkedserviceazuretablestorage",
+      "plural": "linkedserviceazuretablestorages"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceCosmosDB": {
+      "singular": "linkedservicecosmosdb",
+      "plural": "linkedservicecosmosdbs"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceCosmosDBMongoapi": {
+      "singular": "linkedservicecosmosdbmongoapi",
+      "plural": "linkedservicecosmosdbmongoapis"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceDataLakeStorageGen2": {
+      "singular": "linkedservicedatalakestoragegen2",
+      "plural": "linkedservicedatalakestoragegen2s"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceKeyVault": {
+      "singular": "linkedservicekeyvault",
+      "plural": "linkedservicekeyvaults"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceKusto": {
+      "singular": "linkedservicekusto",
+      "plural": "linkedservicekustoes"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceMySQL": {
+      "singular": "linkedservicemysql",
+      "plural": "linkedservicemysqls"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceOData": {
+      "singular": "linkedserviceodata",
+      "plural": "linkedserviceodata"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceOdbc": {
+      "singular": "linkedserviceodbc",
+      "plural": "linkedserviceodbcs"
+    },
+    "datafactory.azure.upbound.io/LinkedServicePostgreSQL": {
+      "singular": "linkedservicepostgresql",
+      "plural": "linkedservicepostgresqls"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceSFTP": {
+      "singular": "linkedservicesftp",
+      "plural": "linkedservicesftps"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceSQLServer": {
+      "singular": "linkedservicesqlserver",
+      "plural": "linkedservicesqlservers"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceSnowflake": {
+      "singular": "linkedservicesnowflake",
+      "plural": "linkedservicesnowflakes"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceSynapse": {
+      "singular": "linkedservicesynapse",
+      "plural": "linkedservicesynapses"
+    },
+    "datafactory.azure.upbound.io/LinkedServiceWeb": {
+      "singular": "linkedserviceweb",
+      "plural": "linkedservicewebs"
+    },
+    "datafactory.azure.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "datafactory.azure.upbound.io/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "datafactory.azure.upbound.io/TriggerBlobEvent": {
+      "singular": "triggerblobevent",
+      "plural": "triggerblobevents"
+    },
+    "datafactory.azure.upbound.io/TriggerCustomEvent": {
+      "singular": "triggercustomevent",
+      "plural": "triggercustomevents"
+    },
+    "datafactory.azure.upbound.io/TriggerSchedule": {
+      "singular": "triggerschedule",
+      "plural": "triggerschedules"
+    },
+    "datamigration.azure.m.upbound.io/DatabaseMigrationProject": {
+      "singular": "databasemigrationproject",
+      "plural": "databasemigrationprojects"
+    },
+    "datamigration.azure.m.upbound.io/DatabaseMigrationService": {
+      "singular": "databasemigrationservice",
+      "plural": "databasemigrationservices"
+    },
+    "datamigration.azure.upbound.io/DatabaseMigrationProject": {
+      "singular": "databasemigrationproject",
+      "plural": "databasemigrationprojects"
+    },
+    "datamigration.azure.upbound.io/DatabaseMigrationService": {
+      "singular": "databasemigrationservice",
+      "plural": "databasemigrationservices"
+    },
+    "dataprotection.azure.m.upbound.io/BackupInstanceBlobStorage": {
+      "singular": "backupinstanceblobstorage",
+      "plural": "backupinstanceblobstorages"
+    },
+    "dataprotection.azure.m.upbound.io/BackupInstanceDisk": {
+      "singular": "backupinstancedisk",
+      "plural": "backupinstancedisks"
+    },
+    "dataprotection.azure.m.upbound.io/BackupInstanceKubernetesCluster": {
+      "singular": "backupinstancekubernetescluster",
+      "plural": "backupinstancekubernetesclusters"
+    },
+    "dataprotection.azure.m.upbound.io/BackupInstancePostgreSQL": {
+      "singular": "backupinstancepostgresql",
+      "plural": "backupinstancepostgresqls"
+    },
+    "dataprotection.azure.m.upbound.io/BackupInstancePostgreSQLFlexibleServer": {
+      "singular": "backupinstancepostgresqlflexibleserver",
+      "plural": "backupinstancepostgresqlflexibleservers"
+    },
+    "dataprotection.azure.m.upbound.io/BackupPolicyBlobStorage": {
+      "singular": "backuppolicyblobstorage",
+      "plural": "backuppolicyblobstorages"
+    },
+    "dataprotection.azure.m.upbound.io/BackupPolicyDisk": {
+      "singular": "backuppolicydisk",
+      "plural": "backuppolicydisks"
+    },
+    "dataprotection.azure.m.upbound.io/BackupPolicyKubernetesCluster": {
+      "singular": "backuppolicykubernetescluster",
+      "plural": "backuppolicykubernetesclusters"
+    },
+    "dataprotection.azure.m.upbound.io/BackupPolicyPostgreSQL": {
+      "singular": "backuppolicypostgresql",
+      "plural": "backuppolicypostgresqls"
+    },
+    "dataprotection.azure.m.upbound.io/BackupPolicyPostgreSQLFlexibleServer": {
+      "singular": "backuppolicypostgresqlflexibleserver",
+      "plural": "backuppolicypostgresqlflexibleservers"
+    },
+    "dataprotection.azure.m.upbound.io/BackupVault": {
+      "singular": "backupvault",
+      "plural": "backupvaults"
+    },
+    "dataprotection.azure.m.upbound.io/ResourceGuard": {
+      "singular": "resourceguard",
+      "plural": "resourceguards"
+    },
+    "dataprotection.azure.upbound.io/BackupInstanceBlobStorage": {
+      "singular": "backupinstanceblobstorage",
+      "plural": "backupinstanceblobstorages"
+    },
+    "dataprotection.azure.upbound.io/BackupInstanceDisk": {
+      "singular": "backupinstancedisk",
+      "plural": "backupinstancedisks"
+    },
+    "dataprotection.azure.upbound.io/BackupInstanceKubernetesCluster": {
+      "singular": "backupinstancekubernetescluster",
+      "plural": "backupinstancekubernetesclusters"
+    },
+    "dataprotection.azure.upbound.io/BackupInstancePostgreSQL": {
+      "singular": "backupinstancepostgresql",
+      "plural": "backupinstancepostgresqls"
+    },
+    "dataprotection.azure.upbound.io/BackupInstancePostgreSQLFlexibleServer": {
+      "singular": "backupinstancepostgresqlflexibleserver",
+      "plural": "backupinstancepostgresqlflexibleservers"
+    },
+    "dataprotection.azure.upbound.io/BackupPolicyBlobStorage": {
+      "singular": "backuppolicyblobstorage",
+      "plural": "backuppolicyblobstorages"
+    },
+    "dataprotection.azure.upbound.io/BackupPolicyDisk": {
+      "singular": "backuppolicydisk",
+      "plural": "backuppolicydisks"
+    },
+    "dataprotection.azure.upbound.io/BackupPolicyKubernetesCluster": {
+      "singular": "backuppolicykubernetescluster",
+      "plural": "backuppolicykubernetesclusters"
+    },
+    "dataprotection.azure.upbound.io/BackupPolicyPostgreSQL": {
+      "singular": "backuppolicypostgresql",
+      "plural": "backuppolicypostgresqls"
+    },
+    "dataprotection.azure.upbound.io/BackupPolicyPostgreSQLFlexibleServer": {
+      "singular": "backuppolicypostgresqlflexibleserver",
+      "plural": "backuppolicypostgresqlflexibleservers"
+    },
+    "dataprotection.azure.upbound.io/BackupVault": {
+      "singular": "backupvault",
+      "plural": "backupvaults"
+    },
+    "dataprotection.azure.upbound.io/ResourceGuard": {
+      "singular": "resourceguard",
+      "plural": "resourceguards"
+    },
+    "datashare.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "datashare.azure.m.upbound.io/DataSetBlobStorage": {
+      "singular": "datasetblobstorage",
+      "plural": "datasetblobstorages"
+    },
+    "datashare.azure.m.upbound.io/DataSetDataLakeGen2": {
+      "singular": "datasetdatalakegen2",
+      "plural": "datasetdatalakegen2s"
+    },
+    "datashare.azure.m.upbound.io/DataSetKustoCluster": {
+      "singular": "datasetkustocluster",
+      "plural": "datasetkustoclusters"
+    },
+    "datashare.azure.m.upbound.io/DataSetKustoDatabase": {
+      "singular": "datasetkustodatabase",
+      "plural": "datasetkustodatabases"
+    },
+    "datashare.azure.m.upbound.io/DataShare": {
+      "singular": "datashare",
+      "plural": "datashares"
+    },
+    "datashare.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "datashare.azure.upbound.io/DataSetBlobStorage": {
+      "singular": "datasetblobstorage",
+      "plural": "datasetblobstorages"
+    },
+    "datashare.azure.upbound.io/DataSetDataLakeGen2": {
+      "singular": "datasetdatalakegen2",
+      "plural": "datasetdatalakegen2s"
+    },
+    "datashare.azure.upbound.io/DataSetKustoCluster": {
+      "singular": "datasetkustocluster",
+      "plural": "datasetkustoclusters"
+    },
+    "datashare.azure.upbound.io/DataSetKustoDatabase": {
+      "singular": "datasetkustodatabase",
+      "plural": "datasetkustodatabases"
+    },
+    "datashare.azure.upbound.io/DataShare": {
+      "singular": "datashare",
+      "plural": "datashares"
+    },
+    "dbformysql.azure.m.upbound.io/FlexibleDatabase": {
+      "singular": "flexibledatabase",
+      "plural": "flexibledatabases"
+    },
+    "dbformysql.azure.m.upbound.io/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbformysql.azure.m.upbound.io/FlexibleServerActiveDirectoryAdministrator": {
+      "singular": "flexibleserveractivedirectoryadministrator",
+      "plural": "flexibleserveractivedirectoryadministrators"
+    },
+    "dbformysql.azure.m.upbound.io/FlexibleServerConfiguration": {
+      "singular": "flexibleserverconfiguration",
+      "plural": "flexibleserverconfigurations"
+    },
+    "dbformysql.azure.m.upbound.io/FlexibleServerFirewallRule": {
+      "singular": "flexibleserverfirewallrule",
+      "plural": "flexibleserverfirewallrules"
+    },
+    "dbformysql.azure.upbound.io/FlexibleDatabase": {
+      "singular": "flexibledatabase",
+      "plural": "flexibledatabases"
+    },
+    "dbformysql.azure.upbound.io/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbformysql.azure.upbound.io/FlexibleServerActiveDirectoryAdministrator": {
+      "singular": "flexibleserveractivedirectoryadministrator",
+      "plural": "flexibleserveractivedirectoryadministrators"
+    },
+    "dbformysql.azure.upbound.io/FlexibleServerConfiguration": {
+      "singular": "flexibleserverconfiguration",
+      "plural": "flexibleserverconfigurations"
+    },
+    "dbformysql.azure.upbound.io/FlexibleServerFirewallRule": {
+      "singular": "flexibleserverfirewallrule",
+      "plural": "flexibleserverfirewallrules"
+    },
+    "dbforpostgresql.azure.m.upbound.io/ActiveDirectoryAdministrator": {
+      "singular": "activedirectoryadministrator",
+      "plural": "activedirectoryadministrators"
+    },
+    "dbforpostgresql.azure.m.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "dbforpostgresql.azure.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerActiveDirectoryAdministrator": {
+      "singular": "flexibleserveractivedirectoryadministrator",
+      "plural": "flexibleserveractivedirectoryadministrators"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerBackup": {
+      "singular": "flexibleserverbackup",
+      "plural": "flexibleserverbackups"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerConfiguration": {
+      "singular": "flexibleserverconfiguration",
+      "plural": "flexibleserverconfigurations"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerDatabase": {
+      "singular": "flexibleserverdatabase",
+      "plural": "flexibleserverdatabases"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerFirewallRule": {
+      "singular": "flexibleserverfirewallrule",
+      "plural": "flexibleserverfirewallrules"
+    },
+    "dbforpostgresql.azure.m.upbound.io/FlexibleServerVirtualEndpoint": {
+      "singular": "flexibleservervirtualendpoint",
+      "plural": "flexibleservervirtualendpoints"
+    },
+    "dbforpostgresql.azure.m.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "dbforpostgresql.azure.m.upbound.io/ServerKey": {
+      "singular": "serverkey",
+      "plural": "serverkeys"
+    },
+    "dbforpostgresql.azure.m.upbound.io/VirtualNetworkRule": {
+      "singular": "virtualnetworkrule",
+      "plural": "virtualnetworkrules"
+    },
+    "dbforpostgresql.azure.upbound.io/ActiveDirectoryAdministrator": {
+      "singular": "activedirectoryadministrator",
+      "plural": "activedirectoryadministrators"
+    },
+    "dbforpostgresql.azure.upbound.io/Configuration": {
+      "singular": "configuration",
+      "plural": "configurations"
+    },
+    "dbforpostgresql.azure.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "dbforpostgresql.azure.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServer": {
+      "singular": "flexibleserver",
+      "plural": "flexibleservers"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerActiveDirectoryAdministrator": {
+      "singular": "flexibleserveractivedirectoryadministrator",
+      "plural": "flexibleserveractivedirectoryadministrators"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerBackup": {
+      "singular": "flexibleserverbackup",
+      "plural": "flexibleserverbackups"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerConfiguration": {
+      "singular": "flexibleserverconfiguration",
+      "plural": "flexibleserverconfigurations"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerDatabase": {
+      "singular": "flexibleserverdatabase",
+      "plural": "flexibleserverdatabases"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerFirewallRule": {
+      "singular": "flexibleserverfirewallrule",
+      "plural": "flexibleserverfirewallrules"
+    },
+    "dbforpostgresql.azure.upbound.io/FlexibleServerVirtualEndpoint": {
+      "singular": "flexibleservervirtualendpoint",
+      "plural": "flexibleservervirtualendpoints"
+    },
+    "dbforpostgresql.azure.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "dbforpostgresql.azure.upbound.io/ServerKey": {
+      "singular": "serverkey",
+      "plural": "serverkeys"
+    },
+    "dbforpostgresql.azure.upbound.io/VirtualNetworkRule": {
+      "singular": "virtualnetworkrule",
+      "plural": "virtualnetworkrules"
+    },
+    "desktopvirtualization.azure.m.upbound.io/VirtualDesktopApplicationGroup": {
+      "singular": "virtualdesktopapplicationgroup",
+      "plural": "virtualdesktopapplicationgroups"
+    },
+    "desktopvirtualization.azure.m.upbound.io/VirtualDesktopHostPool": {
+      "singular": "virtualdesktophostpool",
+      "plural": "virtualdesktophostpools"
+    },
+    "desktopvirtualization.azure.m.upbound.io/VirtualDesktopHostPoolRegistrationInfo": {
+      "singular": "virtualdesktophostpoolregistrationinfo",
+      "plural": "virtualdesktophostpoolregistrationinfoes"
+    },
+    "desktopvirtualization.azure.m.upbound.io/VirtualDesktopWorkspace": {
+      "singular": "virtualdesktopworkspace",
+      "plural": "virtualdesktopworkspaces"
+    },
+    "desktopvirtualization.azure.m.upbound.io/VirtualDesktopWorkspaceApplicationGroupAssociation": {
+      "singular": "virtualdesktopworkspaceapplicationgroupassociation",
+      "plural": "virtualdesktopworkspaceapplicationgroupassociations"
+    },
+    "desktopvirtualization.azure.upbound.io/VirtualDesktopApplicationGroup": {
+      "singular": "virtualdesktopapplicationgroup",
+      "plural": "virtualdesktopapplicationgroups"
+    },
+    "desktopvirtualization.azure.upbound.io/VirtualDesktopHostPool": {
+      "singular": "virtualdesktophostpool",
+      "plural": "virtualdesktophostpools"
+    },
+    "desktopvirtualization.azure.upbound.io/VirtualDesktopHostPoolRegistrationInfo": {
+      "singular": "virtualdesktophostpoolregistrationinfo",
+      "plural": "virtualdesktophostpoolregistrationinfoes"
+    },
+    "desktopvirtualization.azure.upbound.io/VirtualDesktopWorkspace": {
+      "singular": "virtualdesktopworkspace",
+      "plural": "virtualdesktopworkspaces"
+    },
+    "desktopvirtualization.azure.upbound.io/VirtualDesktopWorkspaceApplicationGroupAssociation": {
+      "singular": "virtualdesktopworkspaceapplicationgroupassociation",
+      "plural": "virtualdesktopworkspaceapplicationgroupassociations"
+    },
+    "devices.azure.m.upbound.io/IOTHub": {
+      "singular": "iothub",
+      "plural": "iothubs"
+    },
+    "devices.azure.m.upbound.io/IOTHubCertificate": {
+      "singular": "iothubcertificate",
+      "plural": "iothubcertificates"
+    },
+    "devices.azure.m.upbound.io/IOTHubConsumerGroup": {
+      "singular": "iothubconsumergroup",
+      "plural": "iothubconsumergroups"
+    },
+    "devices.azure.m.upbound.io/IOTHubDPS": {
+      "singular": "iothubdps",
+      "plural": "iothubdps"
+    },
+    "devices.azure.m.upbound.io/IOTHubDPSCertificate": {
+      "singular": "iothubdpscertificate",
+      "plural": "iothubdpscertificates"
+    },
+    "devices.azure.m.upbound.io/IOTHubDPSSharedAccessPolicy": {
+      "singular": "iothubdpssharedaccesspolicy",
+      "plural": "iothubdpssharedaccesspolicies"
+    },
+    "devices.azure.m.upbound.io/IOTHubEndpointEventHub": {
+      "singular": "iothubendpointeventhub",
+      "plural": "iothubendpointeventhubs"
+    },
+    "devices.azure.m.upbound.io/IOTHubEndpointServiceBusQueue": {
+      "singular": "iothubendpointservicebusqueue",
+      "plural": "iothubendpointservicebusqueues"
+    },
+    "devices.azure.m.upbound.io/IOTHubEndpointServiceBusTopic": {
+      "singular": "iothubendpointservicebustopic",
+      "plural": "iothubendpointservicebustopics"
+    },
+    "devices.azure.m.upbound.io/IOTHubEndpointStorageContainer": {
+      "singular": "iothubendpointstoragecontainer",
+      "plural": "iothubendpointstoragecontainers"
+    },
+    "devices.azure.m.upbound.io/IOTHubEnrichment": {
+      "singular": "iothubenrichment",
+      "plural": "iothubenrichments"
+    },
+    "devices.azure.m.upbound.io/IOTHubFallbackRoute": {
+      "singular": "iothubfallbackroute",
+      "plural": "iothubfallbackroutes"
+    },
+    "devices.azure.m.upbound.io/IOTHubRoute": {
+      "singular": "iothubroute",
+      "plural": "iothubroutes"
+    },
+    "devices.azure.m.upbound.io/IOTHubSharedAccessPolicy": {
+      "singular": "iothubsharedaccesspolicy",
+      "plural": "iothubsharedaccesspolicies"
+    },
+    "devices.azure.upbound.io/IOTHub": {
+      "singular": "iothub",
+      "plural": "iothubs"
+    },
+    "devices.azure.upbound.io/IOTHubCertificate": {
+      "singular": "iothubcertificate",
+      "plural": "iothubcertificates"
+    },
+    "devices.azure.upbound.io/IOTHubConsumerGroup": {
+      "singular": "iothubconsumergroup",
+      "plural": "iothubconsumergroups"
+    },
+    "devices.azure.upbound.io/IOTHubDPS": {
+      "singular": "iothubdps",
+      "plural": "iothubdps"
+    },
+    "devices.azure.upbound.io/IOTHubDPSCertificate": {
+      "singular": "iothubdpscertificate",
+      "plural": "iothubdpscertificates"
+    },
+    "devices.azure.upbound.io/IOTHubDPSSharedAccessPolicy": {
+      "singular": "iothubdpssharedaccesspolicy",
+      "plural": "iothubdpssharedaccesspolicies"
+    },
+    "devices.azure.upbound.io/IOTHubEndpointEventHub": {
+      "singular": "iothubendpointeventhub",
+      "plural": "iothubendpointeventhubs"
+    },
+    "devices.azure.upbound.io/IOTHubEndpointServiceBusQueue": {
+      "singular": "iothubendpointservicebusqueue",
+      "plural": "iothubendpointservicebusqueues"
+    },
+    "devices.azure.upbound.io/IOTHubEndpointServiceBusTopic": {
+      "singular": "iothubendpointservicebustopic",
+      "plural": "iothubendpointservicebustopics"
+    },
+    "devices.azure.upbound.io/IOTHubEndpointStorageContainer": {
+      "singular": "iothubendpointstoragecontainer",
+      "plural": "iothubendpointstoragecontainers"
+    },
+    "devices.azure.upbound.io/IOTHubEnrichment": {
+      "singular": "iothubenrichment",
+      "plural": "iothubenrichments"
+    },
+    "devices.azure.upbound.io/IOTHubFallbackRoute": {
+      "singular": "iothubfallbackroute",
+      "plural": "iothubfallbackroutes"
+    },
+    "devices.azure.upbound.io/IOTHubRoute": {
+      "singular": "iothubroute",
+      "plural": "iothubroutes"
+    },
+    "devices.azure.upbound.io/IOTHubSharedAccessPolicy": {
+      "singular": "iothubsharedaccesspolicy",
+      "plural": "iothubsharedaccesspolicies"
+    },
+    "deviceupdate.azure.m.upbound.io/IOTHubDeviceUpdateAccount": {
+      "singular": "iothubdeviceupdateaccount",
+      "plural": "iothubdeviceupdateaccounts"
+    },
+    "deviceupdate.azure.m.upbound.io/IOTHubDeviceUpdateInstance": {
+      "singular": "iothubdeviceupdateinstance",
+      "plural": "iothubdeviceupdateinstances"
+    },
+    "deviceupdate.azure.upbound.io/IOTHubDeviceUpdateAccount": {
+      "singular": "iothubdeviceupdateaccount",
+      "plural": "iothubdeviceupdateaccounts"
+    },
+    "deviceupdate.azure.upbound.io/IOTHubDeviceUpdateInstance": {
+      "singular": "iothubdeviceupdateinstance",
+      "plural": "iothubdeviceupdateinstances"
+    },
+    "devtestlab.azure.m.upbound.io/GlobalVMShutdownSchedule": {
+      "singular": "globalvmshutdownschedule",
+      "plural": "globalvmshutdownschedules"
+    },
+    "devtestlab.azure.m.upbound.io/Lab": {
+      "singular": "lab",
+      "plural": "labs"
+    },
+    "devtestlab.azure.m.upbound.io/LinuxVirtualMachine": {
+      "singular": "linuxvirtualmachine",
+      "plural": "linuxvirtualmachines"
+    },
+    "devtestlab.azure.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "devtestlab.azure.m.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "devtestlab.azure.m.upbound.io/VirtualNetwork": {
+      "singular": "virtualnetwork",
+      "plural": "virtualnetworks"
+    },
+    "devtestlab.azure.m.upbound.io/WindowsVirtualMachine": {
+      "singular": "windowsvirtualmachine",
+      "plural": "windowsvirtualmachines"
+    },
+    "devtestlab.azure.upbound.io/GlobalVMShutdownSchedule": {
+      "singular": "globalvmshutdownschedule",
+      "plural": "globalvmshutdownschedules"
+    },
+    "devtestlab.azure.upbound.io/Lab": {
+      "singular": "lab",
+      "plural": "labs"
+    },
+    "devtestlab.azure.upbound.io/LinuxVirtualMachine": {
+      "singular": "linuxvirtualmachine",
+      "plural": "linuxvirtualmachines"
+    },
+    "devtestlab.azure.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "devtestlab.azure.upbound.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "devtestlab.azure.upbound.io/VirtualNetwork": {
+      "singular": "virtualnetwork",
+      "plural": "virtualnetworks"
+    },
+    "devtestlab.azure.upbound.io/WindowsVirtualMachine": {
+      "singular": "windowsvirtualmachine",
+      "plural": "windowsvirtualmachines"
+    },
+    "digitaltwins.azure.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "digitaltwins.azure.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "elastic.azure.m.upbound.io/CloudElasticsearch": {
+      "singular": "cloudelasticsearch",
+      "plural": "cloudelasticsearches"
+    },
+    "elastic.azure.upbound.io/CloudElasticsearch": {
+      "singular": "cloudelasticsearch",
+      "plural": "cloudelasticsearches"
+    },
+    "eventgrid.azure.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "eventgrid.azure.m.upbound.io/DomainTopic": {
+      "singular": "domaintopic",
+      "plural": "domaintopics"
+    },
+    "eventgrid.azure.m.upbound.io/EventGridNamespace": {
+      "singular": "eventgridnamespace",
+      "plural": "eventgridnamespaces"
+    },
+    "eventgrid.azure.m.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "eventgrid.azure.m.upbound.io/PartnerConfiguration": {
+      "singular": "partnerconfiguration",
+      "plural": "partnerconfigurations"
+    },
+    "eventgrid.azure.m.upbound.io/SystemTopic": {
+      "singular": "systemtopic",
+      "plural": "systemtopics"
+    },
+    "eventgrid.azure.m.upbound.io/SystemTopicEventSubscription": {
+      "singular": "systemtopiceventsubscription",
+      "plural": "systemtopiceventsubscriptions"
+    },
+    "eventgrid.azure.m.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "eventgrid.azure.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "eventgrid.azure.upbound.io/DomainTopic": {
+      "singular": "domaintopic",
+      "plural": "domaintopics"
+    },
+    "eventgrid.azure.upbound.io/EventGridNamespace": {
+      "singular": "eventgridnamespace",
+      "plural": "eventgridnamespaces"
+    },
+    "eventgrid.azure.upbound.io/EventSubscription": {
+      "singular": "eventsubscription",
+      "plural": "eventsubscriptions"
+    },
+    "eventgrid.azure.upbound.io/PartnerConfiguration": {
+      "singular": "partnerconfiguration",
+      "plural": "partnerconfigurations"
+    },
+    "eventgrid.azure.upbound.io/SystemTopic": {
+      "singular": "systemtopic",
+      "plural": "systemtopics"
+    },
+    "eventgrid.azure.upbound.io/SystemTopicEventSubscription": {
+      "singular": "systemtopiceventsubscription",
+      "plural": "systemtopiceventsubscriptions"
+    },
+    "eventgrid.azure.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "eventhub.azure.m.upbound.io/AuthorizationRule": {
+      "singular": "authorizationrule",
+      "plural": "authorizationrules"
+    },
+    "eventhub.azure.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "eventhub.azure.m.upbound.io/ConsumerGroup": {
+      "singular": "consumergroup",
+      "plural": "consumergroups"
+    },
+    "eventhub.azure.m.upbound.io/EventHub": {
+      "singular": "eventhub",
+      "plural": "eventhubs"
+    },
+    "eventhub.azure.m.upbound.io/EventHubNamespace": {
+      "singular": "eventhubnamespace",
+      "plural": "eventhubnamespaces"
+    },
+    "eventhub.azure.m.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "eventhub.azure.m.upbound.io/NamespaceDisasterRecoveryConfig": {
+      "singular": "namespacedisasterrecoveryconfig",
+      "plural": "namespacedisasterrecoveryconfigs"
+    },
+    "eventhub.azure.m.upbound.io/NamespaceSchemaGroup": {
+      "singular": "namespaceschemagroup",
+      "plural": "namespaceschemagroups"
+    },
+    "eventhub.azure.upbound.io/AuthorizationRule": {
+      "singular": "authorizationrule",
+      "plural": "authorizationrules"
+    },
+    "eventhub.azure.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "eventhub.azure.upbound.io/ConsumerGroup": {
+      "singular": "consumergroup",
+      "plural": "consumergroups"
+    },
+    "eventhub.azure.upbound.io/EventHub": {
+      "singular": "eventhub",
+      "plural": "eventhubs"
+    },
+    "eventhub.azure.upbound.io/EventHubNamespace": {
+      "singular": "eventhubnamespace",
+      "plural": "eventhubnamespaces"
+    },
+    "eventhub.azure.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "eventhub.azure.upbound.io/NamespaceDisasterRecoveryConfig": {
+      "singular": "namespacedisasterrecoveryconfig",
+      "plural": "namespacedisasterrecoveryconfigs"
+    },
+    "eventhub.azure.upbound.io/NamespaceSchemaGroup": {
+      "singular": "namespaceschemagroup",
+      "plural": "namespaceschemagroups"
+    },
+    "fluidrelay.azure.m.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "fluidrelay.azure.upbound.io/Server": {
+      "singular": "server",
+      "plural": "servers"
+    },
+    "guestconfiguration.azure.m.upbound.io/PolicyVirtualMachineConfigurationAssignment": {
+      "singular": "policyvirtualmachineconfigurationassignment",
+      "plural": "policyvirtualmachineconfigurationassignments"
+    },
+    "guestconfiguration.azure.upbound.io/PolicyVirtualMachineConfigurationAssignment": {
+      "singular": "policyvirtualmachineconfigurationassignment",
+      "plural": "policyvirtualmachineconfigurationassignments"
+    },
+    "hdinsight.azure.m.upbound.io/HBaseCluster": {
+      "singular": "hbasecluster",
+      "plural": "hbaseclusters"
+    },
+    "hdinsight.azure.m.upbound.io/HadoopCluster": {
+      "singular": "hadoopcluster",
+      "plural": "hadoopclusters"
+    },
+    "hdinsight.azure.m.upbound.io/InteractiveQueryCluster": {
+      "singular": "interactivequerycluster",
+      "plural": "interactivequeryclusters"
+    },
+    "hdinsight.azure.m.upbound.io/KafkaCluster": {
+      "singular": "kafkacluster",
+      "plural": "kafkaclusters"
+    },
+    "hdinsight.azure.m.upbound.io/SparkCluster": {
+      "singular": "sparkcluster",
+      "plural": "sparkclusters"
+    },
+    "hdinsight.azure.upbound.io/HBaseCluster": {
+      "singular": "hbasecluster",
+      "plural": "hbaseclusters"
+    },
+    "hdinsight.azure.upbound.io/HadoopCluster": {
+      "singular": "hadoopcluster",
+      "plural": "hadoopclusters"
+    },
+    "hdinsight.azure.upbound.io/InteractiveQueryCluster": {
+      "singular": "interactivequerycluster",
+      "plural": "interactivequeryclusters"
+    },
+    "hdinsight.azure.upbound.io/KafkaCluster": {
+      "singular": "kafkacluster",
+      "plural": "kafkaclusters"
+    },
+    "hdinsight.azure.upbound.io/SparkCluster": {
+      "singular": "sparkcluster",
+      "plural": "sparkclusters"
+    },
+    "healthbot.azure.m.upbound.io/HealthBot": {
+      "singular": "healthbot",
+      "plural": "healthbots"
+    },
+    "healthbot.azure.upbound.io/HealthBot": {
+      "singular": "healthbot",
+      "plural": "healthbots"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareDICOMService": {
+      "singular": "healthcaredicomservice",
+      "plural": "healthcaredicomservices"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareFHIRService": {
+      "singular": "healthcarefhirservice",
+      "plural": "healthcarefhirservices"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareMedtechService": {
+      "singular": "healthcaremedtechservice",
+      "plural": "healthcaremedtechservices"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareMedtechServiceFHIRDestination": {
+      "singular": "healthcaremedtechservicefhirdestination",
+      "plural": "healthcaremedtechservicefhirdestinations"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareService": {
+      "singular": "healthcareservice",
+      "plural": "healthcareservices"
+    },
+    "healthcareapis.azure.m.upbound.io/HealthcareWorkspace": {
+      "singular": "healthcareworkspace",
+      "plural": "healthcareworkspaces"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareDICOMService": {
+      "singular": "healthcaredicomservice",
+      "plural": "healthcaredicomservices"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareFHIRService": {
+      "singular": "healthcarefhirservice",
+      "plural": "healthcarefhirservices"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareMedtechService": {
+      "singular": "healthcaremedtechservice",
+      "plural": "healthcaremedtechservices"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareMedtechServiceFHIRDestination": {
+      "singular": "healthcaremedtechservicefhirdestination",
+      "plural": "healthcaremedtechservicefhirdestinations"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareService": {
+      "singular": "healthcareservice",
+      "plural": "healthcareservices"
+    },
+    "healthcareapis.azure.upbound.io/HealthcareWorkspace": {
+      "singular": "healthcareworkspace",
+      "plural": "healthcareworkspaces"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsights": {
+      "singular": "applicationinsights",
+      "plural": "applicationinsights"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsAPIKey": {
+      "singular": "applicationinsightsapikey",
+      "plural": "applicationinsightsapikeys"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsAnalyticsItem": {
+      "singular": "applicationinsightsanalyticsitem",
+      "plural": "applicationinsightsanalyticsitems"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsSmartDetectionRule": {
+      "singular": "applicationinsightssmartdetectionrule",
+      "plural": "applicationinsightssmartdetectionrules"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsStandardWebTest": {
+      "singular": "applicationinsightsstandardwebtest",
+      "plural": "applicationinsightsstandardwebtests"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsWebTest": {
+      "singular": "applicationinsightswebtest",
+      "plural": "applicationinsightswebtests"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsWorkbook": {
+      "singular": "applicationinsightsworkbook",
+      "plural": "applicationinsightsworkbooks"
+    },
+    "insights.azure.m.upbound.io/ApplicationInsightsWorkbookTemplate": {
+      "singular": "applicationinsightsworkbooktemplate",
+      "plural": "applicationinsightsworkbooktemplates"
+    },
+    "insights.azure.m.upbound.io/MonitorActionGroup": {
+      "singular": "monitoractiongroup",
+      "plural": "monitoractiongroups"
+    },
+    "insights.azure.m.upbound.io/MonitorActivityLogAlert": {
+      "singular": "monitoractivitylogalert",
+      "plural": "monitoractivitylogalerts"
+    },
+    "insights.azure.m.upbound.io/MonitorAutoscaleSetting": {
+      "singular": "monitorautoscalesetting",
+      "plural": "monitorautoscalesettings"
+    },
+    "insights.azure.m.upbound.io/MonitorDataCollectionEndpoint": {
+      "singular": "monitordatacollectionendpoint",
+      "plural": "monitordatacollectionendpoints"
+    },
+    "insights.azure.m.upbound.io/MonitorDataCollectionRule": {
+      "singular": "monitordatacollectionrule",
+      "plural": "monitordatacollectionrules"
+    },
+    "insights.azure.m.upbound.io/MonitorDataCollectionRuleAssociation": {
+      "singular": "monitordatacollectionruleassociation",
+      "plural": "monitordatacollectionruleassociations"
+    },
+    "insights.azure.m.upbound.io/MonitorDiagnosticSetting": {
+      "singular": "monitordiagnosticsetting",
+      "plural": "monitordiagnosticsettings"
+    },
+    "insights.azure.m.upbound.io/MonitorMetricAlert": {
+      "singular": "monitormetricalert",
+      "plural": "monitormetricalerts"
+    },
+    "insights.azure.m.upbound.io/MonitorPrivateLinkScope": {
+      "singular": "monitorprivatelinkscope",
+      "plural": "monitorprivatelinkscopes"
+    },
+    "insights.azure.m.upbound.io/MonitorPrivateLinkScopedService": {
+      "singular": "monitorprivatelinkscopedservice",
+      "plural": "monitorprivatelinkscopedservices"
+    },
+    "insights.azure.m.upbound.io/MonitorScheduledQueryRulesAlert": {
+      "singular": "monitorscheduledqueryrulesalert",
+      "plural": "monitorscheduledqueryrulesalerts"
+    },
+    "insights.azure.m.upbound.io/MonitorScheduledQueryRulesAlertV2": {
+      "singular": "monitorscheduledqueryrulesalertv2",
+      "plural": "monitorscheduledqueryrulesalertv2s"
+    },
+    "insights.azure.m.upbound.io/MonitorScheduledQueryRulesLog": {
+      "singular": "monitorscheduledqueryruleslog",
+      "plural": "monitorscheduledqueryruleslogs"
+    },
+    "insights.azure.m.upbound.io/MonitorWorkspace": {
+      "singular": "monitorworkspace",
+      "plural": "monitorworkspaces"
+    },
+    "insights.azure.upbound.io/ApplicationInsights": {
+      "singular": "applicationinsights",
+      "plural": "applicationinsights"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsAPIKey": {
+      "singular": "applicationinsightsapikey",
+      "plural": "applicationinsightsapikeys"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsAnalyticsItem": {
+      "singular": "applicationinsightsanalyticsitem",
+      "plural": "applicationinsightsanalyticsitems"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsSmartDetectionRule": {
+      "singular": "applicationinsightssmartdetectionrule",
+      "plural": "applicationinsightssmartdetectionrules"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsStandardWebTest": {
+      "singular": "applicationinsightsstandardwebtest",
+      "plural": "applicationinsightsstandardwebtests"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsWebTest": {
+      "singular": "applicationinsightswebtest",
+      "plural": "applicationinsightswebtests"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsWorkbook": {
+      "singular": "applicationinsightsworkbook",
+      "plural": "applicationinsightsworkbooks"
+    },
+    "insights.azure.upbound.io/ApplicationInsightsWorkbookTemplate": {
+      "singular": "applicationinsightsworkbooktemplate",
+      "plural": "applicationinsightsworkbooktemplates"
+    },
+    "insights.azure.upbound.io/MonitorActionGroup": {
+      "singular": "monitoractiongroup",
+      "plural": "monitoractiongroups"
+    },
+    "insights.azure.upbound.io/MonitorActivityLogAlert": {
+      "singular": "monitoractivitylogalert",
+      "plural": "monitoractivitylogalerts"
+    },
+    "insights.azure.upbound.io/MonitorAutoscaleSetting": {
+      "singular": "monitorautoscalesetting",
+      "plural": "monitorautoscalesettings"
+    },
+    "insights.azure.upbound.io/MonitorDataCollectionEndpoint": {
+      "singular": "monitordatacollectionendpoint",
+      "plural": "monitordatacollectionendpoints"
+    },
+    "insights.azure.upbound.io/MonitorDataCollectionRule": {
+      "singular": "monitordatacollectionrule",
+      "plural": "monitordatacollectionrules"
+    },
+    "insights.azure.upbound.io/MonitorDataCollectionRuleAssociation": {
+      "singular": "monitordatacollectionruleassociation",
+      "plural": "monitordatacollectionruleassociations"
+    },
+    "insights.azure.upbound.io/MonitorDiagnosticSetting": {
+      "singular": "monitordiagnosticsetting",
+      "plural": "monitordiagnosticsettings"
+    },
+    "insights.azure.upbound.io/MonitorMetricAlert": {
+      "singular": "monitormetricalert",
+      "plural": "monitormetricalerts"
+    },
+    "insights.azure.upbound.io/MonitorPrivateLinkScope": {
+      "singular": "monitorprivatelinkscope",
+      "plural": "monitorprivatelinkscopes"
+    },
+    "insights.azure.upbound.io/MonitorPrivateLinkScopedService": {
+      "singular": "monitorprivatelinkscopedservice",
+      "plural": "monitorprivatelinkscopedservices"
+    },
+    "insights.azure.upbound.io/MonitorScheduledQueryRulesAlert": {
+      "singular": "monitorscheduledqueryrulesalert",
+      "plural": "monitorscheduledqueryrulesalerts"
+    },
+    "insights.azure.upbound.io/MonitorScheduledQueryRulesAlertV2": {
+      "singular": "monitorscheduledqueryrulesalertv2",
+      "plural": "monitorscheduledqueryrulesalertv2s"
+    },
+    "insights.azure.upbound.io/MonitorScheduledQueryRulesLog": {
+      "singular": "monitorscheduledqueryruleslog",
+      "plural": "monitorscheduledqueryruleslogs"
+    },
+    "insights.azure.upbound.io/MonitorWorkspace": {
+      "singular": "monitorworkspace",
+      "plural": "monitorworkspaces"
+    },
+    "iotcentral.azure.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "iotcentral.azure.m.upbound.io/ApplicationNetworkRuleSet": {
+      "singular": "applicationnetworkruleset",
+      "plural": "applicationnetworkrulesets"
+    },
+    "iotcentral.azure.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "iotcentral.azure.upbound.io/ApplicationNetworkRuleSet": {
+      "singular": "applicationnetworkruleset",
+      "plural": "applicationnetworkrulesets"
+    },
+    "keyvault.azure.m.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "keyvault.azure.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "keyvault.azure.m.upbound.io/CertificateContacts": {
+      "singular": "certificatecontacts",
+      "plural": "certificatecontacts"
+    },
+    "keyvault.azure.m.upbound.io/CertificateIssuer": {
+      "singular": "certificateissuer",
+      "plural": "certificateissuers"
+    },
+    "keyvault.azure.m.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "keyvault.azure.m.upbound.io/ManagedHardwareSecurityModule": {
+      "singular": "managedhardwaresecuritymodule",
+      "plural": "managedhardwaresecuritymodules"
+    },
+    "keyvault.azure.m.upbound.io/ManagedStorageAccount": {
+      "singular": "managedstorageaccount",
+      "plural": "managedstorageaccounts"
+    },
+    "keyvault.azure.m.upbound.io/ManagedStorageAccountSASTokenDefinition": {
+      "singular": "managedstorageaccountsastokendefinition",
+      "plural": "managedstorageaccountsastokendefinitions"
+    },
+    "keyvault.azure.m.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "keyvault.azure.m.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "keyvault.azure.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "keyvault.azure.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "keyvault.azure.upbound.io/CertificateContacts": {
+      "singular": "certificatecontacts",
+      "plural": "certificatecontacts"
+    },
+    "keyvault.azure.upbound.io/CertificateIssuer": {
+      "singular": "certificateissuer",
+      "plural": "certificateissuers"
+    },
+    "keyvault.azure.upbound.io/Key": {
+      "singular": "key",
+      "plural": "keys"
+    },
+    "keyvault.azure.upbound.io/ManagedHardwareSecurityModule": {
+      "singular": "managedhardwaresecuritymodule",
+      "plural": "managedhardwaresecuritymodules"
+    },
+    "keyvault.azure.upbound.io/ManagedStorageAccount": {
+      "singular": "managedstorageaccount",
+      "plural": "managedstorageaccounts"
+    },
+    "keyvault.azure.upbound.io/ManagedStorageAccountSASTokenDefinition": {
+      "singular": "managedstorageaccountsastokendefinition",
+      "plural": "managedstorageaccountsastokendefinitions"
+    },
+    "keyvault.azure.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "keyvault.azure.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "kusto.azure.m.upbound.io/AttachedDatabaseConfiguration": {
+      "singular": "attacheddatabaseconfiguration",
+      "plural": "attacheddatabaseconfigurations"
+    },
+    "kusto.azure.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "kusto.azure.m.upbound.io/ClusterManagedPrivateEndpoint": {
+      "singular": "clustermanagedprivateendpoint",
+      "plural": "clustermanagedprivateendpoints"
+    },
+    "kusto.azure.m.upbound.io/ClusterPrincipalAssignment": {
+      "singular": "clusterprincipalassignment",
+      "plural": "clusterprincipalassignments"
+    },
+    "kusto.azure.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "kusto.azure.m.upbound.io/DatabasePrincipalAssignment": {
+      "singular": "databaseprincipalassignment",
+      "plural": "databaseprincipalassignments"
+    },
+    "kusto.azure.m.upbound.io/EventGridDataConnection": {
+      "singular": "eventgriddataconnection",
+      "plural": "eventgriddataconnections"
+    },
+    "kusto.azure.m.upbound.io/EventHubDataConnection": {
+      "singular": "eventhubdataconnection",
+      "plural": "eventhubdataconnections"
+    },
+    "kusto.azure.m.upbound.io/IOTHubDataConnection": {
+      "singular": "iothubdataconnection",
+      "plural": "iothubdataconnections"
+    },
+    "kusto.azure.upbound.io/AttachedDatabaseConfiguration": {
+      "singular": "attacheddatabaseconfiguration",
+      "plural": "attacheddatabaseconfigurations"
+    },
+    "kusto.azure.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "kusto.azure.upbound.io/ClusterManagedPrivateEndpoint": {
+      "singular": "clustermanagedprivateendpoint",
+      "plural": "clustermanagedprivateendpoints"
+    },
+    "kusto.azure.upbound.io/ClusterPrincipalAssignment": {
+      "singular": "clusterprincipalassignment",
+      "plural": "clusterprincipalassignments"
+    },
+    "kusto.azure.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "kusto.azure.upbound.io/DatabasePrincipalAssignment": {
+      "singular": "databaseprincipalassignment",
+      "plural": "databaseprincipalassignments"
+    },
+    "kusto.azure.upbound.io/EventGridDataConnection": {
+      "singular": "eventgriddataconnection",
+      "plural": "eventgriddataconnections"
+    },
+    "kusto.azure.upbound.io/EventHubDataConnection": {
+      "singular": "eventhubdataconnection",
+      "plural": "eventhubdataconnections"
+    },
+    "kusto.azure.upbound.io/IOTHubDataConnection": {
+      "singular": "iothubdataconnection",
+      "plural": "iothubdataconnections"
+    },
+    "loadtestservice.azure.m.upbound.io/LoadTest": {
+      "singular": "loadtest",
+      "plural": "loadtests"
+    },
+    "loadtestservice.azure.upbound.io/LoadTest": {
+      "singular": "loadtest",
+      "plural": "loadtests"
+    },
+    "logic.azure.m.upbound.io/AppActionCustom": {
+      "singular": "appactioncustom",
+      "plural": "appactioncustoms"
+    },
+    "logic.azure.m.upbound.io/AppActionHTTP": {
+      "singular": "appactionhttp",
+      "plural": "appactionhttps"
+    },
+    "logic.azure.m.upbound.io/AppIntegrationAccount": {
+      "singular": "appintegrationaccount",
+      "plural": "appintegrationaccounts"
+    },
+    "logic.azure.m.upbound.io/AppIntegrationAccountBatchConfiguration": {
+      "singular": "appintegrationaccountbatchconfiguration",
+      "plural": "appintegrationaccountbatchconfigurations"
+    },
+    "logic.azure.m.upbound.io/AppIntegrationAccountPartner": {
+      "singular": "appintegrationaccountpartner",
+      "plural": "appintegrationaccountpartners"
+    },
+    "logic.azure.m.upbound.io/AppIntegrationAccountSchema": {
+      "singular": "appintegrationaccountschema",
+      "plural": "appintegrationaccountschemas"
+    },
+    "logic.azure.m.upbound.io/AppIntegrationAccountSession": {
+      "singular": "appintegrationaccountsession",
+      "plural": "appintegrationaccountsessions"
+    },
+    "logic.azure.m.upbound.io/AppTriggerCustom": {
+      "singular": "apptriggercustom",
+      "plural": "apptriggercustoms"
+    },
+    "logic.azure.m.upbound.io/AppTriggerHTTPRequest": {
+      "singular": "apptriggerhttprequest",
+      "plural": "apptriggerhttprequests"
+    },
+    "logic.azure.m.upbound.io/AppTriggerRecurrence": {
+      "singular": "apptriggerrecurrence",
+      "plural": "apptriggerrecurrences"
+    },
+    "logic.azure.m.upbound.io/AppWorkflow": {
+      "singular": "appworkflow",
+      "plural": "appworkflows"
+    },
+    "logic.azure.upbound.io/AppActionCustom": {
+      "singular": "appactioncustom",
+      "plural": "appactioncustoms"
+    },
+    "logic.azure.upbound.io/AppActionHTTP": {
+      "singular": "appactionhttp",
+      "plural": "appactionhttps"
+    },
+    "logic.azure.upbound.io/AppIntegrationAccount": {
+      "singular": "appintegrationaccount",
+      "plural": "appintegrationaccounts"
+    },
+    "logic.azure.upbound.io/AppIntegrationAccountBatchConfiguration": {
+      "singular": "appintegrationaccountbatchconfiguration",
+      "plural": "appintegrationaccountbatchconfigurations"
+    },
+    "logic.azure.upbound.io/AppIntegrationAccountPartner": {
+      "singular": "appintegrationaccountpartner",
+      "plural": "appintegrationaccountpartners"
+    },
+    "logic.azure.upbound.io/AppIntegrationAccountSchema": {
+      "singular": "appintegrationaccountschema",
+      "plural": "appintegrationaccountschemas"
+    },
+    "logic.azure.upbound.io/AppIntegrationAccountSession": {
+      "singular": "appintegrationaccountsession",
+      "plural": "appintegrationaccountsessions"
+    },
+    "logic.azure.upbound.io/AppTriggerCustom": {
+      "singular": "apptriggercustom",
+      "plural": "apptriggercustoms"
+    },
+    "logic.azure.upbound.io/AppTriggerHTTPRequest": {
+      "singular": "apptriggerhttprequest",
+      "plural": "apptriggerhttprequests"
+    },
+    "logic.azure.upbound.io/AppTriggerRecurrence": {
+      "singular": "apptriggerrecurrence",
+      "plural": "apptriggerrecurrences"
+    },
+    "logic.azure.upbound.io/AppWorkflow": {
+      "singular": "appworkflow",
+      "plural": "appworkflows"
+    },
+    "machinelearningservices.azure.m.upbound.io/AIFoundry": {
+      "singular": "aifoundry",
+      "plural": "aifoundries"
+    },
+    "machinelearningservices.azure.m.upbound.io/AIFoundryProject": {
+      "singular": "aifoundryproject",
+      "plural": "aifoundryprojects"
+    },
+    "machinelearningservices.azure.m.upbound.io/ComputeCluster": {
+      "singular": "computecluster",
+      "plural": "computeclusters"
+    },
+    "machinelearningservices.azure.m.upbound.io/ComputeInstance": {
+      "singular": "computeinstance",
+      "plural": "computeinstances"
+    },
+    "machinelearningservices.azure.m.upbound.io/SynapseSpark": {
+      "singular": "synapsespark",
+      "plural": "synapsesparks"
+    },
+    "machinelearningservices.azure.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "machinelearningservices.azure.m.upbound.io/WorkspaceOutboundRuleFqdn": {
+      "singular": "workspaceoutboundrulefqdn",
+      "plural": "workspaceoutboundrulefqdns"
+    },
+    "machinelearningservices.azure.m.upbound.io/WorkspaceOutboundRulePrivateEndpoint": {
+      "singular": "workspaceoutboundruleprivateendpoint",
+      "plural": "workspaceoutboundruleprivateendpoints"
+    },
+    "machinelearningservices.azure.m.upbound.io/WorkspaceOutboundRuleServiceTag": {
+      "singular": "workspaceoutboundruleservicetag",
+      "plural": "workspaceoutboundruleservicetags"
+    },
+    "machinelearningservices.azure.upbound.io/AIFoundry": {
+      "singular": "aifoundry",
+      "plural": "aifoundries"
+    },
+    "machinelearningservices.azure.upbound.io/AIFoundryProject": {
+      "singular": "aifoundryproject",
+      "plural": "aifoundryprojects"
+    },
+    "machinelearningservices.azure.upbound.io/ComputeCluster": {
+      "singular": "computecluster",
+      "plural": "computeclusters"
+    },
+    "machinelearningservices.azure.upbound.io/ComputeInstance": {
+      "singular": "computeinstance",
+      "plural": "computeinstances"
+    },
+    "machinelearningservices.azure.upbound.io/SynapseSpark": {
+      "singular": "synapsespark",
+      "plural": "synapsesparks"
+    },
+    "machinelearningservices.azure.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "machinelearningservices.azure.upbound.io/WorkspaceOutboundRuleFqdn": {
+      "singular": "workspaceoutboundrulefqdn",
+      "plural": "workspaceoutboundrulefqdns"
+    },
+    "machinelearningservices.azure.upbound.io/WorkspaceOutboundRulePrivateEndpoint": {
+      "singular": "workspaceoutboundruleprivateendpoint",
+      "plural": "workspaceoutboundruleprivateendpoints"
+    },
+    "machinelearningservices.azure.upbound.io/WorkspaceOutboundRuleServiceTag": {
+      "singular": "workspaceoutboundruleservicetag",
+      "plural": "workspaceoutboundruleservicetags"
+    },
+    "maintenance.azure.m.upbound.io/MaintenanceAssignmentDedicatedHost": {
+      "singular": "maintenanceassignmentdedicatedhost",
+      "plural": "maintenanceassignmentdedicatedhosts"
+    },
+    "maintenance.azure.m.upbound.io/MaintenanceAssignmentVirtualMachine": {
+      "singular": "maintenanceassignmentvirtualmachine",
+      "plural": "maintenanceassignmentvirtualmachines"
+    },
+    "maintenance.azure.m.upbound.io/MaintenanceConfiguration": {
+      "singular": "maintenanceconfiguration",
+      "plural": "maintenanceconfigurations"
+    },
+    "maintenance.azure.upbound.io/MaintenanceAssignmentDedicatedHost": {
+      "singular": "maintenanceassignmentdedicatedhost",
+      "plural": "maintenanceassignmentdedicatedhosts"
+    },
+    "maintenance.azure.upbound.io/MaintenanceAssignmentVirtualMachine": {
+      "singular": "maintenanceassignmentvirtualmachine",
+      "plural": "maintenanceassignmentvirtualmachines"
+    },
+    "maintenance.azure.upbound.io/MaintenanceConfiguration": {
+      "singular": "maintenanceconfiguration",
+      "plural": "maintenanceconfigurations"
+    },
+    "managedidentity.azure.m.upbound.io/FederatedIdentityCredential": {
+      "singular": "federatedidentitycredential",
+      "plural": "federatedidentitycredentials"
+    },
+    "managedidentity.azure.m.upbound.io/UserAssignedIdentity": {
+      "singular": "userassignedidentity",
+      "plural": "userassignedidentities"
+    },
+    "managedidentity.azure.upbound.io/FederatedIdentityCredential": {
+      "singular": "federatedidentitycredential",
+      "plural": "federatedidentitycredentials"
+    },
+    "managedidentity.azure.upbound.io/UserAssignedIdentity": {
+      "singular": "userassignedidentity",
+      "plural": "userassignedidentities"
+    },
+    "management.azure.m.upbound.io/ManagementGroup": {
+      "singular": "managementgroup",
+      "plural": "managementgroups"
+    },
+    "management.azure.m.upbound.io/ManagementGroupSubscriptionAssociation": {
+      "singular": "managementgroupsubscriptionassociation",
+      "plural": "managementgroupsubscriptionassociations"
+    },
+    "management.azure.upbound.io/ManagementGroup": {
+      "singular": "managementgroup",
+      "plural": "managementgroups"
+    },
+    "management.azure.upbound.io/ManagementGroupSubscriptionAssociation": {
+      "singular": "managementgroupsubscriptionassociation",
+      "plural": "managementgroupsubscriptionassociations"
+    },
+    "maps.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "maps.azure.m.upbound.io/Creator": {
+      "singular": "creator",
+      "plural": "creators"
+    },
+    "maps.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "maps.azure.upbound.io/Creator": {
+      "singular": "creator",
+      "plural": "creators"
+    },
+    "marketplaceordering.azure.m.upbound.io/MarketplaceAgreement": {
+      "singular": "marketplaceagreement",
+      "plural": "marketplaceagreements"
+    },
+    "marketplaceordering.azure.upbound.io/MarketplaceAgreement": {
+      "singular": "marketplaceagreement",
+      "plural": "marketplaceagreements"
+    },
+    "netapp.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "netapp.azure.m.upbound.io/Pool": {
+      "singular": "pool",
+      "plural": "pools"
+    },
+    "netapp.azure.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "netapp.azure.m.upbound.io/SnapshotPolicy": {
+      "singular": "snapshotpolicy",
+      "plural": "snapshotpolicies"
+    },
+    "netapp.azure.m.upbound.io/Volume": {
+      "singular": "volume",
+      "plural": "volumes"
+    },
+    "netapp.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "netapp.azure.upbound.io/Pool": {
+      "singular": "pool",
+      "plural": "pools"
+    },
+    "netapp.azure.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "netapp.azure.upbound.io/SnapshotPolicy": {
+      "singular": "snapshotpolicy",
+      "plural": "snapshotpolicies"
+    },
+    "netapp.azure.upbound.io/Volume": {
+      "singular": "volume",
+      "plural": "volumes"
+    },
+    "network.azure.m.upbound.io/ApplicationGateway": {
+      "singular": "applicationgateway",
+      "plural": "applicationgateways"
+    },
+    "network.azure.m.upbound.io/ApplicationSecurityGroup": {
+      "singular": "applicationsecuritygroup",
+      "plural": "applicationsecuritygroups"
+    },
+    "network.azure.m.upbound.io/BastionHost": {
+      "singular": "bastionhost",
+      "plural": "bastionhosts"
+    },
+    "network.azure.m.upbound.io/ConnectionMonitor": {
+      "singular": "connectionmonitor",
+      "plural": "connectionmonitors"
+    },
+    "network.azure.m.upbound.io/DDoSProtectionPlan": {
+      "singular": "ddosprotectionplan",
+      "plural": "ddosprotectionplans"
+    },
+    "network.azure.m.upbound.io/DNSAAAARecord": {
+      "singular": "dnsaaaarecord",
+      "plural": "dnsaaaarecords"
+    },
+    "network.azure.m.upbound.io/DNSARecord": {
+      "singular": "dnsarecord",
+      "plural": "dnsarecords"
+    },
+    "network.azure.m.upbound.io/DNSCAARecord": {
+      "singular": "dnscaarecord",
+      "plural": "dnscaarecords"
+    },
+    "network.azure.m.upbound.io/DNSCNAMERecord": {
+      "singular": "dnscnamerecord",
+      "plural": "dnscnamerecords"
+    },
+    "network.azure.m.upbound.io/DNSMXRecord": {
+      "singular": "dnsmxrecord",
+      "plural": "dnsmxrecords"
+    },
+    "network.azure.m.upbound.io/DNSNSRecord": {
+      "singular": "dnsnsrecord",
+      "plural": "dnsnsrecords"
+    },
+    "network.azure.m.upbound.io/DNSPTRRecord": {
+      "singular": "dnsptrrecord",
+      "plural": "dnsptrrecords"
+    },
+    "network.azure.m.upbound.io/DNSSRVRecord": {
+      "singular": "dnssrvrecord",
+      "plural": "dnssrvrecords"
+    },
+    "network.azure.m.upbound.io/DNSTXTRecord": {
+      "singular": "dnstxtrecord",
+      "plural": "dnstxtrecords"
+    },
+    "network.azure.m.upbound.io/DNSZone": {
+      "singular": "dnszone",
+      "plural": "dnszones"
+    },
+    "network.azure.m.upbound.io/ExpressRouteCircuit": {
+      "singular": "expressroutecircuit",
+      "plural": "expressroutecircuits"
+    },
+    "network.azure.m.upbound.io/ExpressRouteCircuitAuthorization": {
+      "singular": "expressroutecircuitauthorization",
+      "plural": "expressroutecircuitauthorizations"
+    },
+    "network.azure.m.upbound.io/ExpressRouteCircuitConnection": {
+      "singular": "expressroutecircuitconnection",
+      "plural": "expressroutecircuitconnections"
+    },
+    "network.azure.m.upbound.io/ExpressRouteCircuitPeering": {
+      "singular": "expressroutecircuitpeering",
+      "plural": "expressroutecircuitpeerings"
+    },
+    "network.azure.m.upbound.io/ExpressRouteConnection": {
+      "singular": "expressrouteconnection",
+      "plural": "expressrouteconnections"
+    },
+    "network.azure.m.upbound.io/ExpressRouteGateway": {
+      "singular": "expressroutegateway",
+      "plural": "expressroutegateways"
+    },
+    "network.azure.m.upbound.io/ExpressRoutePort": {
+      "singular": "expressrouteport",
+      "plural": "expressrouteports"
+    },
+    "network.azure.m.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "network.azure.m.upbound.io/FirewallApplicationRuleCollection": {
+      "singular": "firewallapplicationrulecollection",
+      "plural": "firewallapplicationrulecollections"
+    },
+    "network.azure.m.upbound.io/FirewallNATRuleCollection": {
+      "singular": "firewallnatrulecollection",
+      "plural": "firewallnatrulecollections"
+    },
+    "network.azure.m.upbound.io/FirewallNetworkRuleCollection": {
+      "singular": "firewallnetworkrulecollection",
+      "plural": "firewallnetworkrulecollections"
+    },
+    "network.azure.m.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "network.azure.m.upbound.io/FirewallPolicyRuleCollectionGroup": {
+      "singular": "firewallpolicyrulecollectiongroup",
+      "plural": "firewallpolicyrulecollectiongroups"
+    },
+    "network.azure.m.upbound.io/FrontDoor": {
+      "singular": "frontdoor",
+      "plural": "frontdoors"
+    },
+    "network.azure.m.upbound.io/FrontdoorCustomHTTPSConfiguration": {
+      "singular": "frontdoorcustomhttpsconfiguration",
+      "plural": "frontdoorcustomhttpsconfigurations"
+    },
+    "network.azure.m.upbound.io/FrontdoorFirewallPolicy": {
+      "singular": "frontdoorfirewallpolicy",
+      "plural": "frontdoorfirewallpolicies"
+    },
+    "network.azure.m.upbound.io/FrontdoorRulesEngine": {
+      "singular": "frontdoorrulesengine",
+      "plural": "frontdoorrulesengines"
+    },
+    "network.azure.m.upbound.io/IPGroup": {
+      "singular": "ipgroup",
+      "plural": "ipgroups"
+    },
+    "network.azure.m.upbound.io/LoadBalancer": {
+      "singular": "loadbalancer",
+      "plural": "loadbalancers"
+    },
+    "network.azure.m.upbound.io/LoadBalancerBackendAddressPool": {
+      "singular": "loadbalancerbackendaddresspool",
+      "plural": "loadbalancerbackendaddresspools"
+    },
+    "network.azure.m.upbound.io/LoadBalancerBackendAddressPoolAddress": {
+      "singular": "loadbalancerbackendaddresspooladdress",
+      "plural": "loadbalancerbackendaddresspooladdresses"
+    },
+    "network.azure.m.upbound.io/LoadBalancerNatPool": {
+      "singular": "loadbalancernatpool",
+      "plural": "loadbalancernatpools"
+    },
+    "network.azure.m.upbound.io/LoadBalancerNatRule": {
+      "singular": "loadbalancernatrule",
+      "plural": "loadbalancernatrules"
+    },
+    "network.azure.m.upbound.io/LoadBalancerOutboundRule": {
+      "singular": "loadbalanceroutboundrule",
+      "plural": "loadbalanceroutboundrules"
+    },
+    "network.azure.m.upbound.io/LoadBalancerProbe": {
+      "singular": "loadbalancerprobe",
+      "plural": "loadbalancerprobes"
+    },
+    "network.azure.m.upbound.io/LoadBalancerRule": {
+      "singular": "loadbalancerrule",
+      "plural": "loadbalancerrules"
+    },
+    "network.azure.m.upbound.io/LocalNetworkGateway": {
+      "singular": "localnetworkgateway",
+      "plural": "localnetworkgateways"
+    },
+    "network.azure.m.upbound.io/Manager": {
+      "singular": "manager",
+      "plural": "managers"
+    },
+    "network.azure.m.upbound.io/ManagerIpamPool": {
+      "singular": "manageripampool",
+      "plural": "manageripampools"
+    },
+    "network.azure.m.upbound.io/ManagerManagementGroupConnection": {
+      "singular": "managermanagementgroupconnection",
+      "plural": "managermanagementgroupconnections"
+    },
+    "network.azure.m.upbound.io/ManagerNetworkGroup": {
+      "singular": "managernetworkgroup",
+      "plural": "managernetworkgroups"
+    },
+    "network.azure.m.upbound.io/ManagerRoutingConfiguration": {
+      "singular": "managerroutingconfiguration",
+      "plural": "managerroutingconfigurations"
+    },
+    "network.azure.m.upbound.io/ManagerStaticMember": {
+      "singular": "managerstaticmember",
+      "plural": "managerstaticmembers"
+    },
+    "network.azure.m.upbound.io/ManagerSubscriptionConnection": {
+      "singular": "managersubscriptionconnection",
+      "plural": "managersubscriptionconnections"
+    },
+    "network.azure.m.upbound.io/ManagerVerifierWorkspace": {
+      "singular": "managerverifierworkspace",
+      "plural": "managerverifierworkspaces"
+    },
+    "network.azure.m.upbound.io/NATGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "network.azure.m.upbound.io/NATGatewayPublicIPAssociation": {
+      "singular": "natgatewaypublicipassociation",
+      "plural": "natgatewaypublicipassociations"
+    },
+    "network.azure.m.upbound.io/NATGatewayPublicIPPrefixAssociation": {
+      "singular": "natgatewaypublicipprefixassociation",
+      "plural": "natgatewaypublicipprefixassociations"
+    },
+    "network.azure.m.upbound.io/NetworkInterface": {
+      "singular": "networkinterface",
+      "plural": "networkinterfaces"
+    },
+    "network.azure.m.upbound.io/NetworkInterfaceApplicationSecurityGroupAssociation": {
+      "singular": "networkinterfaceapplicationsecuritygroupassociation",
+      "plural": "networkinterfaceapplicationsecuritygroupassociations"
+    },
+    "network.azure.m.upbound.io/NetworkInterfaceBackendAddressPoolAssociation": {
+      "singular": "networkinterfacebackendaddresspoolassociation",
+      "plural": "networkinterfacebackendaddresspoolassociations"
+    },
+    "network.azure.m.upbound.io/NetworkInterfaceNatRuleAssociation": {
+      "singular": "networkinterfacenatruleassociation",
+      "plural": "networkinterfacenatruleassociations"
+    },
+    "network.azure.m.upbound.io/NetworkInterfaceSecurityGroupAssociation": {
+      "singular": "networkinterfacesecuritygroupassociation",
+      "plural": "networkinterfacesecuritygroupassociations"
+    },
+    "network.azure.m.upbound.io/PacketCapture": {
+      "singular": "packetcapture",
+      "plural": "packetcaptures"
+    },
+    "network.azure.m.upbound.io/PointToSiteVPNGateway": {
+      "singular": "pointtositevpngateway",
+      "plural": "pointtositevpngateways"
+    },
+    "network.azure.m.upbound.io/PrivateDNSAAAARecord": {
+      "singular": "privatednsaaaarecord",
+      "plural": "privatednsaaaarecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSARecord": {
+      "singular": "privatednsarecord",
+      "plural": "privatednsarecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSCNAMERecord": {
+      "singular": "privatednscnamerecord",
+      "plural": "privatednscnamerecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSMXRecord": {
+      "singular": "privatednsmxrecord",
+      "plural": "privatednsmxrecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSPTRRecord": {
+      "singular": "privatednsptrrecord",
+      "plural": "privatednsptrrecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolver": {
+      "singular": "privatednsresolver",
+      "plural": "privatednsresolvers"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolverDNSForwardingRuleset": {
+      "singular": "privatednsresolverdnsforwardingruleset",
+      "plural": "privatednsresolverdnsforwardingrulesets"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolverForwardingRule": {
+      "singular": "privatednsresolverforwardingrule",
+      "plural": "privatednsresolverforwardingrules"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolverInboundEndpoint": {
+      "singular": "privatednsresolverinboundendpoint",
+      "plural": "privatednsresolverinboundendpoints"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolverOutboundEndpoint": {
+      "singular": "privatednsresolveroutboundendpoint",
+      "plural": "privatednsresolveroutboundendpoints"
+    },
+    "network.azure.m.upbound.io/PrivateDNSResolverVirtualNetworkLink": {
+      "singular": "privatednsresolvervirtualnetworklink",
+      "plural": "privatednsresolvervirtualnetworklinks"
+    },
+    "network.azure.m.upbound.io/PrivateDNSSRVRecord": {
+      "singular": "privatednssrvrecord",
+      "plural": "privatednssrvrecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSTXTRecord": {
+      "singular": "privatednstxtrecord",
+      "plural": "privatednstxtrecords"
+    },
+    "network.azure.m.upbound.io/PrivateDNSZone": {
+      "singular": "privatednszone",
+      "plural": "privatednszones"
+    },
+    "network.azure.m.upbound.io/PrivateDNSZoneVirtualNetworkLink": {
+      "singular": "privatednszonevirtualnetworklink",
+      "plural": "privatednszonevirtualnetworklinks"
+    },
+    "network.azure.m.upbound.io/PrivateEndpoint": {
+      "singular": "privateendpoint",
+      "plural": "privateendpoints"
+    },
+    "network.azure.m.upbound.io/PrivateEndpointApplicationSecurityGroupAssociation": {
+      "singular": "privateendpointapplicationsecuritygroupassociation",
+      "plural": "privateendpointapplicationsecuritygroupassociations"
+    },
+    "network.azure.m.upbound.io/PrivateLinkService": {
+      "singular": "privatelinkservice",
+      "plural": "privatelinkservices"
+    },
+    "network.azure.m.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "network.azure.m.upbound.io/PublicIP": {
+      "singular": "publicip",
+      "plural": "publicips"
+    },
+    "network.azure.m.upbound.io/PublicIPPrefix": {
+      "singular": "publicipprefix",
+      "plural": "publicipprefixes"
+    },
+    "network.azure.m.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "network.azure.m.upbound.io/RouteFilter": {
+      "singular": "routefilter",
+      "plural": "routefilters"
+    },
+    "network.azure.m.upbound.io/RouteMap": {
+      "singular": "routemap",
+      "plural": "routemaps"
+    },
+    "network.azure.m.upbound.io/RouteServer": {
+      "singular": "routeserver",
+      "plural": "routeservers"
+    },
+    "network.azure.m.upbound.io/RouteServerBGPConnection": {
+      "singular": "routeserverbgpconnection",
+      "plural": "routeserverbgpconnections"
+    },
+    "network.azure.m.upbound.io/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "network.azure.m.upbound.io/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "network.azure.m.upbound.io/SecurityRule": {
+      "singular": "securityrule",
+      "plural": "securityrules"
+    },
+    "network.azure.m.upbound.io/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets"
+    },
+    "network.azure.m.upbound.io/SubnetNATGatewayAssociation": {
+      "singular": "subnetnatgatewayassociation",
+      "plural": "subnetnatgatewayassociations"
+    },
+    "network.azure.m.upbound.io/SubnetNetworkSecurityGroupAssociation": {
+      "singular": "subnetnetworksecuritygroupassociation",
+      "plural": "subnetnetworksecuritygroupassociations"
+    },
+    "network.azure.m.upbound.io/SubnetRouteTableAssociation": {
+      "singular": "subnetroutetableassociation",
+      "plural": "subnetroutetableassociations"
+    },
+    "network.azure.m.upbound.io/SubnetServiceEndpointStoragePolicy": {
+      "singular": "subnetserviceendpointstoragepolicy",
+      "plural": "subnetserviceendpointstoragepolicies"
+    },
+    "network.azure.m.upbound.io/TrafficManagerAzureEndpoint": {
+      "singular": "trafficmanagerazureendpoint",
+      "plural": "trafficmanagerazureendpoints"
+    },
+    "network.azure.m.upbound.io/TrafficManagerExternalEndpoint": {
+      "singular": "trafficmanagerexternalendpoint",
+      "plural": "trafficmanagerexternalendpoints"
+    },
+    "network.azure.m.upbound.io/TrafficManagerNestedEndpoint": {
+      "singular": "trafficmanagernestedendpoint",
+      "plural": "trafficmanagernestedendpoints"
+    },
+    "network.azure.m.upbound.io/TrafficManagerProfile": {
+      "singular": "trafficmanagerprofile",
+      "plural": "trafficmanagerprofiles"
+    },
+    "network.azure.m.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "network.azure.m.upbound.io/VPNGatewayConnection": {
+      "singular": "vpngatewayconnection",
+      "plural": "vpngatewayconnections"
+    },
+    "network.azure.m.upbound.io/VPNServerConfiguration": {
+      "singular": "vpnserverconfiguration",
+      "plural": "vpnserverconfigurations"
+    },
+    "network.azure.m.upbound.io/VPNServerConfigurationPolicyGroup": {
+      "singular": "vpnserverconfigurationpolicygroup",
+      "plural": "vpnserverconfigurationpolicygroups"
+    },
+    "network.azure.m.upbound.io/VPNSite": {
+      "singular": "vpnsite",
+      "plural": "vpnsites"
+    },
+    "network.azure.m.upbound.io/VirtualHub": {
+      "singular": "virtualhub",
+      "plural": "virtualhubs"
+    },
+    "network.azure.m.upbound.io/VirtualHubConnection": {
+      "singular": "virtualhubconnection",
+      "plural": "virtualhubconnections"
+    },
+    "network.azure.m.upbound.io/VirtualHubIP": {
+      "singular": "virtualhubip",
+      "plural": "virtualhubips"
+    },
+    "network.azure.m.upbound.io/VirtualHubRouteTable": {
+      "singular": "virtualhubroutetable",
+      "plural": "virtualhubroutetables"
+    },
+    "network.azure.m.upbound.io/VirtualHubRouteTableRoute": {
+      "singular": "virtualhubroutetableroute",
+      "plural": "virtualhubroutetableroutes"
+    },
+    "network.azure.m.upbound.io/VirtualHubRoutingIntent": {
+      "singular": "virtualhubroutingintent",
+      "plural": "virtualhubroutingintents"
+    },
+    "network.azure.m.upbound.io/VirtualHubSecurityPartnerProvider": {
+      "singular": "virtualhubsecuritypartnerprovider",
+      "plural": "virtualhubsecuritypartnerproviders"
+    },
+    "network.azure.m.upbound.io/VirtualNetwork": {
+      "singular": "virtualnetwork",
+      "plural": "virtualnetworks"
+    },
+    "network.azure.m.upbound.io/VirtualNetworkDNSServers": {
+      "singular": "virtualnetworkdnsservers",
+      "plural": "virtualnetworkdnsservers"
+    },
+    "network.azure.m.upbound.io/VirtualNetworkGateway": {
+      "singular": "virtualnetworkgateway",
+      "plural": "virtualnetworkgateways"
+    },
+    "network.azure.m.upbound.io/VirtualNetworkGatewayConnection": {
+      "singular": "virtualnetworkgatewayconnection",
+      "plural": "virtualnetworkgatewayconnections"
+    },
+    "network.azure.m.upbound.io/VirtualNetworkPeering": {
+      "singular": "virtualnetworkpeering",
+      "plural": "virtualnetworkpeerings"
+    },
+    "network.azure.m.upbound.io/VirtualWAN": {
+      "singular": "virtualwan",
+      "plural": "virtualwans"
+    },
+    "network.azure.m.upbound.io/Watcher": {
+      "singular": "watcher",
+      "plural": "watchers"
+    },
+    "network.azure.m.upbound.io/WatcherFlowLog": {
+      "singular": "watcherflowlog",
+      "plural": "watcherflowlogs"
+    },
+    "network.azure.m.upbound.io/WebApplicationFirewallPolicy": {
+      "singular": "webapplicationfirewallpolicy",
+      "plural": "webapplicationfirewallpolicies"
+    },
+    "network.azure.upbound.io/ApplicationGateway": {
+      "singular": "applicationgateway",
+      "plural": "applicationgateways"
+    },
+    "network.azure.upbound.io/ApplicationSecurityGroup": {
+      "singular": "applicationsecuritygroup",
+      "plural": "applicationsecuritygroups"
+    },
+    "network.azure.upbound.io/BastionHost": {
+      "singular": "bastionhost",
+      "plural": "bastionhosts"
+    },
+    "network.azure.upbound.io/ConnectionMonitor": {
+      "singular": "connectionmonitor",
+      "plural": "connectionmonitors"
+    },
+    "network.azure.upbound.io/DDoSProtectionPlan": {
+      "singular": "ddosprotectionplan",
+      "plural": "ddosprotectionplans"
+    },
+    "network.azure.upbound.io/DNSAAAARecord": {
+      "singular": "dnsaaaarecord",
+      "plural": "dnsaaaarecords"
+    },
+    "network.azure.upbound.io/DNSARecord": {
+      "singular": "dnsarecord",
+      "plural": "dnsarecords"
+    },
+    "network.azure.upbound.io/DNSCAARecord": {
+      "singular": "dnscaarecord",
+      "plural": "dnscaarecords"
+    },
+    "network.azure.upbound.io/DNSCNAMERecord": {
+      "singular": "dnscnamerecord",
+      "plural": "dnscnamerecords"
+    },
+    "network.azure.upbound.io/DNSMXRecord": {
+      "singular": "dnsmxrecord",
+      "plural": "dnsmxrecords"
+    },
+    "network.azure.upbound.io/DNSNSRecord": {
+      "singular": "dnsnsrecord",
+      "plural": "dnsnsrecords"
+    },
+    "network.azure.upbound.io/DNSPTRRecord": {
+      "singular": "dnsptrrecord",
+      "plural": "dnsptrrecords"
+    },
+    "network.azure.upbound.io/DNSSRVRecord": {
+      "singular": "dnssrvrecord",
+      "plural": "dnssrvrecords"
+    },
+    "network.azure.upbound.io/DNSTXTRecord": {
+      "singular": "dnstxtrecord",
+      "plural": "dnstxtrecords"
+    },
+    "network.azure.upbound.io/DNSZone": {
+      "singular": "dnszone",
+      "plural": "dnszones"
+    },
+    "network.azure.upbound.io/ExpressRouteCircuit": {
+      "singular": "expressroutecircuit",
+      "plural": "expressroutecircuits"
+    },
+    "network.azure.upbound.io/ExpressRouteCircuitAuthorization": {
+      "singular": "expressroutecircuitauthorization",
+      "plural": "expressroutecircuitauthorizations"
+    },
+    "network.azure.upbound.io/ExpressRouteCircuitConnection": {
+      "singular": "expressroutecircuitconnection",
+      "plural": "expressroutecircuitconnections"
+    },
+    "network.azure.upbound.io/ExpressRouteCircuitPeering": {
+      "singular": "expressroutecircuitpeering",
+      "plural": "expressroutecircuitpeerings"
+    },
+    "network.azure.upbound.io/ExpressRouteConnection": {
+      "singular": "expressrouteconnection",
+      "plural": "expressrouteconnections"
+    },
+    "network.azure.upbound.io/ExpressRouteGateway": {
+      "singular": "expressroutegateway",
+      "plural": "expressroutegateways"
+    },
+    "network.azure.upbound.io/ExpressRoutePort": {
+      "singular": "expressrouteport",
+      "plural": "expressrouteports"
+    },
+    "network.azure.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "network.azure.upbound.io/FirewallApplicationRuleCollection": {
+      "singular": "firewallapplicationrulecollection",
+      "plural": "firewallapplicationrulecollections"
+    },
+    "network.azure.upbound.io/FirewallNATRuleCollection": {
+      "singular": "firewallnatrulecollection",
+      "plural": "firewallnatrulecollections"
+    },
+    "network.azure.upbound.io/FirewallNetworkRuleCollection": {
+      "singular": "firewallnetworkrulecollection",
+      "plural": "firewallnetworkrulecollections"
+    },
+    "network.azure.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "network.azure.upbound.io/FirewallPolicyRuleCollectionGroup": {
+      "singular": "firewallpolicyrulecollectiongroup",
+      "plural": "firewallpolicyrulecollectiongroups"
+    },
+    "network.azure.upbound.io/FrontDoor": {
+      "singular": "frontdoor",
+      "plural": "frontdoors"
+    },
+    "network.azure.upbound.io/FrontdoorCustomHTTPSConfiguration": {
+      "singular": "frontdoorcustomhttpsconfiguration",
+      "plural": "frontdoorcustomhttpsconfigurations"
+    },
+    "network.azure.upbound.io/FrontdoorFirewallPolicy": {
+      "singular": "frontdoorfirewallpolicy",
+      "plural": "frontdoorfirewallpolicies"
+    },
+    "network.azure.upbound.io/FrontdoorRulesEngine": {
+      "singular": "frontdoorrulesengine",
+      "plural": "frontdoorrulesengines"
+    },
+    "network.azure.upbound.io/IPGroup": {
+      "singular": "ipgroup",
+      "plural": "ipgroups"
+    },
+    "network.azure.upbound.io/LoadBalancer": {
+      "singular": "loadbalancer",
+      "plural": "loadbalancers"
+    },
+    "network.azure.upbound.io/LoadBalancerBackendAddressPool": {
+      "singular": "loadbalancerbackendaddresspool",
+      "plural": "loadbalancerbackendaddresspools"
+    },
+    "network.azure.upbound.io/LoadBalancerBackendAddressPoolAddress": {
+      "singular": "loadbalancerbackendaddresspooladdress",
+      "plural": "loadbalancerbackendaddresspooladdresses"
+    },
+    "network.azure.upbound.io/LoadBalancerNatPool": {
+      "singular": "loadbalancernatpool",
+      "plural": "loadbalancernatpools"
+    },
+    "network.azure.upbound.io/LoadBalancerNatRule": {
+      "singular": "loadbalancernatrule",
+      "plural": "loadbalancernatrules"
+    },
+    "network.azure.upbound.io/LoadBalancerOutboundRule": {
+      "singular": "loadbalanceroutboundrule",
+      "plural": "loadbalanceroutboundrules"
+    },
+    "network.azure.upbound.io/LoadBalancerProbe": {
+      "singular": "loadbalancerprobe",
+      "plural": "loadbalancerprobes"
+    },
+    "network.azure.upbound.io/LoadBalancerRule": {
+      "singular": "loadbalancerrule",
+      "plural": "loadbalancerrules"
+    },
+    "network.azure.upbound.io/LocalNetworkGateway": {
+      "singular": "localnetworkgateway",
+      "plural": "localnetworkgateways"
+    },
+    "network.azure.upbound.io/Manager": {
+      "singular": "manager",
+      "plural": "managers"
+    },
+    "network.azure.upbound.io/ManagerIpamPool": {
+      "singular": "manageripampool",
+      "plural": "manageripampools"
+    },
+    "network.azure.upbound.io/ManagerManagementGroupConnection": {
+      "singular": "managermanagementgroupconnection",
+      "plural": "managermanagementgroupconnections"
+    },
+    "network.azure.upbound.io/ManagerNetworkGroup": {
+      "singular": "managernetworkgroup",
+      "plural": "managernetworkgroups"
+    },
+    "network.azure.upbound.io/ManagerRoutingConfiguration": {
+      "singular": "managerroutingconfiguration",
+      "plural": "managerroutingconfigurations"
+    },
+    "network.azure.upbound.io/ManagerStaticMember": {
+      "singular": "managerstaticmember",
+      "plural": "managerstaticmembers"
+    },
+    "network.azure.upbound.io/ManagerSubscriptionConnection": {
+      "singular": "managersubscriptionconnection",
+      "plural": "managersubscriptionconnections"
+    },
+    "network.azure.upbound.io/ManagerVerifierWorkspace": {
+      "singular": "managerverifierworkspace",
+      "plural": "managerverifierworkspaces"
+    },
+    "network.azure.upbound.io/NATGateway": {
+      "singular": "natgateway",
+      "plural": "natgateways"
+    },
+    "network.azure.upbound.io/NATGatewayPublicIPAssociation": {
+      "singular": "natgatewaypublicipassociation",
+      "plural": "natgatewaypublicipassociations"
+    },
+    "network.azure.upbound.io/NATGatewayPublicIPPrefixAssociation": {
+      "singular": "natgatewaypublicipprefixassociation",
+      "plural": "natgatewaypublicipprefixassociations"
+    },
+    "network.azure.upbound.io/NetworkInterface": {
+      "singular": "networkinterface",
+      "plural": "networkinterfaces"
+    },
+    "network.azure.upbound.io/NetworkInterfaceApplicationSecurityGroupAssociation": {
+      "singular": "networkinterfaceapplicationsecuritygroupassociation",
+      "plural": "networkinterfaceapplicationsecuritygroupassociations"
+    },
+    "network.azure.upbound.io/NetworkInterfaceBackendAddressPoolAssociation": {
+      "singular": "networkinterfacebackendaddresspoolassociation",
+      "plural": "networkinterfacebackendaddresspoolassociations"
+    },
+    "network.azure.upbound.io/NetworkInterfaceNatRuleAssociation": {
+      "singular": "networkinterfacenatruleassociation",
+      "plural": "networkinterfacenatruleassociations"
+    },
+    "network.azure.upbound.io/NetworkInterfaceSecurityGroupAssociation": {
+      "singular": "networkinterfacesecuritygroupassociation",
+      "plural": "networkinterfacesecuritygroupassociations"
+    },
+    "network.azure.upbound.io/PacketCapture": {
+      "singular": "packetcapture",
+      "plural": "packetcaptures"
+    },
+    "network.azure.upbound.io/PointToSiteVPNGateway": {
+      "singular": "pointtositevpngateway",
+      "plural": "pointtositevpngateways"
+    },
+    "network.azure.upbound.io/PrivateDNSAAAARecord": {
+      "singular": "privatednsaaaarecord",
+      "plural": "privatednsaaaarecords"
+    },
+    "network.azure.upbound.io/PrivateDNSARecord": {
+      "singular": "privatednsarecord",
+      "plural": "privatednsarecords"
+    },
+    "network.azure.upbound.io/PrivateDNSCNAMERecord": {
+      "singular": "privatednscnamerecord",
+      "plural": "privatednscnamerecords"
+    },
+    "network.azure.upbound.io/PrivateDNSMXRecord": {
+      "singular": "privatednsmxrecord",
+      "plural": "privatednsmxrecords"
+    },
+    "network.azure.upbound.io/PrivateDNSPTRRecord": {
+      "singular": "privatednsptrrecord",
+      "plural": "privatednsptrrecords"
+    },
+    "network.azure.upbound.io/PrivateDNSResolver": {
+      "singular": "privatednsresolver",
+      "plural": "privatednsresolvers"
+    },
+    "network.azure.upbound.io/PrivateDNSResolverDNSForwardingRuleset": {
+      "singular": "privatednsresolverdnsforwardingruleset",
+      "plural": "privatednsresolverdnsforwardingrulesets"
+    },
+    "network.azure.upbound.io/PrivateDNSResolverForwardingRule": {
+      "singular": "privatednsresolverforwardingrule",
+      "plural": "privatednsresolverforwardingrules"
+    },
+    "network.azure.upbound.io/PrivateDNSResolverInboundEndpoint": {
+      "singular": "privatednsresolverinboundendpoint",
+      "plural": "privatednsresolverinboundendpoints"
+    },
+    "network.azure.upbound.io/PrivateDNSResolverOutboundEndpoint": {
+      "singular": "privatednsresolveroutboundendpoint",
+      "plural": "privatednsresolveroutboundendpoints"
+    },
+    "network.azure.upbound.io/PrivateDNSResolverVirtualNetworkLink": {
+      "singular": "privatednsresolvervirtualnetworklink",
+      "plural": "privatednsresolvervirtualnetworklinks"
+    },
+    "network.azure.upbound.io/PrivateDNSSRVRecord": {
+      "singular": "privatednssrvrecord",
+      "plural": "privatednssrvrecords"
+    },
+    "network.azure.upbound.io/PrivateDNSTXTRecord": {
+      "singular": "privatednstxtrecord",
+      "plural": "privatednstxtrecords"
+    },
+    "network.azure.upbound.io/PrivateDNSZone": {
+      "singular": "privatednszone",
+      "plural": "privatednszones"
+    },
+    "network.azure.upbound.io/PrivateDNSZoneVirtualNetworkLink": {
+      "singular": "privatednszonevirtualnetworklink",
+      "plural": "privatednszonevirtualnetworklinks"
+    },
+    "network.azure.upbound.io/PrivateEndpoint": {
+      "singular": "privateendpoint",
+      "plural": "privateendpoints"
+    },
+    "network.azure.upbound.io/PrivateEndpointApplicationSecurityGroupAssociation": {
+      "singular": "privateendpointapplicationsecuritygroupassociation",
+      "plural": "privateendpointapplicationsecuritygroupassociations"
+    },
+    "network.azure.upbound.io/PrivateLinkService": {
+      "singular": "privatelinkservice",
+      "plural": "privatelinkservices"
+    },
+    "network.azure.upbound.io/Profile": {
+      "singular": "profile",
+      "plural": "profiles"
+    },
+    "network.azure.upbound.io/PublicIP": {
+      "singular": "publicip",
+      "plural": "publicips"
+    },
+    "network.azure.upbound.io/PublicIPPrefix": {
+      "singular": "publicipprefix",
+      "plural": "publicipprefixes"
+    },
+    "network.azure.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "network.azure.upbound.io/RouteFilter": {
+      "singular": "routefilter",
+      "plural": "routefilters"
+    },
+    "network.azure.upbound.io/RouteMap": {
+      "singular": "routemap",
+      "plural": "routemaps"
+    },
+    "network.azure.upbound.io/RouteServer": {
+      "singular": "routeserver",
+      "plural": "routeservers"
+    },
+    "network.azure.upbound.io/RouteServerBGPConnection": {
+      "singular": "routeserverbgpconnection",
+      "plural": "routeserverbgpconnections"
+    },
+    "network.azure.upbound.io/RouteTable": {
+      "singular": "routetable",
+      "plural": "routetables"
+    },
+    "network.azure.upbound.io/SecurityGroup": {
+      "singular": "securitygroup",
+      "plural": "securitygroups"
+    },
+    "network.azure.upbound.io/SecurityRule": {
+      "singular": "securityrule",
+      "plural": "securityrules"
+    },
+    "network.azure.upbound.io/Subnet": {
+      "singular": "subnet",
+      "plural": "subnets"
+    },
+    "network.azure.upbound.io/SubnetNATGatewayAssociation": {
+      "singular": "subnetnatgatewayassociation",
+      "plural": "subnetnatgatewayassociations"
+    },
+    "network.azure.upbound.io/SubnetNetworkSecurityGroupAssociation": {
+      "singular": "subnetnetworksecuritygroupassociation",
+      "plural": "subnetnetworksecuritygroupassociations"
+    },
+    "network.azure.upbound.io/SubnetRouteTableAssociation": {
+      "singular": "subnetroutetableassociation",
+      "plural": "subnetroutetableassociations"
+    },
+    "network.azure.upbound.io/SubnetServiceEndpointStoragePolicy": {
+      "singular": "subnetserviceendpointstoragepolicy",
+      "plural": "subnetserviceendpointstoragepolicies"
+    },
+    "network.azure.upbound.io/TrafficManagerAzureEndpoint": {
+      "singular": "trafficmanagerazureendpoint",
+      "plural": "trafficmanagerazureendpoints"
+    },
+    "network.azure.upbound.io/TrafficManagerExternalEndpoint": {
+      "singular": "trafficmanagerexternalendpoint",
+      "plural": "trafficmanagerexternalendpoints"
+    },
+    "network.azure.upbound.io/TrafficManagerNestedEndpoint": {
+      "singular": "trafficmanagernestedendpoint",
+      "plural": "trafficmanagernestedendpoints"
+    },
+    "network.azure.upbound.io/TrafficManagerProfile": {
+      "singular": "trafficmanagerprofile",
+      "plural": "trafficmanagerprofiles"
+    },
+    "network.azure.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "network.azure.upbound.io/VPNGatewayConnection": {
+      "singular": "vpngatewayconnection",
+      "plural": "vpngatewayconnections"
+    },
+    "network.azure.upbound.io/VPNServerConfiguration": {
+      "singular": "vpnserverconfiguration",
+      "plural": "vpnserverconfigurations"
+    },
+    "network.azure.upbound.io/VPNServerConfigurationPolicyGroup": {
+      "singular": "vpnserverconfigurationpolicygroup",
+      "plural": "vpnserverconfigurationpolicygroups"
+    },
+    "network.azure.upbound.io/VPNSite": {
+      "singular": "vpnsite",
+      "plural": "vpnsites"
+    },
+    "network.azure.upbound.io/VirtualHub": {
+      "singular": "virtualhub",
+      "plural": "virtualhubs"
+    },
+    "network.azure.upbound.io/VirtualHubConnection": {
+      "singular": "virtualhubconnection",
+      "plural": "virtualhubconnections"
+    },
+    "network.azure.upbound.io/VirtualHubIP": {
+      "singular": "virtualhubip",
+      "plural": "virtualhubips"
+    },
+    "network.azure.upbound.io/VirtualHubRouteTable": {
+      "singular": "virtualhubroutetable",
+      "plural": "virtualhubroutetables"
+    },
+    "network.azure.upbound.io/VirtualHubRouteTableRoute": {
+      "singular": "virtualhubroutetableroute",
+      "plural": "virtualhubroutetableroutes"
+    },
+    "network.azure.upbound.io/VirtualHubRoutingIntent": {
+      "singular": "virtualhubroutingintent",
+      "plural": "virtualhubroutingintents"
+    },
+    "network.azure.upbound.io/VirtualHubSecurityPartnerProvider": {
+      "singular": "virtualhubsecuritypartnerprovider",
+      "plural": "virtualhubsecuritypartnerproviders"
+    },
+    "network.azure.upbound.io/VirtualNetwork": {
+      "singular": "virtualnetwork",
+      "plural": "virtualnetworks"
+    },
+    "network.azure.upbound.io/VirtualNetworkDNSServers": {
+      "singular": "virtualnetworkdnsservers",
+      "plural": "virtualnetworkdnsservers"
+    },
+    "network.azure.upbound.io/VirtualNetworkGateway": {
+      "singular": "virtualnetworkgateway",
+      "plural": "virtualnetworkgateways"
+    },
+    "network.azure.upbound.io/VirtualNetworkGatewayConnection": {
+      "singular": "virtualnetworkgatewayconnection",
+      "plural": "virtualnetworkgatewayconnections"
+    },
+    "network.azure.upbound.io/VirtualNetworkPeering": {
+      "singular": "virtualnetworkpeering",
+      "plural": "virtualnetworkpeerings"
+    },
+    "network.azure.upbound.io/VirtualWAN": {
+      "singular": "virtualwan",
+      "plural": "virtualwans"
+    },
+    "network.azure.upbound.io/Watcher": {
+      "singular": "watcher",
+      "plural": "watchers"
+    },
+    "network.azure.upbound.io/WatcherFlowLog": {
+      "singular": "watcherflowlog",
+      "plural": "watcherflowlogs"
+    },
+    "network.azure.upbound.io/WebApplicationFirewallPolicy": {
+      "singular": "webapplicationfirewallpolicy",
+      "plural": "webapplicationfirewallpolicies"
+    },
+    "notificationhubs.azure.m.upbound.io/AuthorizationRule": {
+      "singular": "authorizationrule",
+      "plural": "authorizationrules"
+    },
+    "notificationhubs.azure.m.upbound.io/NotificationHub": {
+      "singular": "notificationhub",
+      "plural": "notificationhubs"
+    },
+    "notificationhubs.azure.m.upbound.io/NotificationHubNamespace": {
+      "singular": "notificationhubnamespace",
+      "plural": "notificationhubnamespaces"
+    },
+    "notificationhubs.azure.upbound.io/AuthorizationRule": {
+      "singular": "authorizationrule",
+      "plural": "authorizationrules"
+    },
+    "notificationhubs.azure.upbound.io/NotificationHub": {
+      "singular": "notificationhub",
+      "plural": "notificationhubs"
+    },
+    "notificationhubs.azure.upbound.io/NotificationHubNamespace": {
+      "singular": "notificationhubnamespace",
+      "plural": "notificationhubnamespaces"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsDataExportRule": {
+      "singular": "loganalyticsdataexportrule",
+      "plural": "loganalyticsdataexportrules"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsDataSourceWindowsEvent": {
+      "singular": "loganalyticsdatasourcewindowsevent",
+      "plural": "loganalyticsdatasourcewindowsevents"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsDataSourceWindowsPerformanceCounter": {
+      "singular": "loganalyticsdatasourcewindowsperformancecounter",
+      "plural": "loganalyticsdatasourcewindowsperformancecounters"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsLinkedService": {
+      "singular": "loganalyticslinkedservice",
+      "plural": "loganalyticslinkedservices"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsLinkedStorageAccount": {
+      "singular": "loganalyticslinkedstorageaccount",
+      "plural": "loganalyticslinkedstorageaccounts"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsQueryPack": {
+      "singular": "loganalyticsquerypack",
+      "plural": "loganalyticsquerypacks"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsQueryPackQuery": {
+      "singular": "loganalyticsquerypackquery",
+      "plural": "loganalyticsquerypackqueries"
+    },
+    "operationalinsights.azure.m.upbound.io/LogAnalyticsSavedSearch": {
+      "singular": "loganalyticssavedsearch",
+      "plural": "loganalyticssavedsearches"
+    },
+    "operationalinsights.azure.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsDataExportRule": {
+      "singular": "loganalyticsdataexportrule",
+      "plural": "loganalyticsdataexportrules"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsDataSourceWindowsEvent": {
+      "singular": "loganalyticsdatasourcewindowsevent",
+      "plural": "loganalyticsdatasourcewindowsevents"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsDataSourceWindowsPerformanceCounter": {
+      "singular": "loganalyticsdatasourcewindowsperformancecounter",
+      "plural": "loganalyticsdatasourcewindowsperformancecounters"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsLinkedService": {
+      "singular": "loganalyticslinkedservice",
+      "plural": "loganalyticslinkedservices"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsLinkedStorageAccount": {
+      "singular": "loganalyticslinkedstorageaccount",
+      "plural": "loganalyticslinkedstorageaccounts"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsQueryPack": {
+      "singular": "loganalyticsquerypack",
+      "plural": "loganalyticsquerypacks"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsQueryPackQuery": {
+      "singular": "loganalyticsquerypackquery",
+      "plural": "loganalyticsquerypackqueries"
+    },
+    "operationalinsights.azure.upbound.io/LogAnalyticsSavedSearch": {
+      "singular": "loganalyticssavedsearch",
+      "plural": "loganalyticssavedsearches"
+    },
+    "operationalinsights.azure.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "operationsmanagement.azure.m.upbound.io/LogAnalyticsSolution": {
+      "singular": "loganalyticssolution",
+      "plural": "loganalyticssolutions"
+    },
+    "operationsmanagement.azure.upbound.io/LogAnalyticsSolution": {
+      "singular": "loganalyticssolution",
+      "plural": "loganalyticssolutions"
+    },
+    "oracle.azure.m.upbound.io/AutonomousDatabase": {
+      "singular": "autonomousdatabase",
+      "plural": "autonomousdatabases"
+    },
+    "oracle.azure.m.upbound.io/AutonomousDatabaseBackup": {
+      "singular": "autonomousdatabasebackup",
+      "plural": "autonomousdatabasebackups"
+    },
+    "oracle.azure.m.upbound.io/AutonomousDatabaseCloneFromBackup": {
+      "singular": "autonomousdatabaseclonefrombackup",
+      "plural": "autonomousdatabaseclonefrombackups"
+    },
+    "oracle.azure.m.upbound.io/AutonomousDatabaseCloneFromDatabase": {
+      "singular": "autonomousdatabaseclonefromdatabase",
+      "plural": "autonomousdatabaseclonefromdatabases"
+    },
+    "oracle.azure.upbound.io/AutonomousDatabase": {
+      "singular": "autonomousdatabase",
+      "plural": "autonomousdatabases"
+    },
+    "oracle.azure.upbound.io/AutonomousDatabaseBackup": {
+      "singular": "autonomousdatabasebackup",
+      "plural": "autonomousdatabasebackups"
+    },
+    "oracle.azure.upbound.io/AutonomousDatabaseCloneFromBackup": {
+      "singular": "autonomousdatabaseclonefrombackup",
+      "plural": "autonomousdatabaseclonefrombackups"
+    },
+    "oracle.azure.upbound.io/AutonomousDatabaseCloneFromDatabase": {
+      "singular": "autonomousdatabaseclonefromdatabase",
+      "plural": "autonomousdatabaseclonefromdatabases"
+    },
+    "orbital.azure.m.upbound.io/ContactProfile": {
+      "singular": "contactprofile",
+      "plural": "contactprofiles"
+    },
+    "orbital.azure.m.upbound.io/Spacecraft": {
+      "singular": "spacecraft",
+      "plural": "spacecrafts"
+    },
+    "orbital.azure.upbound.io/ContactProfile": {
+      "singular": "contactprofile",
+      "plural": "contactprofiles"
+    },
+    "orbital.azure.upbound.io/Spacecraft": {
+      "singular": "spacecraft",
+      "plural": "spacecrafts"
+    },
+    "policyinsights.azure.m.upbound.io/ResourcePolicyRemediation": {
+      "singular": "resourcepolicyremediation",
+      "plural": "resourcepolicyremediations"
+    },
+    "policyinsights.azure.m.upbound.io/SubscriptionPolicyRemediation": {
+      "singular": "subscriptionpolicyremediation",
+      "plural": "subscriptionpolicyremediations"
+    },
+    "policyinsights.azure.upbound.io/ResourcePolicyRemediation": {
+      "singular": "resourcepolicyremediation",
+      "plural": "resourcepolicyremediations"
+    },
+    "policyinsights.azure.upbound.io/SubscriptionPolicyRemediation": {
+      "singular": "subscriptionpolicyremediation",
+      "plural": "subscriptionpolicyremediations"
+    },
+    "portal.azure.m.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "portal.azure.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "powerbidedicated.azure.m.upbound.io/PowerBIEmbedded": {
+      "singular": "powerbiembedded",
+      "plural": "powerbiembeddeds"
+    },
+    "powerbidedicated.azure.upbound.io/PowerBIEmbedded": {
+      "singular": "powerbiembedded",
+      "plural": "powerbiembeddeds"
+    },
+    "purview.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "purview.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupContainerStorageAccount": {
+      "singular": "backupcontainerstorageaccount",
+      "plural": "backupcontainerstorageaccounts"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupPolicyFileShare": {
+      "singular": "backuppolicyfileshare",
+      "plural": "backuppolicyfileshares"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupPolicyVM": {
+      "singular": "backuppolicyvm",
+      "plural": "backuppolicyvms"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupPolicyVMWorkload": {
+      "singular": "backuppolicyvmworkload",
+      "plural": "backuppolicyvmworkloads"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupProtectedFileShare": {
+      "singular": "backupprotectedfileshare",
+      "plural": "backupprotectedfileshares"
+    },
+    "recoveryservices.azure.m.upbound.io/BackupProtectedVM": {
+      "singular": "backupprotectedvm",
+      "plural": "backupprotectedvms"
+    },
+    "recoveryservices.azure.m.upbound.io/SiteRecoveryFabric": {
+      "singular": "siterecoveryfabric",
+      "plural": "siterecoveryfabrics"
+    },
+    "recoveryservices.azure.m.upbound.io/SiteRecoveryNetworkMapping": {
+      "singular": "siterecoverynetworkmapping",
+      "plural": "siterecoverynetworkmappings"
+    },
+    "recoveryservices.azure.m.upbound.io/SiteRecoveryProtectionContainer": {
+      "singular": "siterecoveryprotectioncontainer",
+      "plural": "siterecoveryprotectioncontainers"
+    },
+    "recoveryservices.azure.m.upbound.io/SiteRecoveryProtectionContainerMapping": {
+      "singular": "siterecoveryprotectioncontainermapping",
+      "plural": "siterecoveryprotectioncontainermappings"
+    },
+    "recoveryservices.azure.m.upbound.io/SiteRecoveryReplicationPolicy": {
+      "singular": "siterecoveryreplicationpolicy",
+      "plural": "siterecoveryreplicationpolicies"
+    },
+    "recoveryservices.azure.m.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "recoveryservices.azure.upbound.io/BackupContainerStorageAccount": {
+      "singular": "backupcontainerstorageaccount",
+      "plural": "backupcontainerstorageaccounts"
+    },
+    "recoveryservices.azure.upbound.io/BackupPolicyFileShare": {
+      "singular": "backuppolicyfileshare",
+      "plural": "backuppolicyfileshares"
+    },
+    "recoveryservices.azure.upbound.io/BackupPolicyVM": {
+      "singular": "backuppolicyvm",
+      "plural": "backuppolicyvms"
+    },
+    "recoveryservices.azure.upbound.io/BackupPolicyVMWorkload": {
+      "singular": "backuppolicyvmworkload",
+      "plural": "backuppolicyvmworkloads"
+    },
+    "recoveryservices.azure.upbound.io/BackupProtectedFileShare": {
+      "singular": "backupprotectedfileshare",
+      "plural": "backupprotectedfileshares"
+    },
+    "recoveryservices.azure.upbound.io/BackupProtectedVM": {
+      "singular": "backupprotectedvm",
+      "plural": "backupprotectedvms"
+    },
+    "recoveryservices.azure.upbound.io/SiteRecoveryFabric": {
+      "singular": "siterecoveryfabric",
+      "plural": "siterecoveryfabrics"
+    },
+    "recoveryservices.azure.upbound.io/SiteRecoveryNetworkMapping": {
+      "singular": "siterecoverynetworkmapping",
+      "plural": "siterecoverynetworkmappings"
+    },
+    "recoveryservices.azure.upbound.io/SiteRecoveryProtectionContainer": {
+      "singular": "siterecoveryprotectioncontainer",
+      "plural": "siterecoveryprotectioncontainers"
+    },
+    "recoveryservices.azure.upbound.io/SiteRecoveryProtectionContainerMapping": {
+      "singular": "siterecoveryprotectioncontainermapping",
+      "plural": "siterecoveryprotectioncontainermappings"
+    },
+    "recoveryservices.azure.upbound.io/SiteRecoveryReplicationPolicy": {
+      "singular": "siterecoveryreplicationpolicy",
+      "plural": "siterecoveryreplicationpolicies"
+    },
+    "recoveryservices.azure.upbound.io/Vault": {
+      "singular": "vault",
+      "plural": "vaults"
+    },
+    "relay.azure.m.upbound.io/EventRelayNamespace": {
+      "singular": "eventrelaynamespace",
+      "plural": "eventrelaynamespaces"
+    },
+    "relay.azure.m.upbound.io/HybridConnection": {
+      "singular": "hybridconnection",
+      "plural": "hybridconnections"
+    },
+    "relay.azure.m.upbound.io/HybridConnectionAuthorizationRule": {
+      "singular": "hybridconnectionauthorizationrule",
+      "plural": "hybridconnectionauthorizationrules"
+    },
+    "relay.azure.m.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "relay.azure.upbound.io/EventRelayNamespace": {
+      "singular": "eventrelaynamespace",
+      "plural": "eventrelaynamespaces"
+    },
+    "relay.azure.upbound.io/HybridConnection": {
+      "singular": "hybridconnection",
+      "plural": "hybridconnections"
+    },
+    "relay.azure.upbound.io/HybridConnectionAuthorizationRule": {
+      "singular": "hybridconnectionauthorizationrule",
+      "plural": "hybridconnectionauthorizationrules"
+    },
+    "relay.azure.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "resources.azure.m.upbound.io/ResourceDeploymentScriptAzureCli": {
+      "singular": "resourcedeploymentscriptazurecli",
+      "plural": "resourcedeploymentscriptazureclicli"
+    },
+    "resources.azure.m.upbound.io/ResourceDeploymentScriptAzurePowerShell": {
+      "singular": "resourcedeploymentscriptazurepowershell",
+      "plural": "resourcedeploymentscriptazurepowershells"
+    },
+    "resources.azure.m.upbound.io/ResourceGroupTemplateDeployment": {
+      "singular": "resourcegrouptemplatedeployment",
+      "plural": "resourcegrouptemplatedeployments"
+    },
+    "resources.azure.m.upbound.io/SubscriptionTemplateDeployment": {
+      "singular": "subscriptiontemplatedeployment",
+      "plural": "subscriptiontemplatedeployments"
+    },
+    "resources.azure.upbound.io/ResourceDeploymentScriptAzureCli": {
+      "singular": "resourcedeploymentscriptazurecli",
+      "plural": "resourcedeploymentscriptazureclicli"
+    },
+    "resources.azure.upbound.io/ResourceDeploymentScriptAzurePowerShell": {
+      "singular": "resourcedeploymentscriptazurepowershell",
+      "plural": "resourcedeploymentscriptazurepowershells"
+    },
+    "resources.azure.upbound.io/ResourceGroupTemplateDeployment": {
+      "singular": "resourcegrouptemplatedeployment",
+      "plural": "resourcegrouptemplatedeployments"
+    },
+    "resources.azure.upbound.io/SubscriptionTemplateDeployment": {
+      "singular": "subscriptiontemplatedeployment",
+      "plural": "subscriptiontemplatedeployments"
+    },
+    "search.azure.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "search.azure.m.upbound.io/SharedPrivateLinkService": {
+      "singular": "sharedprivatelinkservice",
+      "plural": "sharedprivatelinkservices"
+    },
+    "search.azure.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "search.azure.upbound.io/SharedPrivateLinkService": {
+      "singular": "sharedprivatelinkservice",
+      "plural": "sharedprivatelinkservices"
+    },
+    "security.azure.m.upbound.io/AdvancedThreatProtection": {
+      "singular": "advancedthreatprotection",
+      "plural": "advancedthreatprotections"
+    },
+    "security.azure.m.upbound.io/IOTSecurityDeviceGroup": {
+      "singular": "iotsecuritydevicegroup",
+      "plural": "iotsecuritydevicegroups"
+    },
+    "security.azure.m.upbound.io/IOTSecuritySolution": {
+      "singular": "iotsecuritysolution",
+      "plural": "iotsecuritysolutions"
+    },
+    "security.azure.m.upbound.io/SecurityCenterAssessment": {
+      "singular": "securitycenterassessment",
+      "plural": "securitycenterassessments"
+    },
+    "security.azure.m.upbound.io/SecurityCenterAssessmentPolicy": {
+      "singular": "securitycenterassessmentpolicy",
+      "plural": "securitycenterassessmentpolicies"
+    },
+    "security.azure.m.upbound.io/SecurityCenterAutoProvisioning": {
+      "singular": "securitycenterautoprovisioning",
+      "plural": "securitycenterautoprovisionings"
+    },
+    "security.azure.m.upbound.io/SecurityCenterContact": {
+      "singular": "securitycentercontact",
+      "plural": "securitycentercontacts"
+    },
+    "security.azure.m.upbound.io/SecurityCenterServerVulnerabilityAssessmentVirtualMachine": {
+      "singular": "securitycenterservervulnerabilityassessmentvirtualmachine",
+      "plural": "securitycenterservervulnerabilityassessmentvirtualmachines"
+    },
+    "security.azure.m.upbound.io/SecurityCenterSetting": {
+      "singular": "securitycentersetting",
+      "plural": "securitycentersettings"
+    },
+    "security.azure.m.upbound.io/SecurityCenterSubscriptionPricing": {
+      "singular": "securitycentersubscriptionpricing",
+      "plural": "securitycentersubscriptionpricings"
+    },
+    "security.azure.m.upbound.io/SecurityCenterWorkspace": {
+      "singular": "securitycenterworkspace",
+      "plural": "securitycenterworkspaces"
+    },
+    "security.azure.m.upbound.io/StorageDefender": {
+      "singular": "storagedefender",
+      "plural": "storagedefenders"
+    },
+    "security.azure.upbound.io/AdvancedThreatProtection": {
+      "singular": "advancedthreatprotection",
+      "plural": "advancedthreatprotections"
+    },
+    "security.azure.upbound.io/IOTSecurityDeviceGroup": {
+      "singular": "iotsecuritydevicegroup",
+      "plural": "iotsecuritydevicegroups"
+    },
+    "security.azure.upbound.io/IOTSecuritySolution": {
+      "singular": "iotsecuritysolution",
+      "plural": "iotsecuritysolutions"
+    },
+    "security.azure.upbound.io/SecurityCenterAssessment": {
+      "singular": "securitycenterassessment",
+      "plural": "securitycenterassessments"
+    },
+    "security.azure.upbound.io/SecurityCenterAssessmentPolicy": {
+      "singular": "securitycenterassessmentpolicy",
+      "plural": "securitycenterassessmentpolicies"
+    },
+    "security.azure.upbound.io/SecurityCenterAutoProvisioning": {
+      "singular": "securitycenterautoprovisioning",
+      "plural": "securitycenterautoprovisionings"
+    },
+    "security.azure.upbound.io/SecurityCenterContact": {
+      "singular": "securitycentercontact",
+      "plural": "securitycentercontacts"
+    },
+    "security.azure.upbound.io/SecurityCenterServerVulnerabilityAssessmentVirtualMachine": {
+      "singular": "securitycenterservervulnerabilityassessmentvirtualmachine",
+      "plural": "securitycenterservervulnerabilityassessmentvirtualmachines"
+    },
+    "security.azure.upbound.io/SecurityCenterSetting": {
+      "singular": "securitycentersetting",
+      "plural": "securitycentersettings"
+    },
+    "security.azure.upbound.io/SecurityCenterSubscriptionPricing": {
+      "singular": "securitycentersubscriptionpricing",
+      "plural": "securitycentersubscriptionpricings"
+    },
+    "security.azure.upbound.io/SecurityCenterWorkspace": {
+      "singular": "securitycenterworkspace",
+      "plural": "securitycenterworkspaces"
+    },
+    "security.azure.upbound.io/StorageDefender": {
+      "singular": "storagedefender",
+      "plural": "storagedefenders"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelAlertRuleFusion": {
+      "singular": "sentinelalertrulefusion",
+      "plural": "sentinelalertrulefusions"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelAlertRuleMSSecurityIncident": {
+      "singular": "sentinelalertrulemssecurityincident",
+      "plural": "sentinelalertrulemssecurityincidents"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelAlertRuleMachineLearningBehaviorAnalytics": {
+      "singular": "sentinelalertrulemachinelearningbehavioranalytics",
+      "plural": "sentinelalertrulemachinelearningbehavioranalytics"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelAutomationRule": {
+      "singular": "sentinelautomationrule",
+      "plural": "sentinelautomationrules"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelDataConnectorIOT": {
+      "singular": "sentineldataconnectoriot",
+      "plural": "sentineldataconnectoriots"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelLogAnalyticsWorkspaceOnboarding": {
+      "singular": "sentinelloganalyticsworkspaceonboarding",
+      "plural": "sentinelloganalyticsworkspaceonboardings"
+    },
+    "securityinsights.azure.m.upbound.io/SentinelWatchlist": {
+      "singular": "sentinelwatchlist",
+      "plural": "sentinelwatchlists"
+    },
+    "securityinsights.azure.upbound.io/SentinelAlertRuleFusion": {
+      "singular": "sentinelalertrulefusion",
+      "plural": "sentinelalertrulefusions"
+    },
+    "securityinsights.azure.upbound.io/SentinelAlertRuleMSSecurityIncident": {
+      "singular": "sentinelalertrulemssecurityincident",
+      "plural": "sentinelalertrulemssecurityincidents"
+    },
+    "securityinsights.azure.upbound.io/SentinelAlertRuleMachineLearningBehaviorAnalytics": {
+      "singular": "sentinelalertrulemachinelearningbehavioranalytics",
+      "plural": "sentinelalertrulemachinelearningbehavioranalytics"
+    },
+    "securityinsights.azure.upbound.io/SentinelAutomationRule": {
+      "singular": "sentinelautomationrule",
+      "plural": "sentinelautomationrules"
+    },
+    "securityinsights.azure.upbound.io/SentinelDataConnectorIOT": {
+      "singular": "sentineldataconnectoriot",
+      "plural": "sentineldataconnectoriots"
+    },
+    "securityinsights.azure.upbound.io/SentinelLogAnalyticsWorkspaceOnboarding": {
+      "singular": "sentinelloganalyticsworkspaceonboarding",
+      "plural": "sentinelloganalyticsworkspaceonboardings"
+    },
+    "securityinsights.azure.upbound.io/SentinelWatchlist": {
+      "singular": "sentinelwatchlist",
+      "plural": "sentinelwatchlists"
+    },
+    "servicebus.azure.m.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "servicebus.azure.m.upbound.io/NamespaceDisasterRecoveryConfig": {
+      "singular": "namespacedisasterrecoveryconfig",
+      "plural": "namespacedisasterrecoveryconfigs"
+    },
+    "servicebus.azure.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "servicebus.azure.m.upbound.io/QueueAuthorizationRule": {
+      "singular": "queueauthorizationrule",
+      "plural": "queueauthorizationrules"
+    },
+    "servicebus.azure.m.upbound.io/ServiceBusNamespace": {
+      "singular": "servicebusnamespace",
+      "plural": "servicebusnamespaces"
+    },
+    "servicebus.azure.m.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "servicebus.azure.m.upbound.io/SubscriptionRule": {
+      "singular": "subscriptionrule",
+      "plural": "subscriptionrules"
+    },
+    "servicebus.azure.m.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "servicebus.azure.m.upbound.io/TopicAuthorizationRule": {
+      "singular": "topicauthorizationrule",
+      "plural": "topicauthorizationrules"
+    },
+    "servicebus.azure.upbound.io/NamespaceAuthorizationRule": {
+      "singular": "namespaceauthorizationrule",
+      "plural": "namespaceauthorizationrules"
+    },
+    "servicebus.azure.upbound.io/NamespaceDisasterRecoveryConfig": {
+      "singular": "namespacedisasterrecoveryconfig",
+      "plural": "namespacedisasterrecoveryconfigs"
+    },
+    "servicebus.azure.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "servicebus.azure.upbound.io/QueueAuthorizationRule": {
+      "singular": "queueauthorizationrule",
+      "plural": "queueauthorizationrules"
+    },
+    "servicebus.azure.upbound.io/ServiceBusNamespace": {
+      "singular": "servicebusnamespace",
+      "plural": "servicebusnamespaces"
+    },
+    "servicebus.azure.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "servicebus.azure.upbound.io/SubscriptionRule": {
+      "singular": "subscriptionrule",
+      "plural": "subscriptionrules"
+    },
+    "servicebus.azure.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "servicebus.azure.upbound.io/TopicAuthorizationRule": {
+      "singular": "topicauthorizationrule",
+      "plural": "topicauthorizationrules"
+    },
+    "servicefabric.azure.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "servicefabric.azure.m.upbound.io/ManagedCluster": {
+      "singular": "managedcluster",
+      "plural": "managedclusters"
+    },
+    "servicefabric.azure.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "servicefabric.azure.upbound.io/ManagedCluster": {
+      "singular": "managedcluster",
+      "plural": "managedclusters"
+    },
+    "servicelinker.azure.m.upbound.io/SpringCloudConnection": {
+      "singular": "springcloudconnection",
+      "plural": "springcloudconnections"
+    },
+    "servicelinker.azure.upbound.io/SpringCloudConnection": {
+      "singular": "springcloudconnection",
+      "plural": "springcloudconnections"
+    },
+    "servicenetworking.azure.m.upbound.io/ApplicationLoadBalancer": {
+      "singular": "applicationloadbalancer",
+      "plural": "applicationloadbalancers"
+    },
+    "servicenetworking.azure.m.upbound.io/ApplicationLoadBalancerFrontend": {
+      "singular": "applicationloadbalancerfrontend",
+      "plural": "applicationloadbalancerfrontends"
+    },
+    "servicenetworking.azure.m.upbound.io/ApplicationLoadBalancerSecurityPolicy": {
+      "singular": "applicationloadbalancersecuritypolicy",
+      "plural": "applicationloadbalancersecuritypolicies"
+    },
+    "servicenetworking.azure.m.upbound.io/ApplicationLoadBalancerSubnetAssociation": {
+      "singular": "applicationloadbalancersubnetassociation",
+      "plural": "applicationloadbalancersubnetassociations"
+    },
+    "servicenetworking.azure.upbound.io/ApplicationLoadBalancer": {
+      "singular": "applicationloadbalancer",
+      "plural": "applicationloadbalancers"
+    },
+    "servicenetworking.azure.upbound.io/ApplicationLoadBalancerFrontend": {
+      "singular": "applicationloadbalancerfrontend",
+      "plural": "applicationloadbalancerfrontends"
+    },
+    "servicenetworking.azure.upbound.io/ApplicationLoadBalancerSecurityPolicy": {
+      "singular": "applicationloadbalancersecuritypolicy",
+      "plural": "applicationloadbalancersecuritypolicies"
+    },
+    "servicenetworking.azure.upbound.io/ApplicationLoadBalancerSubnetAssociation": {
+      "singular": "applicationloadbalancersubnetassociation",
+      "plural": "applicationloadbalancersubnetassociations"
+    },
+    "signalrservice.azure.m.upbound.io/NetworkACL": {
+      "singular": "networkacl",
+      "plural": "networkacls"
+    },
+    "signalrservice.azure.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "signalrservice.azure.m.upbound.io/SignalrSharedPrivateLinkResource": {
+      "singular": "signalrsharedprivatelinkresource",
+      "plural": "signalrsharedprivatelinkresources"
+    },
+    "signalrservice.azure.m.upbound.io/WebPubsub": {
+      "singular": "webpubsub",
+      "plural": "webpubsubs"
+    },
+    "signalrservice.azure.m.upbound.io/WebPubsubHub": {
+      "singular": "webpubsubhub",
+      "plural": "webpubsubhubs"
+    },
+    "signalrservice.azure.m.upbound.io/WebPubsubNetworkACL": {
+      "singular": "webpubsubnetworkacl",
+      "plural": "webpubsubnetworkacls"
+    },
+    "signalrservice.azure.upbound.io/NetworkACL": {
+      "singular": "networkacl",
+      "plural": "networkacls"
+    },
+    "signalrservice.azure.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "signalrservice.azure.upbound.io/SignalrSharedPrivateLinkResource": {
+      "singular": "signalrsharedprivatelinkresource",
+      "plural": "signalrsharedprivatelinkresources"
+    },
+    "signalrservice.azure.upbound.io/WebPubsub": {
+      "singular": "webpubsub",
+      "plural": "webpubsubs"
+    },
+    "signalrservice.azure.upbound.io/WebPubsubHub": {
+      "singular": "webpubsubhub",
+      "plural": "webpubsubhubs"
+    },
+    "signalrservice.azure.upbound.io/WebPubsubNetworkACL": {
+      "singular": "webpubsubnetworkacl",
+      "plural": "webpubsubnetworkacls"
+    },
+    "solutions.azure.m.upbound.io/ManagedApplicationDefinition": {
+      "singular": "managedapplicationdefinition",
+      "plural": "managedapplicationdefinitions"
+    },
+    "solutions.azure.upbound.io/ManagedApplicationDefinition": {
+      "singular": "managedapplicationdefinition",
+      "plural": "managedapplicationdefinitions"
+    },
+    "spring.azure.m.upbound.io/CloudApplicationLiveView": {
+      "singular": "cloudapplicationliveview",
+      "plural": "cloudapplicationliveviews"
+    },
+    "spring.azure.upbound.io/CloudApplicationLiveView": {
+      "singular": "cloudapplicationliveview",
+      "plural": "cloudapplicationliveviews"
+    },
+    "sql.azure.m.upbound.io/MSSQLDatabase": {
+      "singular": "mssqldatabase",
+      "plural": "mssqldatabases"
+    },
+    "sql.azure.m.upbound.io/MSSQLDatabaseExtendedAuditingPolicy": {
+      "singular": "mssqldatabaseextendedauditingpolicy",
+      "plural": "mssqldatabaseextendedauditingpolicies"
+    },
+    "sql.azure.m.upbound.io/MSSQLDatabaseVulnerabilityAssessmentRuleBaseline": {
+      "singular": "mssqldatabasevulnerabilityassessmentrulebaseline",
+      "plural": "mssqldatabasevulnerabilityassessmentrulebaselines"
+    },
+    "sql.azure.m.upbound.io/MSSQLElasticPool": {
+      "singular": "mssqlelasticpool",
+      "plural": "mssqlelasticpools"
+    },
+    "sql.azure.m.upbound.io/MSSQLFailoverGroup": {
+      "singular": "mssqlfailovergroup",
+      "plural": "mssqlfailovergroups"
+    },
+    "sql.azure.m.upbound.io/MSSQLFirewallRule": {
+      "singular": "mssqlfirewallrule",
+      "plural": "mssqlfirewallrules"
+    },
+    "sql.azure.m.upbound.io/MSSQLJobAgent": {
+      "singular": "mssqljobagent",
+      "plural": "mssqljobagents"
+    },
+    "sql.azure.m.upbound.io/MSSQLJobCredential": {
+      "singular": "mssqljobcredential",
+      "plural": "mssqljobcredentials"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedDatabase": {
+      "singular": "mssqlmanageddatabase",
+      "plural": "mssqlmanageddatabases"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedInstance": {
+      "singular": "mssqlmanagedinstance",
+      "plural": "mssqlmanagedinstances"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedInstanceActiveDirectoryAdministrator": {
+      "singular": "mssqlmanagedinstanceactivedirectoryadministrator",
+      "plural": "mssqlmanagedinstanceactivedirectoryadministrators"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedInstanceFailoverGroup": {
+      "singular": "mssqlmanagedinstancefailovergroup",
+      "plural": "mssqlmanagedinstancefailovergroups"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedInstanceTransparentDataEncryption": {
+      "singular": "mssqlmanagedinstancetransparentdataencryption",
+      "plural": "mssqlmanagedinstancetransparentdataencryptions"
+    },
+    "sql.azure.m.upbound.io/MSSQLManagedInstanceVulnerabilityAssessment": {
+      "singular": "mssqlmanagedinstancevulnerabilityassessment",
+      "plural": "mssqlmanagedinstancevulnerabilityassessments"
+    },
+    "sql.azure.m.upbound.io/MSSQLOutboundFirewallRule": {
+      "singular": "mssqloutboundfirewallrule",
+      "plural": "mssqloutboundfirewallrules"
+    },
+    "sql.azure.m.upbound.io/MSSQLServer": {
+      "singular": "mssqlserver",
+      "plural": "mssqlservers"
+    },
+    "sql.azure.m.upbound.io/MSSQLServerDNSAlias": {
+      "singular": "mssqlserverdnsalias",
+      "plural": "mssqlserverdnsaliases"
+    },
+    "sql.azure.m.upbound.io/MSSQLServerMicrosoftSupportAuditingPolicy": {
+      "singular": "mssqlservermicrosoftsupportauditingpolicy",
+      "plural": "mssqlservermicrosoftsupportauditingpolicies"
+    },
+    "sql.azure.m.upbound.io/MSSQLServerSecurityAlertPolicy": {
+      "singular": "mssqlserversecurityalertpolicy",
+      "plural": "mssqlserversecurityalertpolicies"
+    },
+    "sql.azure.m.upbound.io/MSSQLServerTransparentDataEncryption": {
+      "singular": "mssqlservertransparentdataencryption",
+      "plural": "mssqlservertransparentdataencryptions"
+    },
+    "sql.azure.m.upbound.io/MSSQLServerVulnerabilityAssessment": {
+      "singular": "mssqlservervulnerabilityassessment",
+      "plural": "mssqlservervulnerabilityassessments"
+    },
+    "sql.azure.m.upbound.io/MSSQLVirtualNetworkRule": {
+      "singular": "mssqlvirtualnetworkrule",
+      "plural": "mssqlvirtualnetworkrules"
+    },
+    "sql.azure.upbound.io/MSSQLDatabase": {
+      "singular": "mssqldatabase",
+      "plural": "mssqldatabases"
+    },
+    "sql.azure.upbound.io/MSSQLDatabaseExtendedAuditingPolicy": {
+      "singular": "mssqldatabaseextendedauditingpolicy",
+      "plural": "mssqldatabaseextendedauditingpolicies"
+    },
+    "sql.azure.upbound.io/MSSQLDatabaseVulnerabilityAssessmentRuleBaseline": {
+      "singular": "mssqldatabasevulnerabilityassessmentrulebaseline",
+      "plural": "mssqldatabasevulnerabilityassessmentrulebaselines"
+    },
+    "sql.azure.upbound.io/MSSQLElasticPool": {
+      "singular": "mssqlelasticpool",
+      "plural": "mssqlelasticpools"
+    },
+    "sql.azure.upbound.io/MSSQLFailoverGroup": {
+      "singular": "mssqlfailovergroup",
+      "plural": "mssqlfailovergroups"
+    },
+    "sql.azure.upbound.io/MSSQLFirewallRule": {
+      "singular": "mssqlfirewallrule",
+      "plural": "mssqlfirewallrules"
+    },
+    "sql.azure.upbound.io/MSSQLJobAgent": {
+      "singular": "mssqljobagent",
+      "plural": "mssqljobagents"
+    },
+    "sql.azure.upbound.io/MSSQLJobCredential": {
+      "singular": "mssqljobcredential",
+      "plural": "mssqljobcredentials"
+    },
+    "sql.azure.upbound.io/MSSQLManagedDatabase": {
+      "singular": "mssqlmanageddatabase",
+      "plural": "mssqlmanageddatabases"
+    },
+    "sql.azure.upbound.io/MSSQLManagedInstance": {
+      "singular": "mssqlmanagedinstance",
+      "plural": "mssqlmanagedinstances"
+    },
+    "sql.azure.upbound.io/MSSQLManagedInstanceActiveDirectoryAdministrator": {
+      "singular": "mssqlmanagedinstanceactivedirectoryadministrator",
+      "plural": "mssqlmanagedinstanceactivedirectoryadministrators"
+    },
+    "sql.azure.upbound.io/MSSQLManagedInstanceFailoverGroup": {
+      "singular": "mssqlmanagedinstancefailovergroup",
+      "plural": "mssqlmanagedinstancefailovergroups"
+    },
+    "sql.azure.upbound.io/MSSQLManagedInstanceTransparentDataEncryption": {
+      "singular": "mssqlmanagedinstancetransparentdataencryption",
+      "plural": "mssqlmanagedinstancetransparentdataencryptions"
+    },
+    "sql.azure.upbound.io/MSSQLManagedInstanceVulnerabilityAssessment": {
+      "singular": "mssqlmanagedinstancevulnerabilityassessment",
+      "plural": "mssqlmanagedinstancevulnerabilityassessments"
+    },
+    "sql.azure.upbound.io/MSSQLOutboundFirewallRule": {
+      "singular": "mssqloutboundfirewallrule",
+      "plural": "mssqloutboundfirewallrules"
+    },
+    "sql.azure.upbound.io/MSSQLServer": {
+      "singular": "mssqlserver",
+      "plural": "mssqlservers"
+    },
+    "sql.azure.upbound.io/MSSQLServerDNSAlias": {
+      "singular": "mssqlserverdnsalias",
+      "plural": "mssqlserverdnsaliases"
+    },
+    "sql.azure.upbound.io/MSSQLServerMicrosoftSupportAuditingPolicy": {
+      "singular": "mssqlservermicrosoftsupportauditingpolicy",
+      "plural": "mssqlservermicrosoftsupportauditingpolicies"
+    },
+    "sql.azure.upbound.io/MSSQLServerSecurityAlertPolicy": {
+      "singular": "mssqlserversecurityalertpolicy",
+      "plural": "mssqlserversecurityalertpolicies"
+    },
+    "sql.azure.upbound.io/MSSQLServerTransparentDataEncryption": {
+      "singular": "mssqlservertransparentdataencryption",
+      "plural": "mssqlservertransparentdataencryptions"
+    },
+    "sql.azure.upbound.io/MSSQLServerVulnerabilityAssessment": {
+      "singular": "mssqlservervulnerabilityassessment",
+      "plural": "mssqlservervulnerabilityassessments"
+    },
+    "sql.azure.upbound.io/MSSQLVirtualNetworkRule": {
+      "singular": "mssqlvirtualnetworkrule",
+      "plural": "mssqlvirtualnetworkrules"
+    },
+    "storage.azure.m.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "storage.azure.m.upbound.io/AccountLocalUser": {
+      "singular": "accountlocaluser",
+      "plural": "accountlocalusers"
+    },
+    "storage.azure.m.upbound.io/AccountNetworkRules": {
+      "singular": "accountnetworkrules",
+      "plural": "accountnetworkrules"
+    },
+    "storage.azure.m.upbound.io/Blob": {
+      "singular": "blob",
+      "plural": "blobs"
+    },
+    "storage.azure.m.upbound.io/BlobInventoryPolicy": {
+      "singular": "blobinventorypolicy",
+      "plural": "blobinventorypolicies"
+    },
+    "storage.azure.m.upbound.io/Container": {
+      "singular": "container",
+      "plural": "containers"
+    },
+    "storage.azure.m.upbound.io/ContainerImmutabilityPolicy": {
+      "singular": "containerimmutabilitypolicy",
+      "plural": "containerimmutabilitypolicies"
+    },
+    "storage.azure.m.upbound.io/DataLakeGen2FileSystem": {
+      "singular": "datalakegen2filesystem",
+      "plural": "datalakegen2filesystems"
+    },
+    "storage.azure.m.upbound.io/DataLakeGen2Path": {
+      "singular": "datalakegen2path",
+      "plural": "datalakegen2paths"
+    },
+    "storage.azure.m.upbound.io/EncryptionScope": {
+      "singular": "encryptionscope",
+      "plural": "encryptionscopes"
+    },
+    "storage.azure.m.upbound.io/ManagementPolicy": {
+      "singular": "managementpolicy",
+      "plural": "managementpolicies"
+    },
+    "storage.azure.m.upbound.io/ObjectReplication": {
+      "singular": "objectreplication",
+      "plural": "objectreplications"
+    },
+    "storage.azure.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "storage.azure.m.upbound.io/Share": {
+      "singular": "share",
+      "plural": "shares"
+    },
+    "storage.azure.m.upbound.io/ShareDirectory": {
+      "singular": "sharedirectory",
+      "plural": "sharedirectories"
+    },
+    "storage.azure.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "storage.azure.m.upbound.io/TableEntity": {
+      "singular": "tableentity",
+      "plural": "tableentities"
+    },
+    "storage.azure.upbound.io/Account": {
+      "singular": "account",
+      "plural": "accounts"
+    },
+    "storage.azure.upbound.io/AccountLocalUser": {
+      "singular": "accountlocaluser",
+      "plural": "accountlocalusers"
+    },
+    "storage.azure.upbound.io/AccountNetworkRules": {
+      "singular": "accountnetworkrules",
+      "plural": "accountnetworkrules"
+    },
+    "storage.azure.upbound.io/Blob": {
+      "singular": "blob",
+      "plural": "blobs"
+    },
+    "storage.azure.upbound.io/BlobInventoryPolicy": {
+      "singular": "blobinventorypolicy",
+      "plural": "blobinventorypolicies"
+    },
+    "storage.azure.upbound.io/Container": {
+      "singular": "container",
+      "plural": "containers"
+    },
+    "storage.azure.upbound.io/ContainerImmutabilityPolicy": {
+      "singular": "containerimmutabilitypolicy",
+      "plural": "containerimmutabilitypolicies"
+    },
+    "storage.azure.upbound.io/DataLakeGen2FileSystem": {
+      "singular": "datalakegen2filesystem",
+      "plural": "datalakegen2filesystems"
+    },
+    "storage.azure.upbound.io/DataLakeGen2Path": {
+      "singular": "datalakegen2path",
+      "plural": "datalakegen2paths"
+    },
+    "storage.azure.upbound.io/EncryptionScope": {
+      "singular": "encryptionscope",
+      "plural": "encryptionscopes"
+    },
+    "storage.azure.upbound.io/ManagementPolicy": {
+      "singular": "managementpolicy",
+      "plural": "managementpolicies"
+    },
+    "storage.azure.upbound.io/ObjectReplication": {
+      "singular": "objectreplication",
+      "plural": "objectreplications"
+    },
+    "storage.azure.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "storage.azure.upbound.io/Share": {
+      "singular": "share",
+      "plural": "shares"
+    },
+    "storage.azure.upbound.io/ShareDirectory": {
+      "singular": "sharedirectory",
+      "plural": "sharedirectories"
+    },
+    "storage.azure.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "storage.azure.upbound.io/TableEntity": {
+      "singular": "tableentity",
+      "plural": "tableentities"
+    },
+    "storagecache.azure.m.upbound.io/HPCCache": {
+      "singular": "hpccache",
+      "plural": "hpccaches"
+    },
+    "storagecache.azure.m.upbound.io/HPCCacheAccessPolicy": {
+      "singular": "hpccacheaccesspolicy",
+      "plural": "hpccacheaccesspolicies"
+    },
+    "storagecache.azure.m.upbound.io/HPCCacheBlobNFSTarget": {
+      "singular": "hpccacheblobnfstarget",
+      "plural": "hpccacheblobnfstargets"
+    },
+    "storagecache.azure.m.upbound.io/HPCCacheBlobTarget": {
+      "singular": "hpccacheblobtarget",
+      "plural": "hpccacheblobtargets"
+    },
+    "storagecache.azure.m.upbound.io/HPCCacheNFSTarget": {
+      "singular": "hpccachenfstarget",
+      "plural": "hpccachenfstargets"
+    },
+    "storagecache.azure.upbound.io/HPCCache": {
+      "singular": "hpccache",
+      "plural": "hpccaches"
+    },
+    "storagecache.azure.upbound.io/HPCCacheAccessPolicy": {
+      "singular": "hpccacheaccesspolicy",
+      "plural": "hpccacheaccesspolicies"
+    },
+    "storagecache.azure.upbound.io/HPCCacheBlobNFSTarget": {
+      "singular": "hpccacheblobnfstarget",
+      "plural": "hpccacheblobnfstargets"
+    },
+    "storagecache.azure.upbound.io/HPCCacheBlobTarget": {
+      "singular": "hpccacheblobtarget",
+      "plural": "hpccacheblobtargets"
+    },
+    "storagecache.azure.upbound.io/HPCCacheNFSTarget": {
+      "singular": "hpccachenfstarget",
+      "plural": "hpccachenfstargets"
+    },
+    "storagesync.azure.m.upbound.io/StorageSync": {
+      "singular": "storagesync",
+      "plural": "storagesyncs"
+    },
+    "storagesync.azure.upbound.io/StorageSync": {
+      "singular": "storagesync",
+      "plural": "storagesyncs"
+    },
+    "streamanalytics.azure.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "streamanalytics.azure.m.upbound.io/FunctionJavascriptUda": {
+      "singular": "functionjavascriptuda",
+      "plural": "functionjavascriptudas"
+    },
+    "streamanalytics.azure.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "streamanalytics.azure.m.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputBlob": {
+      "singular": "outputblob",
+      "plural": "outputblobs"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputEventHub": {
+      "singular": "outputeventhub",
+      "plural": "outputeventhubs"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputFunction": {
+      "singular": "outputfunction",
+      "plural": "outputfunctions"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputMSSQL": {
+      "singular": "outputmssql",
+      "plural": "outputmssqls"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputPowerBI": {
+      "singular": "outputpowerbi",
+      "plural": "outputpowerbis"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputServiceBusQueue": {
+      "singular": "outputservicebusqueue",
+      "plural": "outputservicebusqueues"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputServiceBusTopic": {
+      "singular": "outputservicebustopic",
+      "plural": "outputservicebustopics"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputSynapse": {
+      "singular": "outputsynapse",
+      "plural": "outputsynapses"
+    },
+    "streamanalytics.azure.m.upbound.io/OutputTable": {
+      "singular": "outputtable",
+      "plural": "outputtables"
+    },
+    "streamanalytics.azure.m.upbound.io/ReferenceInputBlob": {
+      "singular": "referenceinputblob",
+      "plural": "referenceinputblobs"
+    },
+    "streamanalytics.azure.m.upbound.io/ReferenceInputMSSQL": {
+      "singular": "referenceinputmssql",
+      "plural": "referenceinputmssqls"
+    },
+    "streamanalytics.azure.m.upbound.io/StreamInputBlob": {
+      "singular": "streaminputblob",
+      "plural": "streaminputblobs"
+    },
+    "streamanalytics.azure.m.upbound.io/StreamInputEventHub": {
+      "singular": "streaminputeventhub",
+      "plural": "streaminputeventhubs"
+    },
+    "streamanalytics.azure.m.upbound.io/StreamInputIOTHub": {
+      "singular": "streaminputiothub",
+      "plural": "streaminputiothubs"
+    },
+    "streamanalytics.azure.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "streamanalytics.azure.upbound.io/FunctionJavascriptUda": {
+      "singular": "functionjavascriptuda",
+      "plural": "functionjavascriptudas"
+    },
+    "streamanalytics.azure.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "streamanalytics.azure.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "streamanalytics.azure.upbound.io/OutputBlob": {
+      "singular": "outputblob",
+      "plural": "outputblobs"
+    },
+    "streamanalytics.azure.upbound.io/OutputEventHub": {
+      "singular": "outputeventhub",
+      "plural": "outputeventhubs"
+    },
+    "streamanalytics.azure.upbound.io/OutputFunction": {
+      "singular": "outputfunction",
+      "plural": "outputfunctions"
+    },
+    "streamanalytics.azure.upbound.io/OutputMSSQL": {
+      "singular": "outputmssql",
+      "plural": "outputmssqls"
+    },
+    "streamanalytics.azure.upbound.io/OutputPowerBI": {
+      "singular": "outputpowerbi",
+      "plural": "outputpowerbis"
+    },
+    "streamanalytics.azure.upbound.io/OutputServiceBusQueue": {
+      "singular": "outputservicebusqueue",
+      "plural": "outputservicebusqueues"
+    },
+    "streamanalytics.azure.upbound.io/OutputServiceBusTopic": {
+      "singular": "outputservicebustopic",
+      "plural": "outputservicebustopics"
+    },
+    "streamanalytics.azure.upbound.io/OutputSynapse": {
+      "singular": "outputsynapse",
+      "plural": "outputsynapses"
+    },
+    "streamanalytics.azure.upbound.io/OutputTable": {
+      "singular": "outputtable",
+      "plural": "outputtables"
+    },
+    "streamanalytics.azure.upbound.io/ReferenceInputBlob": {
+      "singular": "referenceinputblob",
+      "plural": "referenceinputblobs"
+    },
+    "streamanalytics.azure.upbound.io/ReferenceInputMSSQL": {
+      "singular": "referenceinputmssql",
+      "plural": "referenceinputmssqls"
+    },
+    "streamanalytics.azure.upbound.io/StreamInputBlob": {
+      "singular": "streaminputblob",
+      "plural": "streaminputblobs"
+    },
+    "streamanalytics.azure.upbound.io/StreamInputEventHub": {
+      "singular": "streaminputeventhub",
+      "plural": "streaminputeventhubs"
+    },
+    "streamanalytics.azure.upbound.io/StreamInputIOTHub": {
+      "singular": "streaminputiothub",
+      "plural": "streaminputiothubs"
+    },
+    "synapse.azure.m.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "synapse.azure.m.upbound.io/IntegrationRuntimeAzure": {
+      "singular": "integrationruntimeazure",
+      "plural": "integrationruntimeazures"
+    },
+    "synapse.azure.m.upbound.io/IntegrationRuntimeSelfHosted": {
+      "singular": "integrationruntimeselfhosted",
+      "plural": "integrationruntimeselfhosteds"
+    },
+    "synapse.azure.m.upbound.io/LinkedService": {
+      "singular": "linkedservice",
+      "plural": "linkedservices"
+    },
+    "synapse.azure.m.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "synapse.azure.m.upbound.io/PrivateLinkHub": {
+      "singular": "privatelinkhub",
+      "plural": "privatelinkhubs"
+    },
+    "synapse.azure.m.upbound.io/RoleAssignment": {
+      "singular": "roleassignment",
+      "plural": "roleassignments"
+    },
+    "synapse.azure.m.upbound.io/SQLPool": {
+      "singular": "sqlpool",
+      "plural": "sqlpools"
+    },
+    "synapse.azure.m.upbound.io/SQLPoolExtendedAuditingPolicy": {
+      "singular": "sqlpoolextendedauditingpolicy",
+      "plural": "sqlpoolextendedauditingpolicies"
+    },
+    "synapse.azure.m.upbound.io/SQLPoolSecurityAlertPolicy": {
+      "singular": "sqlpoolsecurityalertpolicy",
+      "plural": "sqlpoolsecurityalertpolicies"
+    },
+    "synapse.azure.m.upbound.io/SQLPoolWorkloadClassifier": {
+      "singular": "sqlpoolworkloadclassifier",
+      "plural": "sqlpoolworkloadclassifiers"
+    },
+    "synapse.azure.m.upbound.io/SQLPoolWorkloadGroup": {
+      "singular": "sqlpoolworkloadgroup",
+      "plural": "sqlpoolworkloadgroups"
+    },
+    "synapse.azure.m.upbound.io/SparkPool": {
+      "singular": "sparkpool",
+      "plural": "sparkpools"
+    },
+    "synapse.azure.m.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "synapse.azure.m.upbound.io/WorkspaceAADAdmin": {
+      "singular": "workspaceaadadmin",
+      "plural": "workspaceaadadmins"
+    },
+    "synapse.azure.m.upbound.io/WorkspaceExtendedAuditingPolicy": {
+      "singular": "workspaceextendedauditingpolicy",
+      "plural": "workspaceextendedauditingpolicies"
+    },
+    "synapse.azure.m.upbound.io/WorkspaceSQLAADAdmin": {
+      "singular": "workspacesqlaadadmin",
+      "plural": "workspacesqlaadadmins"
+    },
+    "synapse.azure.m.upbound.io/WorkspaceSecurityAlertPolicy": {
+      "singular": "workspacesecurityalertpolicy",
+      "plural": "workspacesecurityalertpolicies"
+    },
+    "synapse.azure.m.upbound.io/WorkspaceVulnerabilityAssessment": {
+      "singular": "workspacevulnerabilityassessment",
+      "plural": "workspacevulnerabilityassessments"
+    },
+    "synapse.azure.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "synapse.azure.upbound.io/IntegrationRuntimeAzure": {
+      "singular": "integrationruntimeazure",
+      "plural": "integrationruntimeazures"
+    },
+    "synapse.azure.upbound.io/IntegrationRuntimeSelfHosted": {
+      "singular": "integrationruntimeselfhosted",
+      "plural": "integrationruntimeselfhosteds"
+    },
+    "synapse.azure.upbound.io/LinkedService": {
+      "singular": "linkedservice",
+      "plural": "linkedservices"
+    },
+    "synapse.azure.upbound.io/ManagedPrivateEndpoint": {
+      "singular": "managedprivateendpoint",
+      "plural": "managedprivateendpoints"
+    },
+    "synapse.azure.upbound.io/PrivateLinkHub": {
+      "singular": "privatelinkhub",
+      "plural": "privatelinkhubs"
+    },
+    "synapse.azure.upbound.io/RoleAssignment": {
+      "singular": "roleassignment",
+      "plural": "roleassignments"
+    },
+    "synapse.azure.upbound.io/SQLPool": {
+      "singular": "sqlpool",
+      "plural": "sqlpools"
+    },
+    "synapse.azure.upbound.io/SQLPoolExtendedAuditingPolicy": {
+      "singular": "sqlpoolextendedauditingpolicy",
+      "plural": "sqlpoolextendedauditingpolicies"
+    },
+    "synapse.azure.upbound.io/SQLPoolSecurityAlertPolicy": {
+      "singular": "sqlpoolsecurityalertpolicy",
+      "plural": "sqlpoolsecurityalertpolicies"
+    },
+    "synapse.azure.upbound.io/SQLPoolWorkloadClassifier": {
+      "singular": "sqlpoolworkloadclassifier",
+      "plural": "sqlpoolworkloadclassifiers"
+    },
+    "synapse.azure.upbound.io/SQLPoolWorkloadGroup": {
+      "singular": "sqlpoolworkloadgroup",
+      "plural": "sqlpoolworkloadgroups"
+    },
+    "synapse.azure.upbound.io/SparkPool": {
+      "singular": "sparkpool",
+      "plural": "sparkpools"
+    },
+    "synapse.azure.upbound.io/Workspace": {
+      "singular": "workspace",
+      "plural": "workspaces"
+    },
+    "synapse.azure.upbound.io/WorkspaceAADAdmin": {
+      "singular": "workspaceaadadmin",
+      "plural": "workspaceaadadmins"
+    },
+    "synapse.azure.upbound.io/WorkspaceExtendedAuditingPolicy": {
+      "singular": "workspaceextendedauditingpolicy",
+      "plural": "workspaceextendedauditingpolicies"
+    },
+    "synapse.azure.upbound.io/WorkspaceSQLAADAdmin": {
+      "singular": "workspacesqlaadadmin",
+      "plural": "workspacesqlaadadmins"
+    },
+    "synapse.azure.upbound.io/WorkspaceSecurityAlertPolicy": {
+      "singular": "workspacesecurityalertpolicy",
+      "plural": "workspacesecurityalertpolicies"
+    },
+    "synapse.azure.upbound.io/WorkspaceVulnerabilityAssessment": {
+      "singular": "workspacevulnerabilityassessment",
+      "plural": "workspacevulnerabilityassessments"
+    },
+    "web.azure.m.upbound.io/AppActiveSlot": {
+      "singular": "appactiveslot",
+      "plural": "appactiveslots"
+    },
+    "web.azure.m.upbound.io/AppHybridConnection": {
+      "singular": "apphybridconnection",
+      "plural": "apphybridconnections"
+    },
+    "web.azure.m.upbound.io/AppServicePlan": {
+      "singular": "appserviceplan",
+      "plural": "appserviceplans"
+    },
+    "web.azure.m.upbound.io/FunctionApp": {
+      "singular": "functionapp",
+      "plural": "functionapps"
+    },
+    "web.azure.m.upbound.io/FunctionAppActiveSlot": {
+      "singular": "functionappactiveslot",
+      "plural": "functionappactiveslots"
+    },
+    "web.azure.m.upbound.io/FunctionAppFlexConsumption": {
+      "singular": "functionappflexconsumption",
+      "plural": "functionappflexconsumptions"
+    },
+    "web.azure.m.upbound.io/FunctionAppFunction": {
+      "singular": "functionappfunction",
+      "plural": "functionappfunctions"
+    },
+    "web.azure.m.upbound.io/FunctionAppHybridConnection": {
+      "singular": "functionapphybridconnection",
+      "plural": "functionapphybridconnections"
+    },
+    "web.azure.m.upbound.io/FunctionAppSlot": {
+      "singular": "functionappslot",
+      "plural": "functionappslots"
+    },
+    "web.azure.m.upbound.io/LinuxFunctionApp": {
+      "singular": "linuxfunctionapp",
+      "plural": "linuxfunctionapps"
+    },
+    "web.azure.m.upbound.io/LinuxFunctionAppSlot": {
+      "singular": "linuxfunctionappslot",
+      "plural": "linuxfunctionappslots"
+    },
+    "web.azure.m.upbound.io/LinuxWebApp": {
+      "singular": "linuxwebapp",
+      "plural": "linuxwebapps"
+    },
+    "web.azure.m.upbound.io/LinuxWebAppSlot": {
+      "singular": "linuxwebappslot",
+      "plural": "linuxwebappslots"
+    },
+    "web.azure.m.upbound.io/ServicePlan": {
+      "singular": "serviceplan",
+      "plural": "serviceplans"
+    },
+    "web.azure.m.upbound.io/SourceControlToken": {
+      "singular": "sourcecontroltoken",
+      "plural": "sourcecontroltokens"
+    },
+    "web.azure.m.upbound.io/StaticSite": {
+      "singular": "staticsite",
+      "plural": "staticsites"
+    },
+    "web.azure.m.upbound.io/WindowsFunctionApp": {
+      "singular": "windowsfunctionapp",
+      "plural": "windowsfunctionapps"
+    },
+    "web.azure.m.upbound.io/WindowsFunctionAppSlot": {
+      "singular": "windowsfunctionappslot",
+      "plural": "windowsfunctionappslots"
+    },
+    "web.azure.m.upbound.io/WindowsWebApp": {
+      "singular": "windowswebapp",
+      "plural": "windowswebapps"
+    },
+    "web.azure.m.upbound.io/WindowsWebAppSlot": {
+      "singular": "windowswebappslot",
+      "plural": "windowswebappslots"
+    },
+    "web.azure.upbound.io/AppActiveSlot": {
+      "singular": "appactiveslot",
+      "plural": "appactiveslots"
+    },
+    "web.azure.upbound.io/AppHybridConnection": {
+      "singular": "apphybridconnection",
+      "plural": "apphybridconnections"
+    },
+    "web.azure.upbound.io/AppServicePlan": {
+      "singular": "appserviceplan",
+      "plural": "appserviceplans"
+    },
+    "web.azure.upbound.io/FunctionApp": {
+      "singular": "functionapp",
+      "plural": "functionapps"
+    },
+    "web.azure.upbound.io/FunctionAppActiveSlot": {
+      "singular": "functionappactiveslot",
+      "plural": "functionappactiveslots"
+    },
+    "web.azure.upbound.io/FunctionAppFlexConsumption": {
+      "singular": "functionappflexconsumption",
+      "plural": "functionappflexconsumptions"
+    },
+    "web.azure.upbound.io/FunctionAppFunction": {
+      "singular": "functionappfunction",
+      "plural": "functionappfunctions"
+    },
+    "web.azure.upbound.io/FunctionAppHybridConnection": {
+      "singular": "functionapphybridconnection",
+      "plural": "functionapphybridconnections"
+    },
+    "web.azure.upbound.io/FunctionAppSlot": {
+      "singular": "functionappslot",
+      "plural": "functionappslots"
+    },
+    "web.azure.upbound.io/LinuxFunctionApp": {
+      "singular": "linuxfunctionapp",
+      "plural": "linuxfunctionapps"
+    },
+    "web.azure.upbound.io/LinuxFunctionAppSlot": {
+      "singular": "linuxfunctionappslot",
+      "plural": "linuxfunctionappslots"
+    },
+    "web.azure.upbound.io/LinuxWebApp": {
+      "singular": "linuxwebapp",
+      "plural": "linuxwebapps"
+    },
+    "web.azure.upbound.io/LinuxWebAppSlot": {
+      "singular": "linuxwebappslot",
+      "plural": "linuxwebappslots"
+    },
+    "web.azure.upbound.io/ServicePlan": {
+      "singular": "serviceplan",
+      "plural": "serviceplans"
+    },
+    "web.azure.upbound.io/SourceControlToken": {
+      "singular": "sourcecontroltoken",
+      "plural": "sourcecontroltokens"
+    },
+    "web.azure.upbound.io/StaticSite": {
+      "singular": "staticsite",
+      "plural": "staticsites"
+    },
+    "web.azure.upbound.io/WindowsFunctionApp": {
+      "singular": "windowsfunctionapp",
+      "plural": "windowsfunctionapps"
+    },
+    "web.azure.upbound.io/WindowsFunctionAppSlot": {
+      "singular": "windowsfunctionappslot",
+      "plural": "windowsfunctionappslots"
+    },
+    "web.azure.upbound.io/WindowsWebApp": {
+      "singular": "windowswebapp",
+      "plural": "windowswebapps"
+    },
+    "web.azure.upbound.io/WindowsWebAppSlot": {
+      "singular": "windowswebappslot",
+      "plural": "windowswebappslots"
+    }
+  },
   "files": [
     "catalog/alertsmanagement.azure.m.upbound.io/monitoralertprocessingruleactiongroup_v1beta1.fields.txt",
     "catalog/alertsmanagement.azure.m.upbound.io/monitoralertprocessingruleactiongroup_v1beta1.json",

--- a/build/history/provider-upjet-gcp.json
+++ b/build/history/provider-upjet-gcp.json
@@ -2,8 +2,8 @@
   "name": "provider-upjet-gcp",
   "repo": "crossplane-contrib/provider-upjet-gcp",
   "version": "v2.6.0",
-  "builtAt": "2026-07-05T15:00:32.890Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:08:44.679Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "accesscontextmanager.gcp.m.upbound.io/AccessLevel",
     "accesscontextmanager.gcp.m.upbound.io/AccessLevelCondition",
@@ -815,6 +815,3244 @@
     "workflows.gcp.m.upbound.io/Workflow",
     "workflows.gcp.upbound.io/Workflow"
   ],
+  "resources": {
+    "accesscontextmanager.gcp.m.upbound.io/AccessLevel": {
+      "singular": "accesslevel",
+      "plural": "accesslevels"
+    },
+    "accesscontextmanager.gcp.m.upbound.io/AccessLevelCondition": {
+      "singular": "accesslevelcondition",
+      "plural": "accesslevelconditions"
+    },
+    "accesscontextmanager.gcp.m.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "accesscontextmanager.gcp.m.upbound.io/AccessPolicyIAMMember": {
+      "singular": "accesspolicyiammember",
+      "plural": "accesspolicyiammembers"
+    },
+    "accesscontextmanager.gcp.m.upbound.io/ServicePerimeter": {
+      "singular": "serviceperimeter",
+      "plural": "serviceperimeters"
+    },
+    "accesscontextmanager.gcp.m.upbound.io/ServicePerimeterResource": {
+      "singular": "serviceperimeterresource",
+      "plural": "serviceperimeterresources"
+    },
+    "accesscontextmanager.gcp.upbound.io/AccessLevel": {
+      "singular": "accesslevel",
+      "plural": "accesslevels"
+    },
+    "accesscontextmanager.gcp.upbound.io/AccessLevelCondition": {
+      "singular": "accesslevelcondition",
+      "plural": "accesslevelconditions"
+    },
+    "accesscontextmanager.gcp.upbound.io/AccessPolicy": {
+      "singular": "accesspolicy",
+      "plural": "accesspolicies"
+    },
+    "accesscontextmanager.gcp.upbound.io/AccessPolicyIAMMember": {
+      "singular": "accesspolicyiammember",
+      "plural": "accesspolicyiammembers"
+    },
+    "accesscontextmanager.gcp.upbound.io/ServicePerimeter": {
+      "singular": "serviceperimeter",
+      "plural": "serviceperimeters"
+    },
+    "accesscontextmanager.gcp.upbound.io/ServicePerimeterResource": {
+      "singular": "serviceperimeterresource",
+      "plural": "serviceperimeterresources"
+    },
+    "activedirectory.gcp.m.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "activedirectory.gcp.upbound.io/Domain": {
+      "singular": "domain",
+      "plural": "domains"
+    },
+    "alloydb.gcp.m.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "alloydb.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "alloydb.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "alloydb.gcp.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "alloydb.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "alloydb.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "apigee.gcp.m.upbound.io/AddonsConfig": {
+      "singular": "addonsconfig",
+      "plural": "addonsconfigs"
+    },
+    "apigee.gcp.m.upbound.io/EndpointAttachment": {
+      "singular": "endpointattachment",
+      "plural": "endpointattachments"
+    },
+    "apigee.gcp.m.upbound.io/EnvKeystore": {
+      "singular": "envkeystore",
+      "plural": "envkeystores"
+    },
+    "apigee.gcp.m.upbound.io/EnvReferences": {
+      "singular": "envreferences",
+      "plural": "envreferences"
+    },
+    "apigee.gcp.m.upbound.io/Envgroup": {
+      "singular": "envgroup",
+      "plural": "envgroups"
+    },
+    "apigee.gcp.m.upbound.io/EnvgroupAttachment": {
+      "singular": "envgroupattachment",
+      "plural": "envgroupattachments"
+    },
+    "apigee.gcp.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "apigee.gcp.m.upbound.io/EnvironmentIAMMember": {
+      "singular": "environmentiammember",
+      "plural": "environmentiammembers"
+    },
+    "apigee.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "apigee.gcp.m.upbound.io/InstanceAttachment": {
+      "singular": "instanceattachment",
+      "plural": "instanceattachments"
+    },
+    "apigee.gcp.m.upbound.io/KeystoresAliasesKeyCertFile": {
+      "singular": "keystoresaliaseskeycertfile",
+      "plural": "keystoresaliaseskeycertfiles"
+    },
+    "apigee.gcp.m.upbound.io/NATAddress": {
+      "singular": "nataddress",
+      "plural": "nataddresses"
+    },
+    "apigee.gcp.m.upbound.io/Organization": {
+      "singular": "organization",
+      "plural": "organizations"
+    },
+    "apigee.gcp.m.upbound.io/SyncAuthorization": {
+      "singular": "syncauthorization",
+      "plural": "syncauthorizations"
+    },
+    "apigee.gcp.m.upbound.io/TargetServer": {
+      "singular": "targetserver",
+      "plural": "targetservers"
+    },
+    "apigee.gcp.upbound.io/AddonsConfig": {
+      "singular": "addonsconfig",
+      "plural": "addonsconfigs"
+    },
+    "apigee.gcp.upbound.io/EndpointAttachment": {
+      "singular": "endpointattachment",
+      "plural": "endpointattachments"
+    },
+    "apigee.gcp.upbound.io/EnvKeystore": {
+      "singular": "envkeystore",
+      "plural": "envkeystores"
+    },
+    "apigee.gcp.upbound.io/EnvReferences": {
+      "singular": "envreferences",
+      "plural": "envreferences"
+    },
+    "apigee.gcp.upbound.io/Envgroup": {
+      "singular": "envgroup",
+      "plural": "envgroups"
+    },
+    "apigee.gcp.upbound.io/EnvgroupAttachment": {
+      "singular": "envgroupattachment",
+      "plural": "envgroupattachments"
+    },
+    "apigee.gcp.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "apigee.gcp.upbound.io/EnvironmentIAMMember": {
+      "singular": "environmentiammember",
+      "plural": "environmentiammembers"
+    },
+    "apigee.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "apigee.gcp.upbound.io/InstanceAttachment": {
+      "singular": "instanceattachment",
+      "plural": "instanceattachments"
+    },
+    "apigee.gcp.upbound.io/KeystoresAliasesKeyCertFile": {
+      "singular": "keystoresaliaseskeycertfile",
+      "plural": "keystoresaliaseskeycertfiles"
+    },
+    "apigee.gcp.upbound.io/NATAddress": {
+      "singular": "nataddress",
+      "plural": "nataddresses"
+    },
+    "apigee.gcp.upbound.io/Organization": {
+      "singular": "organization",
+      "plural": "organizations"
+    },
+    "apigee.gcp.upbound.io/SyncAuthorization": {
+      "singular": "syncauthorization",
+      "plural": "syncauthorizations"
+    },
+    "apigee.gcp.upbound.io/TargetServer": {
+      "singular": "targetserver",
+      "plural": "targetservers"
+    },
+    "appengine.gcp.m.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "appengine.gcp.m.upbound.io/ApplicationURLDispatchRules": {
+      "singular": "applicationurldispatchrules",
+      "plural": "applicationurldispatchrules"
+    },
+    "appengine.gcp.m.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "appengine.gcp.m.upbound.io/ServiceNetworkSettings": {
+      "singular": "servicenetworksettings",
+      "plural": "servicenetworksettings"
+    },
+    "appengine.gcp.m.upbound.io/StandardAppVersion": {
+      "singular": "standardappversion",
+      "plural": "standardappversions"
+    },
+    "appengine.gcp.upbound.io/Application": {
+      "singular": "application",
+      "plural": "applications"
+    },
+    "appengine.gcp.upbound.io/ApplicationURLDispatchRules": {
+      "singular": "applicationurldispatchrules",
+      "plural": "applicationurldispatchrules"
+    },
+    "appengine.gcp.upbound.io/FirewallRule": {
+      "singular": "firewallrule",
+      "plural": "firewallrules"
+    },
+    "appengine.gcp.upbound.io/ServiceNetworkSettings": {
+      "singular": "servicenetworksettings",
+      "plural": "servicenetworksettings"
+    },
+    "appengine.gcp.upbound.io/StandardAppVersion": {
+      "singular": "standardappversion",
+      "plural": "standardappversions"
+    },
+    "artifact.gcp.m.upbound.io/RegistryRepository": {
+      "singular": "registryrepository",
+      "plural": "registryrepositories"
+    },
+    "artifact.gcp.m.upbound.io/RegistryRepositoryIAMMember": {
+      "singular": "registryrepositoryiammember",
+      "plural": "registryrepositoryiammembers"
+    },
+    "artifact.gcp.upbound.io/RegistryRepository": {
+      "singular": "registryrepository",
+      "plural": "registryrepositories"
+    },
+    "artifact.gcp.upbound.io/RegistryRepositoryIAMMember": {
+      "singular": "registryrepositoryiammember",
+      "plural": "registryrepositoryiammembers"
+    },
+    "beyondcorp.gcp.m.upbound.io/AppConnection": {
+      "singular": "appconnection",
+      "plural": "appconnections"
+    },
+    "beyondcorp.gcp.m.upbound.io/AppConnector": {
+      "singular": "appconnector",
+      "plural": "appconnectors"
+    },
+    "beyondcorp.gcp.m.upbound.io/AppGateway": {
+      "singular": "appgateway",
+      "plural": "appgateways"
+    },
+    "beyondcorp.gcp.upbound.io/AppConnection": {
+      "singular": "appconnection",
+      "plural": "appconnections"
+    },
+    "beyondcorp.gcp.upbound.io/AppConnector": {
+      "singular": "appconnector",
+      "plural": "appconnectors"
+    },
+    "beyondcorp.gcp.upbound.io/AppGateway": {
+      "singular": "appgateway",
+      "plural": "appgateways"
+    },
+    "bigquery.gcp.m.upbound.io/AnalyticsHubDataExchange": {
+      "singular": "analyticshubdataexchange",
+      "plural": "analyticshubdataexchanges"
+    },
+    "bigquery.gcp.m.upbound.io/AnalyticsHubDataExchangeIAMMember": {
+      "singular": "analyticshubdataexchangeiammember",
+      "plural": "analyticshubdataexchangeiammembers"
+    },
+    "bigquery.gcp.m.upbound.io/AnalyticsHubListing": {
+      "singular": "analyticshublisting",
+      "plural": "analyticshublistings"
+    },
+    "bigquery.gcp.m.upbound.io/AnalyticsHubListingSubscription": {
+      "singular": "analyticshublistingsubscription",
+      "plural": "analyticshublistingsubscriptions"
+    },
+    "bigquery.gcp.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "bigquery.gcp.m.upbound.io/DataTransferConfig": {
+      "singular": "datatransferconfig",
+      "plural": "datatransferconfigs"
+    },
+    "bigquery.gcp.m.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "bigquery.gcp.m.upbound.io/DatasetAccess": {
+      "singular": "datasetaccess",
+      "plural": "datasetaccesses"
+    },
+    "bigquery.gcp.m.upbound.io/DatasetIAMBinding": {
+      "singular": "datasetiambinding",
+      "plural": "datasetiambindings"
+    },
+    "bigquery.gcp.m.upbound.io/DatasetIAMMember": {
+      "singular": "datasetiammember",
+      "plural": "datasetiammembers"
+    },
+    "bigquery.gcp.m.upbound.io/DatasetIAMPolicy": {
+      "singular": "datasetiampolicy",
+      "plural": "datasetiampolicies"
+    },
+    "bigquery.gcp.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "bigquery.gcp.m.upbound.io/Reservation": {
+      "singular": "reservation",
+      "plural": "reservations"
+    },
+    "bigquery.gcp.m.upbound.io/ReservationAssignment": {
+      "singular": "reservationassignment",
+      "plural": "reservationassignments"
+    },
+    "bigquery.gcp.m.upbound.io/Routine": {
+      "singular": "routine",
+      "plural": "routines"
+    },
+    "bigquery.gcp.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "bigquery.gcp.m.upbound.io/TableIAMBinding": {
+      "singular": "tableiambinding",
+      "plural": "tableiambindings"
+    },
+    "bigquery.gcp.m.upbound.io/TableIAMMember": {
+      "singular": "tableiammember",
+      "plural": "tableiammembers"
+    },
+    "bigquery.gcp.m.upbound.io/TableIAMPolicy": {
+      "singular": "tableiampolicy",
+      "plural": "tableiampolicies"
+    },
+    "bigquery.gcp.upbound.io/AnalyticsHubDataExchange": {
+      "singular": "analyticshubdataexchange",
+      "plural": "analyticshubdataexchanges"
+    },
+    "bigquery.gcp.upbound.io/AnalyticsHubDataExchangeIAMMember": {
+      "singular": "analyticshubdataexchangeiammember",
+      "plural": "analyticshubdataexchangeiammembers"
+    },
+    "bigquery.gcp.upbound.io/AnalyticsHubListing": {
+      "singular": "analyticshublisting",
+      "plural": "analyticshublistings"
+    },
+    "bigquery.gcp.upbound.io/AnalyticsHubListingSubscription": {
+      "singular": "analyticshublistingsubscription",
+      "plural": "analyticshublistingsubscriptions"
+    },
+    "bigquery.gcp.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "bigquery.gcp.upbound.io/DataTransferConfig": {
+      "singular": "datatransferconfig",
+      "plural": "datatransferconfigs"
+    },
+    "bigquery.gcp.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "bigquery.gcp.upbound.io/DatasetAccess": {
+      "singular": "datasetaccess",
+      "plural": "datasetaccesses"
+    },
+    "bigquery.gcp.upbound.io/DatasetIAMBinding": {
+      "singular": "datasetiambinding",
+      "plural": "datasetiambindings"
+    },
+    "bigquery.gcp.upbound.io/DatasetIAMMember": {
+      "singular": "datasetiammember",
+      "plural": "datasetiammembers"
+    },
+    "bigquery.gcp.upbound.io/DatasetIAMPolicy": {
+      "singular": "datasetiampolicy",
+      "plural": "datasetiampolicies"
+    },
+    "bigquery.gcp.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "bigquery.gcp.upbound.io/Reservation": {
+      "singular": "reservation",
+      "plural": "reservations"
+    },
+    "bigquery.gcp.upbound.io/ReservationAssignment": {
+      "singular": "reservationassignment",
+      "plural": "reservationassignments"
+    },
+    "bigquery.gcp.upbound.io/Routine": {
+      "singular": "routine",
+      "plural": "routines"
+    },
+    "bigquery.gcp.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "bigquery.gcp.upbound.io/TableIAMBinding": {
+      "singular": "tableiambinding",
+      "plural": "tableiambindings"
+    },
+    "bigquery.gcp.upbound.io/TableIAMMember": {
+      "singular": "tableiammember",
+      "plural": "tableiammembers"
+    },
+    "bigquery.gcp.upbound.io/TableIAMPolicy": {
+      "singular": "tableiampolicy",
+      "plural": "tableiampolicies"
+    },
+    "bigtable.gcp.m.upbound.io/AppProfile": {
+      "singular": "appprofile",
+      "plural": "appprofiles"
+    },
+    "bigtable.gcp.m.upbound.io/GarbageCollectionPolicy": {
+      "singular": "garbagecollectionpolicy",
+      "plural": "garbagecollectionpolicies"
+    },
+    "bigtable.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "bigtable.gcp.m.upbound.io/InstanceIAMBinding": {
+      "singular": "instanceiambinding",
+      "plural": "instanceiambindings"
+    },
+    "bigtable.gcp.m.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "bigtable.gcp.m.upbound.io/InstanceIAMPolicy": {
+      "singular": "instanceiampolicy",
+      "plural": "instanceiampolicies"
+    },
+    "bigtable.gcp.m.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "bigtable.gcp.m.upbound.io/TableIAMBinding": {
+      "singular": "tableiambinding",
+      "plural": "tableiambindings"
+    },
+    "bigtable.gcp.m.upbound.io/TableIAMMember": {
+      "singular": "tableiammember",
+      "plural": "tableiammembers"
+    },
+    "bigtable.gcp.m.upbound.io/TableIAMPolicy": {
+      "singular": "tableiampolicy",
+      "plural": "tableiampolicies"
+    },
+    "bigtable.gcp.upbound.io/AppProfile": {
+      "singular": "appprofile",
+      "plural": "appprofiles"
+    },
+    "bigtable.gcp.upbound.io/GarbageCollectionPolicy": {
+      "singular": "garbagecollectionpolicy",
+      "plural": "garbagecollectionpolicies"
+    },
+    "bigtable.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "bigtable.gcp.upbound.io/InstanceIAMBinding": {
+      "singular": "instanceiambinding",
+      "plural": "instanceiambindings"
+    },
+    "bigtable.gcp.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "bigtable.gcp.upbound.io/InstanceIAMPolicy": {
+      "singular": "instanceiampolicy",
+      "plural": "instanceiampolicies"
+    },
+    "bigtable.gcp.upbound.io/Table": {
+      "singular": "table",
+      "plural": "tables"
+    },
+    "bigtable.gcp.upbound.io/TableIAMBinding": {
+      "singular": "tableiambinding",
+      "plural": "tableiambindings"
+    },
+    "bigtable.gcp.upbound.io/TableIAMMember": {
+      "singular": "tableiammember",
+      "plural": "tableiammembers"
+    },
+    "bigtable.gcp.upbound.io/TableIAMPolicy": {
+      "singular": "tableiampolicy",
+      "plural": "tableiampolicies"
+    },
+    "binaryauthorization.gcp.m.upbound.io/Attestor": {
+      "singular": "attestor",
+      "plural": "attestors"
+    },
+    "binaryauthorization.gcp.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "binaryauthorization.gcp.upbound.io/Attestor": {
+      "singular": "attestor",
+      "plural": "attestors"
+    },
+    "binaryauthorization.gcp.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "certificatemanager.gcp.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "certificatemanager.gcp.m.upbound.io/CertificateMap": {
+      "singular": "certificatemap",
+      "plural": "certificatemaps"
+    },
+    "certificatemanager.gcp.m.upbound.io/CertificateMapEntry": {
+      "singular": "certificatemapentry",
+      "plural": "certificatemapentries"
+    },
+    "certificatemanager.gcp.m.upbound.io/DNSAuthorization": {
+      "singular": "dnsauthorization",
+      "plural": "dnsauthorizations"
+    },
+    "certificatemanager.gcp.m.upbound.io/TrustConfig": {
+      "singular": "trustconfig",
+      "plural": "trustconfigs"
+    },
+    "certificatemanager.gcp.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "certificatemanager.gcp.upbound.io/CertificateMap": {
+      "singular": "certificatemap",
+      "plural": "certificatemaps"
+    },
+    "certificatemanager.gcp.upbound.io/CertificateMapEntry": {
+      "singular": "certificatemapentry",
+      "plural": "certificatemapentries"
+    },
+    "certificatemanager.gcp.upbound.io/DNSAuthorization": {
+      "singular": "dnsauthorization",
+      "plural": "dnsauthorizations"
+    },
+    "certificatemanager.gcp.upbound.io/TrustConfig": {
+      "singular": "trustconfig",
+      "plural": "trustconfigs"
+    },
+    "cloud.gcp.m.upbound.io/IdsEndpoint": {
+      "singular": "idsendpoint",
+      "plural": "idsendpoints"
+    },
+    "cloud.gcp.upbound.io/IdsEndpoint": {
+      "singular": "idsendpoint",
+      "plural": "idsendpoints"
+    },
+    "cloudbuild.gcp.m.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "cloudbuild.gcp.m.upbound.io/WorkerPool": {
+      "singular": "workerpool",
+      "plural": "workerpools"
+    },
+    "cloudbuild.gcp.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "cloudbuild.gcp.upbound.io/WorkerPool": {
+      "singular": "workerpool",
+      "plural": "workerpools"
+    },
+    "cloudfunctions.gcp.m.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudfunctions.gcp.m.upbound.io/FunctionIAMMember": {
+      "singular": "functioniammember",
+      "plural": "functioniammembers"
+    },
+    "cloudfunctions.gcp.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudfunctions.gcp.upbound.io/FunctionIAMMember": {
+      "singular": "functioniammember",
+      "plural": "functioniammembers"
+    },
+    "cloudfunctions2.gcp.m.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudfunctions2.gcp.upbound.io/Function": {
+      "singular": "function",
+      "plural": "functions"
+    },
+    "cloudidentity.gcp.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "cloudidentity.gcp.m.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "cloudidentity.gcp.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "cloudidentity.gcp.upbound.io/GroupMembership": {
+      "singular": "groupmembership",
+      "plural": "groupmemberships"
+    },
+    "cloudplatform.gcp.m.upbound.io/Folder": {
+      "singular": "folder",
+      "plural": "folders"
+    },
+    "cloudplatform.gcp.m.upbound.io/FolderIAMMember": {
+      "singular": "folderiammember",
+      "plural": "folderiammembers"
+    },
+    "cloudplatform.gcp.m.upbound.io/OrganizationIAMAuditConfig": {
+      "singular": "organizationiamauditconfig",
+      "plural": "organizationiamauditconfigs"
+    },
+    "cloudplatform.gcp.m.upbound.io/OrganizationIAMCustomRole": {
+      "singular": "organizationiamcustomrole",
+      "plural": "organizationiamcustomroles"
+    },
+    "cloudplatform.gcp.m.upbound.io/OrganizationIAMMember": {
+      "singular": "organizationiammember",
+      "plural": "organizationiammembers"
+    },
+    "cloudplatform.gcp.m.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectDefaultServiceAccounts": {
+      "singular": "projectdefaultserviceaccounts",
+      "plural": "projectdefaultserviceaccounts"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectIAMAuditConfig": {
+      "singular": "projectiamauditconfig",
+      "plural": "projectiamauditconfigs"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectIAMCustomRole": {
+      "singular": "projectiamcustomrole",
+      "plural": "projectiamcustomroles"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectIAMMember": {
+      "singular": "projectiammember",
+      "plural": "projectiammembers"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectService": {
+      "singular": "projectservice",
+      "plural": "projectservices"
+    },
+    "cloudplatform.gcp.m.upbound.io/ProjectUsageExportBucket": {
+      "singular": "projectusageexportbucket",
+      "plural": "projectusageexportbuckets"
+    },
+    "cloudplatform.gcp.m.upbound.io/ServiceAccount": {
+      "singular": "serviceaccount",
+      "plural": "serviceaccounts"
+    },
+    "cloudplatform.gcp.m.upbound.io/ServiceAccountIAMMember": {
+      "singular": "serviceaccountiammember",
+      "plural": "serviceaccountiammembers"
+    },
+    "cloudplatform.gcp.m.upbound.io/ServiceAccountKey": {
+      "singular": "serviceaccountkey",
+      "plural": "serviceaccountkeys"
+    },
+    "cloudplatform.gcp.m.upbound.io/ServiceNetworkingPeeredDNSDomain": {
+      "singular": "servicenetworkingpeereddnsdomain",
+      "plural": "servicenetworkingpeereddnsdomains"
+    },
+    "cloudplatform.gcp.upbound.io/Folder": {
+      "singular": "folder",
+      "plural": "folders"
+    },
+    "cloudplatform.gcp.upbound.io/FolderIAMMember": {
+      "singular": "folderiammember",
+      "plural": "folderiammembers"
+    },
+    "cloudplatform.gcp.upbound.io/OrganizationIAMAuditConfig": {
+      "singular": "organizationiamauditconfig",
+      "plural": "organizationiamauditconfigs"
+    },
+    "cloudplatform.gcp.upbound.io/OrganizationIAMCustomRole": {
+      "singular": "organizationiamcustomrole",
+      "plural": "organizationiamcustomroles"
+    },
+    "cloudplatform.gcp.upbound.io/OrganizationIAMMember": {
+      "singular": "organizationiammember",
+      "plural": "organizationiammembers"
+    },
+    "cloudplatform.gcp.upbound.io/Project": {
+      "singular": "project",
+      "plural": "projects"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectDefaultServiceAccounts": {
+      "singular": "projectdefaultserviceaccounts",
+      "plural": "projectdefaultserviceaccounts"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectIAMAuditConfig": {
+      "singular": "projectiamauditconfig",
+      "plural": "projectiamauditconfigs"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectIAMCustomRole": {
+      "singular": "projectiamcustomrole",
+      "plural": "projectiamcustomroles"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectIAMMember": {
+      "singular": "projectiammember",
+      "plural": "projectiammembers"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectService": {
+      "singular": "projectservice",
+      "plural": "projectservices"
+    },
+    "cloudplatform.gcp.upbound.io/ProjectUsageExportBucket": {
+      "singular": "projectusageexportbucket",
+      "plural": "projectusageexportbuckets"
+    },
+    "cloudplatform.gcp.upbound.io/ServiceAccount": {
+      "singular": "serviceaccount",
+      "plural": "serviceaccounts"
+    },
+    "cloudplatform.gcp.upbound.io/ServiceAccountIAMMember": {
+      "singular": "serviceaccountiammember",
+      "plural": "serviceaccountiammembers"
+    },
+    "cloudplatform.gcp.upbound.io/ServiceAccountKey": {
+      "singular": "serviceaccountkey",
+      "plural": "serviceaccountkeys"
+    },
+    "cloudplatform.gcp.upbound.io/ServiceNetworkingPeeredDNSDomain": {
+      "singular": "servicenetworkingpeereddnsdomain",
+      "plural": "servicenetworkingpeereddnsdomains"
+    },
+    "cloudquotas.gcp.m.upbound.io/QuotaPreference": {
+      "singular": "quotapreference",
+      "plural": "quotapreferences"
+    },
+    "cloudquotas.gcp.upbound.io/QuotaPreference": {
+      "singular": "quotapreference",
+      "plural": "quotapreferences"
+    },
+    "cloudrun.gcp.m.upbound.io/DomainMapping": {
+      "singular": "domainmapping",
+      "plural": "domainmappings"
+    },
+    "cloudrun.gcp.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "cloudrun.gcp.m.upbound.io/ServiceIAMMember": {
+      "singular": "serviceiammember",
+      "plural": "serviceiammembers"
+    },
+    "cloudrun.gcp.m.upbound.io/V2Job": {
+      "singular": "v2job",
+      "plural": "v2jobs"
+    },
+    "cloudrun.gcp.m.upbound.io/V2Service": {
+      "singular": "v2service",
+      "plural": "v2services"
+    },
+    "cloudrun.gcp.upbound.io/DomainMapping": {
+      "singular": "domainmapping",
+      "plural": "domainmappings"
+    },
+    "cloudrun.gcp.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "cloudrun.gcp.upbound.io/ServiceIAMMember": {
+      "singular": "serviceiammember",
+      "plural": "serviceiammembers"
+    },
+    "cloudrun.gcp.upbound.io/V2Job": {
+      "singular": "v2job",
+      "plural": "v2jobs"
+    },
+    "cloudrun.gcp.upbound.io/V2Service": {
+      "singular": "v2service",
+      "plural": "v2services"
+    },
+    "cloudscheduler.gcp.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "cloudscheduler.gcp.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "cloudtasks.gcp.m.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "cloudtasks.gcp.upbound.io/Queue": {
+      "singular": "queue",
+      "plural": "queues"
+    },
+    "composer.gcp.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "composer.gcp.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "compute.gcp.m.upbound.io/Address": {
+      "singular": "address",
+      "plural": "addresses"
+    },
+    "compute.gcp.m.upbound.io/AttachedDisk": {
+      "singular": "attacheddisk",
+      "plural": "attacheddisks"
+    },
+    "compute.gcp.m.upbound.io/Autoscaler": {
+      "singular": "autoscaler",
+      "plural": "autoscalers"
+    },
+    "compute.gcp.m.upbound.io/BackendBucket": {
+      "singular": "backendbucket",
+      "plural": "backendbuckets"
+    },
+    "compute.gcp.m.upbound.io/BackendBucketSignedURLKey": {
+      "singular": "backendbucketsignedurlkey",
+      "plural": "backendbucketsignedurlkeys"
+    },
+    "compute.gcp.m.upbound.io/BackendService": {
+      "singular": "backendservice",
+      "plural": "backendservices"
+    },
+    "compute.gcp.m.upbound.io/BackendServiceSignedURLKey": {
+      "singular": "backendservicesignedurlkey",
+      "plural": "backendservicesignedurlkeys"
+    },
+    "compute.gcp.m.upbound.io/Disk": {
+      "singular": "disk",
+      "plural": "disks"
+    },
+    "compute.gcp.m.upbound.io/DiskIAMMember": {
+      "singular": "diskiammember",
+      "plural": "diskiammembers"
+    },
+    "compute.gcp.m.upbound.io/DiskResourcePolicyAttachment": {
+      "singular": "diskresourcepolicyattachment",
+      "plural": "diskresourcepolicyattachments"
+    },
+    "compute.gcp.m.upbound.io/ExternalVPNGateway": {
+      "singular": "externalvpngateway",
+      "plural": "externalvpngateways"
+    },
+    "compute.gcp.m.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "compute.gcp.m.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "compute.gcp.m.upbound.io/FirewallPolicyAssociation": {
+      "singular": "firewallpolicyassociation",
+      "plural": "firewallpolicyassociations"
+    },
+    "compute.gcp.m.upbound.io/FirewallPolicyRule": {
+      "singular": "firewallpolicyrule",
+      "plural": "firewallpolicyrules"
+    },
+    "compute.gcp.m.upbound.io/ForwardingRule": {
+      "singular": "forwardingrule",
+      "plural": "forwardingrules"
+    },
+    "compute.gcp.m.upbound.io/GlobalAddress": {
+      "singular": "globaladdress",
+      "plural": "globaladdresses"
+    },
+    "compute.gcp.m.upbound.io/GlobalForwardingRule": {
+      "singular": "globalforwardingrule",
+      "plural": "globalforwardingrules"
+    },
+    "compute.gcp.m.upbound.io/GlobalNetworkEndpoint": {
+      "singular": "globalnetworkendpoint",
+      "plural": "globalnetworkendpoints"
+    },
+    "compute.gcp.m.upbound.io/GlobalNetworkEndpointGroup": {
+      "singular": "globalnetworkendpointgroup",
+      "plural": "globalnetworkendpointgroups"
+    },
+    "compute.gcp.m.upbound.io/HTTPHealthCheck": {
+      "singular": "httphealthcheck",
+      "plural": "httphealthchecks"
+    },
+    "compute.gcp.m.upbound.io/HTTPSHealthCheck": {
+      "singular": "httpshealthcheck",
+      "plural": "httpshealthchecks"
+    },
+    "compute.gcp.m.upbound.io/HaVPNGateway": {
+      "singular": "havpngateway",
+      "plural": "havpngateways"
+    },
+    "compute.gcp.m.upbound.io/HealthCheck": {
+      "singular": "healthcheck",
+      "plural": "healthchecks"
+    },
+    "compute.gcp.m.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "compute.gcp.m.upbound.io/ImageIAMMember": {
+      "singular": "imageiammember",
+      "plural": "imageiammembers"
+    },
+    "compute.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "compute.gcp.m.upbound.io/InstanceFromTemplate": {
+      "singular": "instancefromtemplate",
+      "plural": "instancefromtemplates"
+    },
+    "compute.gcp.m.upbound.io/InstanceGroup": {
+      "singular": "instancegroup",
+      "plural": "instancegroups"
+    },
+    "compute.gcp.m.upbound.io/InstanceGroupManager": {
+      "singular": "instancegroupmanager",
+      "plural": "instancegroupmanagers"
+    },
+    "compute.gcp.m.upbound.io/InstanceGroupNamedPort": {
+      "singular": "instancegroupnamedport",
+      "plural": "instancegroupnamedports"
+    },
+    "compute.gcp.m.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "compute.gcp.m.upbound.io/InstanceTemplate": {
+      "singular": "instancetemplate",
+      "plural": "instancetemplates"
+    },
+    "compute.gcp.m.upbound.io/InterconnectAttachment": {
+      "singular": "interconnectattachment",
+      "plural": "interconnectattachments"
+    },
+    "compute.gcp.m.upbound.io/ManagedSSLCertificate": {
+      "singular": "managedsslcertificate",
+      "plural": "managedsslcertificates"
+    },
+    "compute.gcp.m.upbound.io/Network": {
+      "singular": "network",
+      "plural": "networks"
+    },
+    "compute.gcp.m.upbound.io/NetworkEndpoint": {
+      "singular": "networkendpoint",
+      "plural": "networkendpoints"
+    },
+    "compute.gcp.m.upbound.io/NetworkEndpointGroup": {
+      "singular": "networkendpointgroup",
+      "plural": "networkendpointgroups"
+    },
+    "compute.gcp.m.upbound.io/NetworkFirewallPolicy": {
+      "singular": "networkfirewallpolicy",
+      "plural": "networkfirewallpolicies"
+    },
+    "compute.gcp.m.upbound.io/NetworkFirewallPolicyAssociation": {
+      "singular": "networkfirewallpolicyassociation",
+      "plural": "networkfirewallpolicyassociations"
+    },
+    "compute.gcp.m.upbound.io/NetworkFirewallPolicyRule": {
+      "singular": "networkfirewallpolicyrule",
+      "plural": "networkfirewallpolicyrules"
+    },
+    "compute.gcp.m.upbound.io/NetworkPeering": {
+      "singular": "networkpeering",
+      "plural": "networkpeerings"
+    },
+    "compute.gcp.m.upbound.io/NetworkPeeringRoutesConfig": {
+      "singular": "networkpeeringroutesconfig",
+      "plural": "networkpeeringroutesconfigs"
+    },
+    "compute.gcp.m.upbound.io/NodeGroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups"
+    },
+    "compute.gcp.m.upbound.io/NodeTemplate": {
+      "singular": "nodetemplate",
+      "plural": "nodetemplates"
+    },
+    "compute.gcp.m.upbound.io/PacketMirroring": {
+      "singular": "packetmirroring",
+      "plural": "packetmirrorings"
+    },
+    "compute.gcp.m.upbound.io/PerInstanceConfig": {
+      "singular": "perinstanceconfig",
+      "plural": "perinstanceconfigs"
+    },
+    "compute.gcp.m.upbound.io/ProjectDefaultNetworkTier": {
+      "singular": "projectdefaultnetworktier",
+      "plural": "projectdefaultnetworktiers"
+    },
+    "compute.gcp.m.upbound.io/ProjectMetadata": {
+      "singular": "projectmetadata",
+      "plural": "projectmetadata"
+    },
+    "compute.gcp.m.upbound.io/ProjectMetadataItem": {
+      "singular": "projectmetadataitem",
+      "plural": "projectmetadataitems"
+    },
+    "compute.gcp.m.upbound.io/RegionAutoscaler": {
+      "singular": "regionautoscaler",
+      "plural": "regionautoscalers"
+    },
+    "compute.gcp.m.upbound.io/RegionBackendService": {
+      "singular": "regionbackendservice",
+      "plural": "regionbackendservices"
+    },
+    "compute.gcp.m.upbound.io/RegionDisk": {
+      "singular": "regiondisk",
+      "plural": "regiondisks"
+    },
+    "compute.gcp.m.upbound.io/RegionDiskIAMMember": {
+      "singular": "regiondiskiammember",
+      "plural": "regiondiskiammembers"
+    },
+    "compute.gcp.m.upbound.io/RegionDiskResourcePolicyAttachment": {
+      "singular": "regiondiskresourcepolicyattachment",
+      "plural": "regiondiskresourcepolicyattachments"
+    },
+    "compute.gcp.m.upbound.io/RegionHealthCheck": {
+      "singular": "regionhealthcheck",
+      "plural": "regionhealthchecks"
+    },
+    "compute.gcp.m.upbound.io/RegionInstanceGroupManager": {
+      "singular": "regioninstancegroupmanager",
+      "plural": "regioninstancegroupmanagers"
+    },
+    "compute.gcp.m.upbound.io/RegionNetworkEndpoint": {
+      "singular": "regionnetworkendpoint",
+      "plural": "regionnetworkendpoints"
+    },
+    "compute.gcp.m.upbound.io/RegionNetworkEndpointGroup": {
+      "singular": "regionnetworkendpointgroup",
+      "plural": "regionnetworkendpointgroups"
+    },
+    "compute.gcp.m.upbound.io/RegionNetworkFirewallPolicy": {
+      "singular": "regionnetworkfirewallpolicy",
+      "plural": "regionnetworkfirewallpolicies"
+    },
+    "compute.gcp.m.upbound.io/RegionNetworkFirewallPolicyAssociation": {
+      "singular": "regionnetworkfirewallpolicyassociation",
+      "plural": "regionnetworkfirewallpolicyassociations"
+    },
+    "compute.gcp.m.upbound.io/RegionPerInstanceConfig": {
+      "singular": "regionperinstanceconfig",
+      "plural": "regionperinstanceconfigs"
+    },
+    "compute.gcp.m.upbound.io/RegionSSLCertificate": {
+      "singular": "regionsslcertificate",
+      "plural": "regionsslcertificates"
+    },
+    "compute.gcp.m.upbound.io/RegionSSLPolicy": {
+      "singular": "regionsslpolicy",
+      "plural": "regionsslpolicies"
+    },
+    "compute.gcp.m.upbound.io/RegionSecurityPolicy": {
+      "singular": "regionsecuritypolicy",
+      "plural": "regionsecuritypolicies"
+    },
+    "compute.gcp.m.upbound.io/RegionTargetHTTPProxy": {
+      "singular": "regiontargethttpproxy",
+      "plural": "regiontargethttpproxies"
+    },
+    "compute.gcp.m.upbound.io/RegionTargetHTTPSProxy": {
+      "singular": "regiontargethttpsproxy",
+      "plural": "regiontargethttpsproxies"
+    },
+    "compute.gcp.m.upbound.io/RegionTargetTCPProxy": {
+      "singular": "regiontargettcpproxy",
+      "plural": "regiontargettcpproxies"
+    },
+    "compute.gcp.m.upbound.io/RegionURLMap": {
+      "singular": "regionurlmap",
+      "plural": "regionurlmaps"
+    },
+    "compute.gcp.m.upbound.io/Reservation": {
+      "singular": "reservation",
+      "plural": "reservations"
+    },
+    "compute.gcp.m.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "compute.gcp.m.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "compute.gcp.m.upbound.io/Router": {
+      "singular": "router",
+      "plural": "routers"
+    },
+    "compute.gcp.m.upbound.io/RouterInterface": {
+      "singular": "routerinterface",
+      "plural": "routerinterfaces"
+    },
+    "compute.gcp.m.upbound.io/RouterNAT": {
+      "singular": "routernat",
+      "plural": "routernats"
+    },
+    "compute.gcp.m.upbound.io/RouterPeer": {
+      "singular": "routerpeer",
+      "plural": "routerpeers"
+    },
+    "compute.gcp.m.upbound.io/SSLCertificate": {
+      "singular": "sslcertificate",
+      "plural": "sslcertificates"
+    },
+    "compute.gcp.m.upbound.io/SSLPolicy": {
+      "singular": "sslpolicy",
+      "plural": "sslpolicies"
+    },
+    "compute.gcp.m.upbound.io/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies"
+    },
+    "compute.gcp.m.upbound.io/ServiceAttachment": {
+      "singular": "serviceattachment",
+      "plural": "serviceattachments"
+    },
+    "compute.gcp.m.upbound.io/SharedVPCHostProject": {
+      "singular": "sharedvpchostproject",
+      "plural": "sharedvpchostprojects"
+    },
+    "compute.gcp.m.upbound.io/SharedVPCServiceProject": {
+      "singular": "sharedvpcserviceproject",
+      "plural": "sharedvpcserviceprojects"
+    },
+    "compute.gcp.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "compute.gcp.m.upbound.io/SnapshotIAMMember": {
+      "singular": "snapshotiammember",
+      "plural": "snapshotiammembers"
+    },
+    "compute.gcp.m.upbound.io/Subnetwork": {
+      "singular": "subnetwork",
+      "plural": "subnetworks"
+    },
+    "compute.gcp.m.upbound.io/SubnetworkIAMMember": {
+      "singular": "subnetworkiammember",
+      "plural": "subnetworkiammembers"
+    },
+    "compute.gcp.m.upbound.io/TargetGRPCProxy": {
+      "singular": "targetgrpcproxy",
+      "plural": "targetgrpcproxies"
+    },
+    "compute.gcp.m.upbound.io/TargetHTTPProxy": {
+      "singular": "targethttpproxy",
+      "plural": "targethttpproxies"
+    },
+    "compute.gcp.m.upbound.io/TargetHTTPSProxy": {
+      "singular": "targethttpsproxy",
+      "plural": "targethttpsproxies"
+    },
+    "compute.gcp.m.upbound.io/TargetInstance": {
+      "singular": "targetinstance",
+      "plural": "targetinstances"
+    },
+    "compute.gcp.m.upbound.io/TargetPool": {
+      "singular": "targetpool",
+      "plural": "targetpools"
+    },
+    "compute.gcp.m.upbound.io/TargetSSLProxy": {
+      "singular": "targetsslproxy",
+      "plural": "targetsslproxies"
+    },
+    "compute.gcp.m.upbound.io/TargetTCPProxy": {
+      "singular": "targettcpproxy",
+      "plural": "targettcpproxies"
+    },
+    "compute.gcp.m.upbound.io/URLMap": {
+      "singular": "urlmap",
+      "plural": "urlmaps"
+    },
+    "compute.gcp.m.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "compute.gcp.m.upbound.io/VPNTunnel": {
+      "singular": "vpntunnel",
+      "plural": "vpntunnels"
+    },
+    "compute.gcp.upbound.io/Address": {
+      "singular": "address",
+      "plural": "addresses"
+    },
+    "compute.gcp.upbound.io/AttachedDisk": {
+      "singular": "attacheddisk",
+      "plural": "attacheddisks"
+    },
+    "compute.gcp.upbound.io/Autoscaler": {
+      "singular": "autoscaler",
+      "plural": "autoscalers"
+    },
+    "compute.gcp.upbound.io/BackendBucket": {
+      "singular": "backendbucket",
+      "plural": "backendbuckets"
+    },
+    "compute.gcp.upbound.io/BackendBucketSignedURLKey": {
+      "singular": "backendbucketsignedurlkey",
+      "plural": "backendbucketsignedurlkeys"
+    },
+    "compute.gcp.upbound.io/BackendService": {
+      "singular": "backendservice",
+      "plural": "backendservices"
+    },
+    "compute.gcp.upbound.io/BackendServiceSignedURLKey": {
+      "singular": "backendservicesignedurlkey",
+      "plural": "backendservicesignedurlkeys"
+    },
+    "compute.gcp.upbound.io/Disk": {
+      "singular": "disk",
+      "plural": "disks"
+    },
+    "compute.gcp.upbound.io/DiskIAMMember": {
+      "singular": "diskiammember",
+      "plural": "diskiammembers"
+    },
+    "compute.gcp.upbound.io/DiskResourcePolicyAttachment": {
+      "singular": "diskresourcepolicyattachment",
+      "plural": "diskresourcepolicyattachments"
+    },
+    "compute.gcp.upbound.io/ExternalVPNGateway": {
+      "singular": "externalvpngateway",
+      "plural": "externalvpngateways"
+    },
+    "compute.gcp.upbound.io/Firewall": {
+      "singular": "firewall",
+      "plural": "firewalls"
+    },
+    "compute.gcp.upbound.io/FirewallPolicy": {
+      "singular": "firewallpolicy",
+      "plural": "firewallpolicies"
+    },
+    "compute.gcp.upbound.io/FirewallPolicyAssociation": {
+      "singular": "firewallpolicyassociation",
+      "plural": "firewallpolicyassociations"
+    },
+    "compute.gcp.upbound.io/FirewallPolicyRule": {
+      "singular": "firewallpolicyrule",
+      "plural": "firewallpolicyrules"
+    },
+    "compute.gcp.upbound.io/ForwardingRule": {
+      "singular": "forwardingrule",
+      "plural": "forwardingrules"
+    },
+    "compute.gcp.upbound.io/GlobalAddress": {
+      "singular": "globaladdress",
+      "plural": "globaladdresses"
+    },
+    "compute.gcp.upbound.io/GlobalForwardingRule": {
+      "singular": "globalforwardingrule",
+      "plural": "globalforwardingrules"
+    },
+    "compute.gcp.upbound.io/GlobalNetworkEndpoint": {
+      "singular": "globalnetworkendpoint",
+      "plural": "globalnetworkendpoints"
+    },
+    "compute.gcp.upbound.io/GlobalNetworkEndpointGroup": {
+      "singular": "globalnetworkendpointgroup",
+      "plural": "globalnetworkendpointgroups"
+    },
+    "compute.gcp.upbound.io/HTTPHealthCheck": {
+      "singular": "httphealthcheck",
+      "plural": "httphealthchecks"
+    },
+    "compute.gcp.upbound.io/HTTPSHealthCheck": {
+      "singular": "httpshealthcheck",
+      "plural": "httpshealthchecks"
+    },
+    "compute.gcp.upbound.io/HaVPNGateway": {
+      "singular": "havpngateway",
+      "plural": "havpngateways"
+    },
+    "compute.gcp.upbound.io/HealthCheck": {
+      "singular": "healthcheck",
+      "plural": "healthchecks"
+    },
+    "compute.gcp.upbound.io/Image": {
+      "singular": "image",
+      "plural": "images"
+    },
+    "compute.gcp.upbound.io/ImageIAMMember": {
+      "singular": "imageiammember",
+      "plural": "imageiammembers"
+    },
+    "compute.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "compute.gcp.upbound.io/InstanceFromTemplate": {
+      "singular": "instancefromtemplate",
+      "plural": "instancefromtemplates"
+    },
+    "compute.gcp.upbound.io/InstanceGroup": {
+      "singular": "instancegroup",
+      "plural": "instancegroups"
+    },
+    "compute.gcp.upbound.io/InstanceGroupManager": {
+      "singular": "instancegroupmanager",
+      "plural": "instancegroupmanagers"
+    },
+    "compute.gcp.upbound.io/InstanceGroupNamedPort": {
+      "singular": "instancegroupnamedport",
+      "plural": "instancegroupnamedports"
+    },
+    "compute.gcp.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "compute.gcp.upbound.io/InstanceTemplate": {
+      "singular": "instancetemplate",
+      "plural": "instancetemplates"
+    },
+    "compute.gcp.upbound.io/InterconnectAttachment": {
+      "singular": "interconnectattachment",
+      "plural": "interconnectattachments"
+    },
+    "compute.gcp.upbound.io/ManagedSSLCertificate": {
+      "singular": "managedsslcertificate",
+      "plural": "managedsslcertificates"
+    },
+    "compute.gcp.upbound.io/Network": {
+      "singular": "network",
+      "plural": "networks"
+    },
+    "compute.gcp.upbound.io/NetworkEndpoint": {
+      "singular": "networkendpoint",
+      "plural": "networkendpoints"
+    },
+    "compute.gcp.upbound.io/NetworkEndpointGroup": {
+      "singular": "networkendpointgroup",
+      "plural": "networkendpointgroups"
+    },
+    "compute.gcp.upbound.io/NetworkFirewallPolicy": {
+      "singular": "networkfirewallpolicy",
+      "plural": "networkfirewallpolicies"
+    },
+    "compute.gcp.upbound.io/NetworkFirewallPolicyAssociation": {
+      "singular": "networkfirewallpolicyassociation",
+      "plural": "networkfirewallpolicyassociations"
+    },
+    "compute.gcp.upbound.io/NetworkFirewallPolicyRule": {
+      "singular": "networkfirewallpolicyrule",
+      "plural": "networkfirewallpolicyrules"
+    },
+    "compute.gcp.upbound.io/NetworkPeering": {
+      "singular": "networkpeering",
+      "plural": "networkpeerings"
+    },
+    "compute.gcp.upbound.io/NetworkPeeringRoutesConfig": {
+      "singular": "networkpeeringroutesconfig",
+      "plural": "networkpeeringroutesconfigs"
+    },
+    "compute.gcp.upbound.io/NodeGroup": {
+      "singular": "nodegroup",
+      "plural": "nodegroups"
+    },
+    "compute.gcp.upbound.io/NodeTemplate": {
+      "singular": "nodetemplate",
+      "plural": "nodetemplates"
+    },
+    "compute.gcp.upbound.io/PacketMirroring": {
+      "singular": "packetmirroring",
+      "plural": "packetmirrorings"
+    },
+    "compute.gcp.upbound.io/PerInstanceConfig": {
+      "singular": "perinstanceconfig",
+      "plural": "perinstanceconfigs"
+    },
+    "compute.gcp.upbound.io/ProjectDefaultNetworkTier": {
+      "singular": "projectdefaultnetworktier",
+      "plural": "projectdefaultnetworktiers"
+    },
+    "compute.gcp.upbound.io/ProjectMetadata": {
+      "singular": "projectmetadata",
+      "plural": "projectmetadata"
+    },
+    "compute.gcp.upbound.io/ProjectMetadataItem": {
+      "singular": "projectmetadataitem",
+      "plural": "projectmetadataitems"
+    },
+    "compute.gcp.upbound.io/RegionAutoscaler": {
+      "singular": "regionautoscaler",
+      "plural": "regionautoscalers"
+    },
+    "compute.gcp.upbound.io/RegionBackendService": {
+      "singular": "regionbackendservice",
+      "plural": "regionbackendservices"
+    },
+    "compute.gcp.upbound.io/RegionDisk": {
+      "singular": "regiondisk",
+      "plural": "regiondisks"
+    },
+    "compute.gcp.upbound.io/RegionDiskIAMMember": {
+      "singular": "regiondiskiammember",
+      "plural": "regiondiskiammembers"
+    },
+    "compute.gcp.upbound.io/RegionDiskResourcePolicyAttachment": {
+      "singular": "regiondiskresourcepolicyattachment",
+      "plural": "regiondiskresourcepolicyattachments"
+    },
+    "compute.gcp.upbound.io/RegionHealthCheck": {
+      "singular": "regionhealthcheck",
+      "plural": "regionhealthchecks"
+    },
+    "compute.gcp.upbound.io/RegionInstanceGroupManager": {
+      "singular": "regioninstancegroupmanager",
+      "plural": "regioninstancegroupmanagers"
+    },
+    "compute.gcp.upbound.io/RegionNetworkEndpoint": {
+      "singular": "regionnetworkendpoint",
+      "plural": "regionnetworkendpoints"
+    },
+    "compute.gcp.upbound.io/RegionNetworkEndpointGroup": {
+      "singular": "regionnetworkendpointgroup",
+      "plural": "regionnetworkendpointgroups"
+    },
+    "compute.gcp.upbound.io/RegionNetworkFirewallPolicy": {
+      "singular": "regionnetworkfirewallpolicy",
+      "plural": "regionnetworkfirewallpolicies"
+    },
+    "compute.gcp.upbound.io/RegionNetworkFirewallPolicyAssociation": {
+      "singular": "regionnetworkfirewallpolicyassociation",
+      "plural": "regionnetworkfirewallpolicyassociations"
+    },
+    "compute.gcp.upbound.io/RegionPerInstanceConfig": {
+      "singular": "regionperinstanceconfig",
+      "plural": "regionperinstanceconfigs"
+    },
+    "compute.gcp.upbound.io/RegionSSLCertificate": {
+      "singular": "regionsslcertificate",
+      "plural": "regionsslcertificates"
+    },
+    "compute.gcp.upbound.io/RegionSSLPolicy": {
+      "singular": "regionsslpolicy",
+      "plural": "regionsslpolicies"
+    },
+    "compute.gcp.upbound.io/RegionSecurityPolicy": {
+      "singular": "regionsecuritypolicy",
+      "plural": "regionsecuritypolicies"
+    },
+    "compute.gcp.upbound.io/RegionTargetHTTPProxy": {
+      "singular": "regiontargethttpproxy",
+      "plural": "regiontargethttpproxies"
+    },
+    "compute.gcp.upbound.io/RegionTargetHTTPSProxy": {
+      "singular": "regiontargethttpsproxy",
+      "plural": "regiontargethttpsproxies"
+    },
+    "compute.gcp.upbound.io/RegionTargetTCPProxy": {
+      "singular": "regiontargettcpproxy",
+      "plural": "regiontargettcpproxies"
+    },
+    "compute.gcp.upbound.io/RegionURLMap": {
+      "singular": "regionurlmap",
+      "plural": "regionurlmaps"
+    },
+    "compute.gcp.upbound.io/Reservation": {
+      "singular": "reservation",
+      "plural": "reservations"
+    },
+    "compute.gcp.upbound.io/ResourcePolicy": {
+      "singular": "resourcepolicy",
+      "plural": "resourcepolicies"
+    },
+    "compute.gcp.upbound.io/Route": {
+      "singular": "route",
+      "plural": "routes"
+    },
+    "compute.gcp.upbound.io/Router": {
+      "singular": "router",
+      "plural": "routers"
+    },
+    "compute.gcp.upbound.io/RouterInterface": {
+      "singular": "routerinterface",
+      "plural": "routerinterfaces"
+    },
+    "compute.gcp.upbound.io/RouterNAT": {
+      "singular": "routernat",
+      "plural": "routernats"
+    },
+    "compute.gcp.upbound.io/RouterPeer": {
+      "singular": "routerpeer",
+      "plural": "routerpeers"
+    },
+    "compute.gcp.upbound.io/SSLCertificate": {
+      "singular": "sslcertificate",
+      "plural": "sslcertificates"
+    },
+    "compute.gcp.upbound.io/SSLPolicy": {
+      "singular": "sslpolicy",
+      "plural": "sslpolicies"
+    },
+    "compute.gcp.upbound.io/SecurityPolicy": {
+      "singular": "securitypolicy",
+      "plural": "securitypolicies"
+    },
+    "compute.gcp.upbound.io/ServiceAttachment": {
+      "singular": "serviceattachment",
+      "plural": "serviceattachments"
+    },
+    "compute.gcp.upbound.io/SharedVPCHostProject": {
+      "singular": "sharedvpchostproject",
+      "plural": "sharedvpchostprojects"
+    },
+    "compute.gcp.upbound.io/SharedVPCServiceProject": {
+      "singular": "sharedvpcserviceproject",
+      "plural": "sharedvpcserviceprojects"
+    },
+    "compute.gcp.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "compute.gcp.upbound.io/SnapshotIAMMember": {
+      "singular": "snapshotiammember",
+      "plural": "snapshotiammembers"
+    },
+    "compute.gcp.upbound.io/Subnetwork": {
+      "singular": "subnetwork",
+      "plural": "subnetworks"
+    },
+    "compute.gcp.upbound.io/SubnetworkIAMMember": {
+      "singular": "subnetworkiammember",
+      "plural": "subnetworkiammembers"
+    },
+    "compute.gcp.upbound.io/TargetGRPCProxy": {
+      "singular": "targetgrpcproxy",
+      "plural": "targetgrpcproxies"
+    },
+    "compute.gcp.upbound.io/TargetHTTPProxy": {
+      "singular": "targethttpproxy",
+      "plural": "targethttpproxies"
+    },
+    "compute.gcp.upbound.io/TargetHTTPSProxy": {
+      "singular": "targethttpsproxy",
+      "plural": "targethttpsproxies"
+    },
+    "compute.gcp.upbound.io/TargetInstance": {
+      "singular": "targetinstance",
+      "plural": "targetinstances"
+    },
+    "compute.gcp.upbound.io/TargetPool": {
+      "singular": "targetpool",
+      "plural": "targetpools"
+    },
+    "compute.gcp.upbound.io/TargetSSLProxy": {
+      "singular": "targetsslproxy",
+      "plural": "targetsslproxies"
+    },
+    "compute.gcp.upbound.io/TargetTCPProxy": {
+      "singular": "targettcpproxy",
+      "plural": "targettcpproxies"
+    },
+    "compute.gcp.upbound.io/URLMap": {
+      "singular": "urlmap",
+      "plural": "urlmaps"
+    },
+    "compute.gcp.upbound.io/VPNGateway": {
+      "singular": "vpngateway",
+      "plural": "vpngateways"
+    },
+    "compute.gcp.upbound.io/VPNTunnel": {
+      "singular": "vpntunnel",
+      "plural": "vpntunnels"
+    },
+    "container.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "container.gcp.m.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "container.gcp.m.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "container.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "container.gcp.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "container.gcp.upbound.io/Registry": {
+      "singular": "registry",
+      "plural": "registries"
+    },
+    "containeranalysis.gcp.m.upbound.io/Note": {
+      "singular": "note",
+      "plural": "notes"
+    },
+    "containeranalysis.gcp.upbound.io/Note": {
+      "singular": "note",
+      "plural": "notes"
+    },
+    "containerattached.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containerattached.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containeraws.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containeraws.gcp.m.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "containeraws.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containeraws.gcp.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "containerazure.gcp.m.upbound.io/Client": {
+      "singular": "client",
+      "plural": "clients"
+    },
+    "containerazure.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containerazure.gcp.m.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "containerazure.gcp.upbound.io/Client": {
+      "singular": "client",
+      "plural": "clients"
+    },
+    "containerazure.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "containerazure.gcp.upbound.io/NodePool": {
+      "singular": "nodepool",
+      "plural": "nodepools"
+    },
+    "datacatalog.gcp.m.upbound.io/Entry": {
+      "singular": "entry",
+      "plural": "entries"
+    },
+    "datacatalog.gcp.m.upbound.io/EntryGroup": {
+      "singular": "entrygroup",
+      "plural": "entrygroups"
+    },
+    "datacatalog.gcp.m.upbound.io/PolicyTag": {
+      "singular": "policytag",
+      "plural": "policytags"
+    },
+    "datacatalog.gcp.m.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "datacatalog.gcp.m.upbound.io/TagTemplate": {
+      "singular": "tagtemplate",
+      "plural": "tagtemplates"
+    },
+    "datacatalog.gcp.m.upbound.io/Taxonomy": {
+      "singular": "taxonomy",
+      "plural": "taxonomies"
+    },
+    "datacatalog.gcp.upbound.io/Entry": {
+      "singular": "entry",
+      "plural": "entries"
+    },
+    "datacatalog.gcp.upbound.io/EntryGroup": {
+      "singular": "entrygroup",
+      "plural": "entrygroups"
+    },
+    "datacatalog.gcp.upbound.io/PolicyTag": {
+      "singular": "policytag",
+      "plural": "policytags"
+    },
+    "datacatalog.gcp.upbound.io/Tag": {
+      "singular": "tag",
+      "plural": "tags"
+    },
+    "datacatalog.gcp.upbound.io/TagTemplate": {
+      "singular": "tagtemplate",
+      "plural": "tagtemplates"
+    },
+    "datacatalog.gcp.upbound.io/Taxonomy": {
+      "singular": "taxonomy",
+      "plural": "taxonomies"
+    },
+    "dataflow.gcp.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "dataflow.gcp.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "datafusion.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "datafusion.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "datalossprevention.gcp.m.upbound.io/DeidentifyTemplate": {
+      "singular": "deidentifytemplate",
+      "plural": "deidentifytemplates"
+    },
+    "datalossprevention.gcp.m.upbound.io/InspectTemplate": {
+      "singular": "inspecttemplate",
+      "plural": "inspecttemplates"
+    },
+    "datalossprevention.gcp.m.upbound.io/JobTrigger": {
+      "singular": "jobtrigger",
+      "plural": "jobtriggers"
+    },
+    "datalossprevention.gcp.m.upbound.io/StoredInfoType": {
+      "singular": "storedinfotype",
+      "plural": "storedinfotypes"
+    },
+    "datalossprevention.gcp.upbound.io/DeidentifyTemplate": {
+      "singular": "deidentifytemplate",
+      "plural": "deidentifytemplates"
+    },
+    "datalossprevention.gcp.upbound.io/InspectTemplate": {
+      "singular": "inspecttemplate",
+      "plural": "inspecttemplates"
+    },
+    "datalossprevention.gcp.upbound.io/JobTrigger": {
+      "singular": "jobtrigger",
+      "plural": "jobtriggers"
+    },
+    "datalossprevention.gcp.upbound.io/StoredInfoType": {
+      "singular": "storedinfotype",
+      "plural": "storedinfotypes"
+    },
+    "dataplex.gcp.m.upbound.io/AspectType": {
+      "singular": "aspecttype",
+      "plural": "aspecttypes"
+    },
+    "dataplex.gcp.m.upbound.io/Asset": {
+      "singular": "asset",
+      "plural": "assets"
+    },
+    "dataplex.gcp.m.upbound.io/Lake": {
+      "singular": "lake",
+      "plural": "lakes"
+    },
+    "dataplex.gcp.m.upbound.io/LakeIAMPolicy": {
+      "singular": "lakeiampolicy",
+      "plural": "lakeiampolicies"
+    },
+    "dataplex.gcp.m.upbound.io/Zone": {
+      "singular": "zone",
+      "plural": "zones"
+    },
+    "dataplex.gcp.upbound.io/AspectType": {
+      "singular": "aspecttype",
+      "plural": "aspecttypes"
+    },
+    "dataplex.gcp.upbound.io/Asset": {
+      "singular": "asset",
+      "plural": "assets"
+    },
+    "dataplex.gcp.upbound.io/Lake": {
+      "singular": "lake",
+      "plural": "lakes"
+    },
+    "dataplex.gcp.upbound.io/LakeIAMPolicy": {
+      "singular": "lakeiampolicy",
+      "plural": "lakeiampolicies"
+    },
+    "dataplex.gcp.upbound.io/Zone": {
+      "singular": "zone",
+      "plural": "zones"
+    },
+    "dataproc.gcp.m.upbound.io/AutoscalingPolicy": {
+      "singular": "autoscalingpolicy",
+      "plural": "autoscalingpolicies"
+    },
+    "dataproc.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dataproc.gcp.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "dataproc.gcp.m.upbound.io/MetastoreService": {
+      "singular": "metastoreservice",
+      "plural": "metastoreservices"
+    },
+    "dataproc.gcp.m.upbound.io/WorkflowTemplate": {
+      "singular": "workflowtemplate",
+      "plural": "workflowtemplates"
+    },
+    "dataproc.gcp.upbound.io/AutoscalingPolicy": {
+      "singular": "autoscalingpolicy",
+      "plural": "autoscalingpolicies"
+    },
+    "dataproc.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "dataproc.gcp.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "dataproc.gcp.upbound.io/MetastoreService": {
+      "singular": "metastoreservice",
+      "plural": "metastoreservices"
+    },
+    "dataproc.gcp.upbound.io/WorkflowTemplate": {
+      "singular": "workflowtemplate",
+      "plural": "workflowtemplates"
+    },
+    "datastream.gcp.m.upbound.io/ConnectionProfile": {
+      "singular": "connectionprofile",
+      "plural": "connectionprofiles"
+    },
+    "datastream.gcp.m.upbound.io/PrivateConnection": {
+      "singular": "privateconnection",
+      "plural": "privateconnections"
+    },
+    "datastream.gcp.m.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "datastream.gcp.upbound.io/ConnectionProfile": {
+      "singular": "connectionprofile",
+      "plural": "connectionprofiles"
+    },
+    "datastream.gcp.upbound.io/PrivateConnection": {
+      "singular": "privateconnection",
+      "plural": "privateconnections"
+    },
+    "datastream.gcp.upbound.io/Stream": {
+      "singular": "stream",
+      "plural": "streams"
+    },
+    "developerconnect.gcp.m.upbound.io/ConnectAccountConnector": {
+      "singular": "connectaccountconnector",
+      "plural": "connectaccountconnectors"
+    },
+    "developerconnect.gcp.m.upbound.io/ConnectConnection": {
+      "singular": "connectconnection",
+      "plural": "connectconnections"
+    },
+    "developerconnect.gcp.m.upbound.io/ConnectGitRepositoryLink": {
+      "singular": "connectgitrepositorylink",
+      "plural": "connectgitrepositorylinks"
+    },
+    "developerconnect.gcp.upbound.io/ConnectAccountConnector": {
+      "singular": "connectaccountconnector",
+      "plural": "connectaccountconnectors"
+    },
+    "developerconnect.gcp.upbound.io/ConnectConnection": {
+      "singular": "connectconnection",
+      "plural": "connectconnections"
+    },
+    "developerconnect.gcp.upbound.io/ConnectGitRepositoryLink": {
+      "singular": "connectgitrepositorylink",
+      "plural": "connectgitrepositorylinks"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Agent": {
+      "singular": "agent",
+      "plural": "agents"
+    },
+    "dialogflowcx.gcp.m.upbound.io/EntityType": {
+      "singular": "entitytype",
+      "plural": "entitytypes"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Flow": {
+      "singular": "flow",
+      "plural": "flows"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Intent": {
+      "singular": "intent",
+      "plural": "intents"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Page": {
+      "singular": "page",
+      "plural": "pages"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Version": {
+      "singular": "version",
+      "plural": "versions"
+    },
+    "dialogflowcx.gcp.m.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "dialogflowcx.gcp.upbound.io/Agent": {
+      "singular": "agent",
+      "plural": "agents"
+    },
+    "dialogflowcx.gcp.upbound.io/EntityType": {
+      "singular": "entitytype",
+      "plural": "entitytypes"
+    },
+    "dialogflowcx.gcp.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "dialogflowcx.gcp.upbound.io/Flow": {
+      "singular": "flow",
+      "plural": "flows"
+    },
+    "dialogflowcx.gcp.upbound.io/Intent": {
+      "singular": "intent",
+      "plural": "intents"
+    },
+    "dialogflowcx.gcp.upbound.io/Page": {
+      "singular": "page",
+      "plural": "pages"
+    },
+    "dialogflowcx.gcp.upbound.io/Version": {
+      "singular": "version",
+      "plural": "versions"
+    },
+    "dialogflowcx.gcp.upbound.io/Webhook": {
+      "singular": "webhook",
+      "plural": "webhooks"
+    },
+    "dns.gcp.m.upbound.io/ManagedZone": {
+      "singular": "managedzone",
+      "plural": "managedzones"
+    },
+    "dns.gcp.m.upbound.io/ManagedZoneIAMMember": {
+      "singular": "managedzoneiammember",
+      "plural": "managedzoneiammembers"
+    },
+    "dns.gcp.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "dns.gcp.m.upbound.io/RecordSet": {
+      "singular": "recordset",
+      "plural": "recordsets"
+    },
+    "dns.gcp.m.upbound.io/ResponsePolicy": {
+      "singular": "responsepolicy",
+      "plural": "responsepolicies"
+    },
+    "dns.gcp.m.upbound.io/ResponsePolicyRule": {
+      "singular": "responsepolicyrule",
+      "plural": "responsepolicyrules"
+    },
+    "dns.gcp.upbound.io/ManagedZone": {
+      "singular": "managedzone",
+      "plural": "managedzones"
+    },
+    "dns.gcp.upbound.io/ManagedZoneIAMMember": {
+      "singular": "managedzoneiammember",
+      "plural": "managedzoneiammembers"
+    },
+    "dns.gcp.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "dns.gcp.upbound.io/RecordSet": {
+      "singular": "recordset",
+      "plural": "recordsets"
+    },
+    "dns.gcp.upbound.io/ResponsePolicy": {
+      "singular": "responsepolicy",
+      "plural": "responsepolicies"
+    },
+    "dns.gcp.upbound.io/ResponsePolicyRule": {
+      "singular": "responsepolicyrule",
+      "plural": "responsepolicyrules"
+    },
+    "documentai.gcp.m.upbound.io/Processor": {
+      "singular": "processor",
+      "plural": "processors"
+    },
+    "documentai.gcp.upbound.io/Processor": {
+      "singular": "processor",
+      "plural": "processors"
+    },
+    "essentialcontacts.gcp.m.upbound.io/Contact": {
+      "singular": "contact",
+      "plural": "contacts"
+    },
+    "essentialcontacts.gcp.upbound.io/Contact": {
+      "singular": "contact",
+      "plural": "contacts"
+    },
+    "eventarc.gcp.m.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "eventarc.gcp.m.upbound.io/GoogleChannelConfig": {
+      "singular": "googlechannelconfig",
+      "plural": "googlechannelconfigs"
+    },
+    "eventarc.gcp.m.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "eventarc.gcp.upbound.io/Channel": {
+      "singular": "channel",
+      "plural": "channels"
+    },
+    "eventarc.gcp.upbound.io/GoogleChannelConfig": {
+      "singular": "googlechannelconfig",
+      "plural": "googlechannelconfigs"
+    },
+    "eventarc.gcp.upbound.io/Trigger": {
+      "singular": "trigger",
+      "plural": "triggers"
+    },
+    "filestore.gcp.m.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "filestore.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "filestore.gcp.m.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "filestore.gcp.upbound.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "filestore.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "filestore.gcp.upbound.io/Snapshot": {
+      "singular": "snapshot",
+      "plural": "snapshots"
+    },
+    "firebaserules.gcp.m.upbound.io/Release": {
+      "singular": "release",
+      "plural": "releases"
+    },
+    "firebaserules.gcp.m.upbound.io/Ruleset": {
+      "singular": "ruleset",
+      "plural": "rulesets"
+    },
+    "firebaserules.gcp.upbound.io/Release": {
+      "singular": "release",
+      "plural": "releases"
+    },
+    "firebaserules.gcp.upbound.io/Ruleset": {
+      "singular": "ruleset",
+      "plural": "rulesets"
+    },
+    "gcp.m.upbound.io/ClusterProviderConfig": {
+      "singular": "clusterproviderconfig",
+      "plural": "clusterproviderconfigs"
+    },
+    "gcp.m.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "gcp.m.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "gcp.upbound.io/ProviderConfig": {
+      "singular": "providerconfig",
+      "plural": "providerconfigs"
+    },
+    "gcp.upbound.io/ProviderConfigUsage": {
+      "singular": "providerconfigusage",
+      "plural": "providerconfigusages"
+    },
+    "gemini.gcp.m.upbound.io/CodeRepositoryIndex": {
+      "singular": "coderepositoryindex",
+      "plural": "coderepositoryindices"
+    },
+    "gemini.gcp.m.upbound.io/CodeToolsSetting": {
+      "singular": "codetoolssetting",
+      "plural": "codetoolssettings"
+    },
+    "gemini.gcp.m.upbound.io/DataSharingWithGoogleSetting": {
+      "singular": "datasharingwithgooglesetting",
+      "plural": "datasharingwithgooglesettings"
+    },
+    "gemini.gcp.m.upbound.io/GeminiGCPEnablementSetting": {
+      "singular": "geminigcpenablementsetting",
+      "plural": "geminigcpenablementsettings"
+    },
+    "gemini.gcp.m.upbound.io/LoggingSetting": {
+      "singular": "loggingsetting",
+      "plural": "loggingsettings"
+    },
+    "gemini.gcp.m.upbound.io/ReleaseChannelSetting": {
+      "singular": "releasechannelsetting",
+      "plural": "releasechannelsettings"
+    },
+    "gemini.gcp.m.upbound.io/RepositoryGroup": {
+      "singular": "repositorygroup",
+      "plural": "repositorygroups"
+    },
+    "gemini.gcp.upbound.io/CodeRepositoryIndex": {
+      "singular": "coderepositoryindex",
+      "plural": "coderepositoryindices"
+    },
+    "gemini.gcp.upbound.io/CodeToolsSetting": {
+      "singular": "codetoolssetting",
+      "plural": "codetoolssettings"
+    },
+    "gemini.gcp.upbound.io/DataSharingWithGoogleSetting": {
+      "singular": "datasharingwithgooglesetting",
+      "plural": "datasharingwithgooglesettings"
+    },
+    "gemini.gcp.upbound.io/GeminiGCPEnablementSetting": {
+      "singular": "geminigcpenablementsetting",
+      "plural": "geminigcpenablementsettings"
+    },
+    "gemini.gcp.upbound.io/LoggingSetting": {
+      "singular": "loggingsetting",
+      "plural": "loggingsettings"
+    },
+    "gemini.gcp.upbound.io/ReleaseChannelSetting": {
+      "singular": "releasechannelsetting",
+      "plural": "releasechannelsettings"
+    },
+    "gemini.gcp.upbound.io/RepositoryGroup": {
+      "singular": "repositorygroup",
+      "plural": "repositorygroups"
+    },
+    "gke.gcp.m.upbound.io/BackupBackupPlan": {
+      "singular": "backupbackupplan",
+      "plural": "backupbackupplans"
+    },
+    "gke.gcp.upbound.io/BackupBackupPlan": {
+      "singular": "backupbackupplan",
+      "plural": "backupbackupplans"
+    },
+    "gkehub.gcp.m.upbound.io/Membership": {
+      "singular": "membership",
+      "plural": "memberships"
+    },
+    "gkehub.gcp.m.upbound.io/MembershipIAMMember": {
+      "singular": "membershipiammember",
+      "plural": "membershipiammembers"
+    },
+    "gkehub.gcp.upbound.io/Membership": {
+      "singular": "membership",
+      "plural": "memberships"
+    },
+    "gkehub.gcp.upbound.io/MembershipIAMMember": {
+      "singular": "membershipiammember",
+      "plural": "membershipiammembers"
+    },
+    "healthcare.gcp.m.upbound.io/ConsentStore": {
+      "singular": "consentstore",
+      "plural": "consentstores"
+    },
+    "healthcare.gcp.m.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "healthcare.gcp.m.upbound.io/DatasetIAMMember": {
+      "singular": "datasetiammember",
+      "plural": "datasetiammembers"
+    },
+    "healthcare.gcp.upbound.io/ConsentStore": {
+      "singular": "consentstore",
+      "plural": "consentstores"
+    },
+    "healthcare.gcp.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "healthcare.gcp.upbound.io/DatasetIAMMember": {
+      "singular": "datasetiammember",
+      "plural": "datasetiammembers"
+    },
+    "iam.gcp.m.upbound.io/WorkloadIdentityPool": {
+      "singular": "workloadidentitypool",
+      "plural": "workloadidentitypools"
+    },
+    "iam.gcp.m.upbound.io/WorkloadIdentityPoolProvider": {
+      "singular": "workloadidentitypoolprovider",
+      "plural": "workloadidentitypoolproviders"
+    },
+    "iam.gcp.upbound.io/WorkloadIdentityPool": {
+      "singular": "workloadidentitypool",
+      "plural": "workloadidentitypools"
+    },
+    "iam.gcp.upbound.io/WorkloadIdentityPoolProvider": {
+      "singular": "workloadidentitypoolprovider",
+      "plural": "workloadidentitypoolproviders"
+    },
+    "iap.gcp.m.upbound.io/AppEngineServiceIAMMember": {
+      "singular": "appengineserviceiammember",
+      "plural": "appengineserviceiammembers"
+    },
+    "iap.gcp.m.upbound.io/AppEngineVersionIAMMember": {
+      "singular": "appengineversioniammember",
+      "plural": "appengineversioniammembers"
+    },
+    "iap.gcp.m.upbound.io/TunnelIAMMember": {
+      "singular": "tunneliammember",
+      "plural": "tunneliammembers"
+    },
+    "iap.gcp.m.upbound.io/WebBackendServiceIAMMember": {
+      "singular": "webbackendserviceiammember",
+      "plural": "webbackendserviceiammembers"
+    },
+    "iap.gcp.m.upbound.io/WebIAMMember": {
+      "singular": "webiammember",
+      "plural": "webiammembers"
+    },
+    "iap.gcp.m.upbound.io/WebTypeAppEngineIAMMember": {
+      "singular": "webtypeappengineiammember",
+      "plural": "webtypeappengineiammembers"
+    },
+    "iap.gcp.m.upbound.io/WebTypeComputeIAMMember": {
+      "singular": "webtypecomputeiammember",
+      "plural": "webtypecomputeiammembers"
+    },
+    "iap.gcp.upbound.io/AppEngineServiceIAMMember": {
+      "singular": "appengineserviceiammember",
+      "plural": "appengineserviceiammembers"
+    },
+    "iap.gcp.upbound.io/AppEngineVersionIAMMember": {
+      "singular": "appengineversioniammember",
+      "plural": "appengineversioniammembers"
+    },
+    "iap.gcp.upbound.io/TunnelIAMMember": {
+      "singular": "tunneliammember",
+      "plural": "tunneliammembers"
+    },
+    "iap.gcp.upbound.io/WebBackendServiceIAMMember": {
+      "singular": "webbackendserviceiammember",
+      "plural": "webbackendserviceiammembers"
+    },
+    "iap.gcp.upbound.io/WebIAMMember": {
+      "singular": "webiammember",
+      "plural": "webiammembers"
+    },
+    "iap.gcp.upbound.io/WebTypeAppEngineIAMMember": {
+      "singular": "webtypeappengineiammember",
+      "plural": "webtypeappengineiammembers"
+    },
+    "iap.gcp.upbound.io/WebTypeComputeIAMMember": {
+      "singular": "webtypecomputeiammember",
+      "plural": "webtypecomputeiammembers"
+    },
+    "identityplatform.gcp.m.upbound.io/Config": {
+      "singular": "config",
+      "plural": "configs"
+    },
+    "identityplatform.gcp.m.upbound.io/DefaultSupportedIdPConfig": {
+      "singular": "defaultsupportedidpconfig",
+      "plural": "defaultsupportedidpconfigs"
+    },
+    "identityplatform.gcp.m.upbound.io/InboundSAMLConfig": {
+      "singular": "inboundsamlconfig",
+      "plural": "inboundsamlconfigs"
+    },
+    "identityplatform.gcp.m.upbound.io/OAuthIdPConfig": {
+      "singular": "oauthidpconfig",
+      "plural": "oauthidpconfigs"
+    },
+    "identityplatform.gcp.m.upbound.io/Tenant": {
+      "singular": "tenant",
+      "plural": "tenants"
+    },
+    "identityplatform.gcp.m.upbound.io/TenantDefaultSupportedIdPConfig": {
+      "singular": "tenantdefaultsupportedidpconfig",
+      "plural": "tenantdefaultsupportedidpconfigs"
+    },
+    "identityplatform.gcp.m.upbound.io/TenantInboundSAMLConfig": {
+      "singular": "tenantinboundsamlconfig",
+      "plural": "tenantinboundsamlconfigs"
+    },
+    "identityplatform.gcp.m.upbound.io/TenantOAuthIdPConfig": {
+      "singular": "tenantoauthidpconfig",
+      "plural": "tenantoauthidpconfigs"
+    },
+    "identityplatform.gcp.upbound.io/Config": {
+      "singular": "config",
+      "plural": "configs"
+    },
+    "identityplatform.gcp.upbound.io/DefaultSupportedIdPConfig": {
+      "singular": "defaultsupportedidpconfig",
+      "plural": "defaultsupportedidpconfigs"
+    },
+    "identityplatform.gcp.upbound.io/InboundSAMLConfig": {
+      "singular": "inboundsamlconfig",
+      "plural": "inboundsamlconfigs"
+    },
+    "identityplatform.gcp.upbound.io/OAuthIdPConfig": {
+      "singular": "oauthidpconfig",
+      "plural": "oauthidpconfigs"
+    },
+    "identityplatform.gcp.upbound.io/Tenant": {
+      "singular": "tenant",
+      "plural": "tenants"
+    },
+    "identityplatform.gcp.upbound.io/TenantDefaultSupportedIdPConfig": {
+      "singular": "tenantdefaultsupportedidpconfig",
+      "plural": "tenantdefaultsupportedidpconfigs"
+    },
+    "identityplatform.gcp.upbound.io/TenantInboundSAMLConfig": {
+      "singular": "tenantinboundsamlconfig",
+      "plural": "tenantinboundsamlconfigs"
+    },
+    "identityplatform.gcp.upbound.io/TenantOAuthIdPConfig": {
+      "singular": "tenantoauthidpconfig",
+      "plural": "tenantoauthidpconfigs"
+    },
+    "kms.gcp.m.upbound.io/CryptoKey": {
+      "singular": "cryptokey",
+      "plural": "cryptokeys"
+    },
+    "kms.gcp.m.upbound.io/CryptoKeyIAMMember": {
+      "singular": "cryptokeyiammember",
+      "plural": "cryptokeyiammembers"
+    },
+    "kms.gcp.m.upbound.io/CryptoKeyVersion": {
+      "singular": "cryptokeyversion",
+      "plural": "cryptokeyversions"
+    },
+    "kms.gcp.m.upbound.io/KeyRing": {
+      "singular": "keyring",
+      "plural": "keyrings"
+    },
+    "kms.gcp.m.upbound.io/KeyRingIAMMember": {
+      "singular": "keyringiammember",
+      "plural": "keyringiammembers"
+    },
+    "kms.gcp.m.upbound.io/KeyRingImportJob": {
+      "singular": "keyringimportjob",
+      "plural": "keyringimportjobs"
+    },
+    "kms.gcp.m.upbound.io/SecretCiphertext": {
+      "singular": "secretciphertext",
+      "plural": "secretciphertexts"
+    },
+    "kms.gcp.upbound.io/CryptoKey": {
+      "singular": "cryptokey",
+      "plural": "cryptokeys"
+    },
+    "kms.gcp.upbound.io/CryptoKeyIAMMember": {
+      "singular": "cryptokeyiammember",
+      "plural": "cryptokeyiammembers"
+    },
+    "kms.gcp.upbound.io/CryptoKeyVersion": {
+      "singular": "cryptokeyversion",
+      "plural": "cryptokeyversions"
+    },
+    "kms.gcp.upbound.io/KeyRing": {
+      "singular": "keyring",
+      "plural": "keyrings"
+    },
+    "kms.gcp.upbound.io/KeyRingIAMMember": {
+      "singular": "keyringiammember",
+      "plural": "keyringiammembers"
+    },
+    "kms.gcp.upbound.io/KeyRingImportJob": {
+      "singular": "keyringimportjob",
+      "plural": "keyringimportjobs"
+    },
+    "kms.gcp.upbound.io/SecretCiphertext": {
+      "singular": "secretciphertext",
+      "plural": "secretciphertexts"
+    },
+    "logging.gcp.m.upbound.io/FolderBucketConfig": {
+      "singular": "folderbucketconfig",
+      "plural": "folderbucketconfigs"
+    },
+    "logging.gcp.m.upbound.io/FolderExclusion": {
+      "singular": "folderexclusion",
+      "plural": "folderexclusions"
+    },
+    "logging.gcp.m.upbound.io/FolderSink": {
+      "singular": "foldersink",
+      "plural": "foldersinks"
+    },
+    "logging.gcp.m.upbound.io/LogView": {
+      "singular": "logview",
+      "plural": "logviews"
+    },
+    "logging.gcp.m.upbound.io/Metric": {
+      "singular": "metric",
+      "plural": "metrics"
+    },
+    "logging.gcp.m.upbound.io/ProjectBucketConfig": {
+      "singular": "projectbucketconfig",
+      "plural": "projectbucketconfigs"
+    },
+    "logging.gcp.m.upbound.io/ProjectExclusion": {
+      "singular": "projectexclusion",
+      "plural": "projectexclusions"
+    },
+    "logging.gcp.m.upbound.io/ProjectSink": {
+      "singular": "projectsink",
+      "plural": "projectsinks"
+    },
+    "logging.gcp.upbound.io/FolderBucketConfig": {
+      "singular": "folderbucketconfig",
+      "plural": "folderbucketconfigs"
+    },
+    "logging.gcp.upbound.io/FolderExclusion": {
+      "singular": "folderexclusion",
+      "plural": "folderexclusions"
+    },
+    "logging.gcp.upbound.io/FolderSink": {
+      "singular": "foldersink",
+      "plural": "foldersinks"
+    },
+    "logging.gcp.upbound.io/LogView": {
+      "singular": "logview",
+      "plural": "logviews"
+    },
+    "logging.gcp.upbound.io/Metric": {
+      "singular": "metric",
+      "plural": "metrics"
+    },
+    "logging.gcp.upbound.io/ProjectBucketConfig": {
+      "singular": "projectbucketconfig",
+      "plural": "projectbucketconfigs"
+    },
+    "logging.gcp.upbound.io/ProjectExclusion": {
+      "singular": "projectexclusion",
+      "plural": "projectexclusions"
+    },
+    "logging.gcp.upbound.io/ProjectSink": {
+      "singular": "projectsink",
+      "plural": "projectsinks"
+    },
+    "memcache.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "memcache.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "memorystore.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "memorystore.gcp.m.upbound.io/InstanceDesiredUserCreatedEndpoints": {
+      "singular": "instancedesiredusercreatedendpoints",
+      "plural": "instancedesiredusercreatedendpoints"
+    },
+    "memorystore.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "memorystore.gcp.upbound.io/InstanceDesiredUserCreatedEndpoints": {
+      "singular": "instancedesiredusercreatedendpoints",
+      "plural": "instancedesiredusercreatedendpoints"
+    },
+    "mlengine.gcp.m.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "mlengine.gcp.upbound.io/Model": {
+      "singular": "model",
+      "plural": "models"
+    },
+    "modelarmor.gcp.m.upbound.io/FloorSetting": {
+      "singular": "floorsetting",
+      "plural": "floorsettings"
+    },
+    "modelarmor.gcp.m.upbound.io/Template": {
+      "singular": "template",
+      "plural": "templates"
+    },
+    "modelarmor.gcp.upbound.io/FloorSetting": {
+      "singular": "floorsetting",
+      "plural": "floorsettings"
+    },
+    "modelarmor.gcp.upbound.io/Template": {
+      "singular": "template",
+      "plural": "templates"
+    },
+    "monitoring.gcp.m.upbound.io/AlertPolicy": {
+      "singular": "alertpolicy",
+      "plural": "alertpolicies"
+    },
+    "monitoring.gcp.m.upbound.io/CustomService": {
+      "singular": "customservice",
+      "plural": "customservices"
+    },
+    "monitoring.gcp.m.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "monitoring.gcp.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "monitoring.gcp.m.upbound.io/MetricDescriptor": {
+      "singular": "metricdescriptor",
+      "plural": "metricdescriptors"
+    },
+    "monitoring.gcp.m.upbound.io/NotificationChannel": {
+      "singular": "notificationchannel",
+      "plural": "notificationchannels"
+    },
+    "monitoring.gcp.m.upbound.io/SLO": {
+      "singular": "slo",
+      "plural": "sloes"
+    },
+    "monitoring.gcp.m.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "monitoring.gcp.m.upbound.io/UptimeCheckConfig": {
+      "singular": "uptimecheckconfig",
+      "plural": "uptimecheckconfigs"
+    },
+    "monitoring.gcp.upbound.io/AlertPolicy": {
+      "singular": "alertpolicy",
+      "plural": "alertpolicies"
+    },
+    "monitoring.gcp.upbound.io/CustomService": {
+      "singular": "customservice",
+      "plural": "customservices"
+    },
+    "monitoring.gcp.upbound.io/Dashboard": {
+      "singular": "dashboard",
+      "plural": "dashboards"
+    },
+    "monitoring.gcp.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "monitoring.gcp.upbound.io/MetricDescriptor": {
+      "singular": "metricdescriptor",
+      "plural": "metricdescriptors"
+    },
+    "monitoring.gcp.upbound.io/NotificationChannel": {
+      "singular": "notificationchannel",
+      "plural": "notificationchannels"
+    },
+    "monitoring.gcp.upbound.io/SLO": {
+      "singular": "slo",
+      "plural": "sloes"
+    },
+    "monitoring.gcp.upbound.io/Service": {
+      "singular": "service",
+      "plural": "services"
+    },
+    "monitoring.gcp.upbound.io/UptimeCheckConfig": {
+      "singular": "uptimecheckconfig",
+      "plural": "uptimecheckconfigs"
+    },
+    "networkconnectivity.gcp.m.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "networkconnectivity.gcp.m.upbound.io/Hub": {
+      "singular": "hub",
+      "plural": "hubs"
+    },
+    "networkconnectivity.gcp.m.upbound.io/InternalRange": {
+      "singular": "internalrange",
+      "plural": "internalranges"
+    },
+    "networkconnectivity.gcp.m.upbound.io/ServiceConnectionPolicy": {
+      "singular": "serviceconnectionpolicy",
+      "plural": "serviceconnectionpolicies"
+    },
+    "networkconnectivity.gcp.m.upbound.io/Spoke": {
+      "singular": "spoke",
+      "plural": "spokes"
+    },
+    "networkconnectivity.gcp.upbound.io/Group": {
+      "singular": "group",
+      "plural": "groups"
+    },
+    "networkconnectivity.gcp.upbound.io/Hub": {
+      "singular": "hub",
+      "plural": "hubs"
+    },
+    "networkconnectivity.gcp.upbound.io/InternalRange": {
+      "singular": "internalrange",
+      "plural": "internalranges"
+    },
+    "networkconnectivity.gcp.upbound.io/ServiceConnectionPolicy": {
+      "singular": "serviceconnectionpolicy",
+      "plural": "serviceconnectionpolicies"
+    },
+    "networkconnectivity.gcp.upbound.io/Spoke": {
+      "singular": "spoke",
+      "plural": "spokes"
+    },
+    "networkmanagement.gcp.m.upbound.io/ConnectivityTest": {
+      "singular": "connectivitytest",
+      "plural": "connectivitytests"
+    },
+    "networkmanagement.gcp.upbound.io/ConnectivityTest": {
+      "singular": "connectivitytest",
+      "plural": "connectivitytests"
+    },
+    "networksecurity.gcp.m.upbound.io/AddressGroup": {
+      "singular": "addressgroup",
+      "plural": "addressgroups"
+    },
+    "networksecurity.gcp.m.upbound.io/GatewaySecurityPolicy": {
+      "singular": "gatewaysecuritypolicy",
+      "plural": "gatewaysecuritypolicies"
+    },
+    "networksecurity.gcp.m.upbound.io/GatewaySecurityPolicyRule": {
+      "singular": "gatewaysecuritypolicyrule",
+      "plural": "gatewaysecuritypolicyrules"
+    },
+    "networksecurity.gcp.m.upbound.io/TLSInspectionPolicy": {
+      "singular": "tlsinspectionpolicy",
+      "plural": "tlsinspectionpolicies"
+    },
+    "networksecurity.gcp.m.upbound.io/URLLists": {
+      "singular": "urllists",
+      "plural": "urllists"
+    },
+    "networksecurity.gcp.upbound.io/AddressGroup": {
+      "singular": "addressgroup",
+      "plural": "addressgroups"
+    },
+    "networksecurity.gcp.upbound.io/GatewaySecurityPolicy": {
+      "singular": "gatewaysecuritypolicy",
+      "plural": "gatewaysecuritypolicies"
+    },
+    "networksecurity.gcp.upbound.io/GatewaySecurityPolicyRule": {
+      "singular": "gatewaysecuritypolicyrule",
+      "plural": "gatewaysecuritypolicyrules"
+    },
+    "networksecurity.gcp.upbound.io/TLSInspectionPolicy": {
+      "singular": "tlsinspectionpolicy",
+      "plural": "tlsinspectionpolicies"
+    },
+    "networksecurity.gcp.upbound.io/URLLists": {
+      "singular": "urllists",
+      "plural": "urllists"
+    },
+    "networkservices.gcp.m.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "networkservices.gcp.upbound.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "notebooks.gcp.m.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "notebooks.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "notebooks.gcp.m.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "notebooks.gcp.m.upbound.io/Runtime": {
+      "singular": "runtime",
+      "plural": "runtimes"
+    },
+    "notebooks.gcp.m.upbound.io/RuntimeIAMMember": {
+      "singular": "runtimeiammember",
+      "plural": "runtimeiammembers"
+    },
+    "notebooks.gcp.upbound.io/Environment": {
+      "singular": "environment",
+      "plural": "environments"
+    },
+    "notebooks.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "notebooks.gcp.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "notebooks.gcp.upbound.io/Runtime": {
+      "singular": "runtime",
+      "plural": "runtimes"
+    },
+    "notebooks.gcp.upbound.io/RuntimeIAMMember": {
+      "singular": "runtimeiammember",
+      "plural": "runtimeiammembers"
+    },
+    "orgpolicy.gcp.m.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "orgpolicy.gcp.upbound.io/Policy": {
+      "singular": "policy",
+      "plural": "policies"
+    },
+    "osconfig.gcp.m.upbound.io/OsPolicyAssignment": {
+      "singular": "ospolicyassignment",
+      "plural": "ospolicyassignments"
+    },
+    "osconfig.gcp.m.upbound.io/PatchDeployment": {
+      "singular": "patchdeployment",
+      "plural": "patchdeployments"
+    },
+    "osconfig.gcp.upbound.io/OsPolicyAssignment": {
+      "singular": "ospolicyassignment",
+      "plural": "ospolicyassignments"
+    },
+    "osconfig.gcp.upbound.io/PatchDeployment": {
+      "singular": "patchdeployment",
+      "plural": "patchdeployments"
+    },
+    "oslogin.gcp.m.upbound.io/SSHPublicKey": {
+      "singular": "sshpublickey",
+      "plural": "sshpublickeys"
+    },
+    "oslogin.gcp.upbound.io/SSHPublicKey": {
+      "singular": "sshpublickey",
+      "plural": "sshpublickeys"
+    },
+    "privateca.gcp.m.upbound.io/CAPool": {
+      "singular": "capool",
+      "plural": "capools"
+    },
+    "privateca.gcp.m.upbound.io/CAPoolIAMMember": {
+      "singular": "capooliammember",
+      "plural": "capooliammembers"
+    },
+    "privateca.gcp.m.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "privateca.gcp.m.upbound.io/CertificateAuthority": {
+      "singular": "certificateauthority",
+      "plural": "certificateauthorities"
+    },
+    "privateca.gcp.m.upbound.io/CertificateTemplate": {
+      "singular": "certificatetemplate",
+      "plural": "certificatetemplates"
+    },
+    "privateca.gcp.m.upbound.io/CertificateTemplateIAMMember": {
+      "singular": "certificatetemplateiammember",
+      "plural": "certificatetemplateiammembers"
+    },
+    "privateca.gcp.upbound.io/CAPool": {
+      "singular": "capool",
+      "plural": "capools"
+    },
+    "privateca.gcp.upbound.io/CAPoolIAMMember": {
+      "singular": "capooliammember",
+      "plural": "capooliammembers"
+    },
+    "privateca.gcp.upbound.io/Certificate": {
+      "singular": "certificate",
+      "plural": "certificates"
+    },
+    "privateca.gcp.upbound.io/CertificateAuthority": {
+      "singular": "certificateauthority",
+      "plural": "certificateauthorities"
+    },
+    "privateca.gcp.upbound.io/CertificateTemplate": {
+      "singular": "certificatetemplate",
+      "plural": "certificatetemplates"
+    },
+    "privateca.gcp.upbound.io/CertificateTemplateIAMMember": {
+      "singular": "certificatetemplateiammember",
+      "plural": "certificatetemplateiammembers"
+    },
+    "pubsub.gcp.m.upbound.io/LiteReservation": {
+      "singular": "litereservation",
+      "plural": "litereservations"
+    },
+    "pubsub.gcp.m.upbound.io/LiteSubscription": {
+      "singular": "litesubscription",
+      "plural": "litesubscriptions"
+    },
+    "pubsub.gcp.m.upbound.io/LiteTopic": {
+      "singular": "litetopic",
+      "plural": "litetopics"
+    },
+    "pubsub.gcp.m.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "pubsub.gcp.m.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "pubsub.gcp.m.upbound.io/SubscriptionIAMMember": {
+      "singular": "subscriptioniammember",
+      "plural": "subscriptioniammembers"
+    },
+    "pubsub.gcp.m.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "pubsub.gcp.m.upbound.io/TopicIAMMember": {
+      "singular": "topiciammember",
+      "plural": "topiciammembers"
+    },
+    "pubsub.gcp.upbound.io/LiteReservation": {
+      "singular": "litereservation",
+      "plural": "litereservations"
+    },
+    "pubsub.gcp.upbound.io/LiteSubscription": {
+      "singular": "litesubscription",
+      "plural": "litesubscriptions"
+    },
+    "pubsub.gcp.upbound.io/LiteTopic": {
+      "singular": "litetopic",
+      "plural": "litetopics"
+    },
+    "pubsub.gcp.upbound.io/Schema": {
+      "singular": "schema",
+      "plural": "schemas"
+    },
+    "pubsub.gcp.upbound.io/Subscription": {
+      "singular": "subscription",
+      "plural": "subscriptions"
+    },
+    "pubsub.gcp.upbound.io/SubscriptionIAMMember": {
+      "singular": "subscriptioniammember",
+      "plural": "subscriptioniammembers"
+    },
+    "pubsub.gcp.upbound.io/Topic": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "pubsub.gcp.upbound.io/TopicIAMMember": {
+      "singular": "topiciammember",
+      "plural": "topiciammembers"
+    },
+    "redis.gcp.m.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "redis.gcp.m.upbound.io/ClusterUserCreatedConnections": {
+      "singular": "clusterusercreatedconnections",
+      "plural": "clusterusercreatedconnections"
+    },
+    "redis.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "redis.gcp.upbound.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "redis.gcp.upbound.io/ClusterUserCreatedConnections": {
+      "singular": "clusterusercreatedconnections",
+      "plural": "clusterusercreatedconnections"
+    },
+    "redis.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "secretmanager.gcp.m.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "secretmanager.gcp.m.upbound.io/SecretIAMMember": {
+      "singular": "secretiammember",
+      "plural": "secretiammembers"
+    },
+    "secretmanager.gcp.m.upbound.io/SecretVersion": {
+      "singular": "secretversion",
+      "plural": "secretversions"
+    },
+    "secretmanager.gcp.upbound.io/Secret": {
+      "singular": "secret",
+      "plural": "secrets"
+    },
+    "secretmanager.gcp.upbound.io/SecretIAMMember": {
+      "singular": "secretiammember",
+      "plural": "secretiammembers"
+    },
+    "secretmanager.gcp.upbound.io/SecretVersion": {
+      "singular": "secretversion",
+      "plural": "secretversions"
+    },
+    "servicenetworking.gcp.m.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "servicenetworking.gcp.upbound.io/Connection": {
+      "singular": "connection",
+      "plural": "connections"
+    },
+    "sourcerepo.gcp.m.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "sourcerepo.gcp.m.upbound.io/RepositoryIAMMember": {
+      "singular": "repositoryiammember",
+      "plural": "repositoryiammembers"
+    },
+    "sourcerepo.gcp.upbound.io/Repository": {
+      "singular": "repository",
+      "plural": "repositories"
+    },
+    "sourcerepo.gcp.upbound.io/RepositoryIAMMember": {
+      "singular": "repositoryiammember",
+      "plural": "repositoryiammembers"
+    },
+    "spanner.gcp.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "spanner.gcp.m.upbound.io/DatabaseIAMMember": {
+      "singular": "databaseiammember",
+      "plural": "databaseiammembers"
+    },
+    "spanner.gcp.m.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "spanner.gcp.m.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "spanner.gcp.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "spanner.gcp.upbound.io/DatabaseIAMMember": {
+      "singular": "databaseiammember",
+      "plural": "databaseiammembers"
+    },
+    "spanner.gcp.upbound.io/Instance": {
+      "singular": "instance",
+      "plural": "instances"
+    },
+    "spanner.gcp.upbound.io/InstanceIAMMember": {
+      "singular": "instanceiammember",
+      "plural": "instanceiammembers"
+    },
+    "sql.gcp.m.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "sql.gcp.m.upbound.io/DatabaseInstance": {
+      "singular": "databaseinstance",
+      "plural": "databaseinstances"
+    },
+    "sql.gcp.m.upbound.io/SSLCert": {
+      "singular": "sslcert",
+      "plural": "sslcerts"
+    },
+    "sql.gcp.m.upbound.io/SourceRepresentationInstance": {
+      "singular": "sourcerepresentationinstance",
+      "plural": "sourcerepresentationinstances"
+    },
+    "sql.gcp.m.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "sql.gcp.upbound.io/Database": {
+      "singular": "database",
+      "plural": "databases"
+    },
+    "sql.gcp.upbound.io/DatabaseInstance": {
+      "singular": "databaseinstance",
+      "plural": "databaseinstances"
+    },
+    "sql.gcp.upbound.io/SSLCert": {
+      "singular": "sslcert",
+      "plural": "sslcerts"
+    },
+    "sql.gcp.upbound.io/SourceRepresentationInstance": {
+      "singular": "sourcerepresentationinstance",
+      "plural": "sourcerepresentationinstances"
+    },
+    "sql.gcp.upbound.io/User": {
+      "singular": "user",
+      "plural": "users"
+    },
+    "storage.gcp.m.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "storage.gcp.m.upbound.io/BucketACL": {
+      "singular": "bucketacl",
+      "plural": "bucketacls"
+    },
+    "storage.gcp.m.upbound.io/BucketAccessControl": {
+      "singular": "bucketaccesscontrol",
+      "plural": "bucketaccesscontrols"
+    },
+    "storage.gcp.m.upbound.io/BucketIAMMember": {
+      "singular": "bucketiammember",
+      "plural": "bucketiammembers"
+    },
+    "storage.gcp.m.upbound.io/BucketIAMPolicy": {
+      "singular": "bucketiampolicy",
+      "plural": "bucketiampolicies"
+    },
+    "storage.gcp.m.upbound.io/BucketObject": {
+      "singular": "bucketobject",
+      "plural": "bucketobjects"
+    },
+    "storage.gcp.m.upbound.io/DefaultObjectACL": {
+      "singular": "defaultobjectacl",
+      "plural": "defaultobjectacls"
+    },
+    "storage.gcp.m.upbound.io/DefaultObjectAccessControl": {
+      "singular": "defaultobjectaccesscontrol",
+      "plural": "defaultobjectaccesscontrols"
+    },
+    "storage.gcp.m.upbound.io/HMACKey": {
+      "singular": "hmackey",
+      "plural": "hmackeys"
+    },
+    "storage.gcp.m.upbound.io/ManagedFolder": {
+      "singular": "managedfolder",
+      "plural": "managedfolders"
+    },
+    "storage.gcp.m.upbound.io/ManagedFolderIAMMember": {
+      "singular": "managedfolderiammember",
+      "plural": "managedfolderiammembers"
+    },
+    "storage.gcp.m.upbound.io/Notification": {
+      "singular": "notification",
+      "plural": "notifications"
+    },
+    "storage.gcp.m.upbound.io/ObjectACL": {
+      "singular": "objectacl",
+      "plural": "objectacls"
+    },
+    "storage.gcp.m.upbound.io/ObjectAccessControl": {
+      "singular": "objectaccesscontrol",
+      "plural": "objectaccesscontrols"
+    },
+    "storage.gcp.upbound.io/Bucket": {
+      "singular": "bucket",
+      "plural": "buckets"
+    },
+    "storage.gcp.upbound.io/BucketACL": {
+      "singular": "bucketacl",
+      "plural": "bucketacls"
+    },
+    "storage.gcp.upbound.io/BucketAccessControl": {
+      "singular": "bucketaccesscontrol",
+      "plural": "bucketaccesscontrols"
+    },
+    "storage.gcp.upbound.io/BucketIAMMember": {
+      "singular": "bucketiammember",
+      "plural": "bucketiammembers"
+    },
+    "storage.gcp.upbound.io/BucketIAMPolicy": {
+      "singular": "bucketiampolicy",
+      "plural": "bucketiampolicies"
+    },
+    "storage.gcp.upbound.io/BucketObject": {
+      "singular": "bucketobject",
+      "plural": "bucketobjects"
+    },
+    "storage.gcp.upbound.io/DefaultObjectACL": {
+      "singular": "defaultobjectacl",
+      "plural": "defaultobjectacls"
+    },
+    "storage.gcp.upbound.io/DefaultObjectAccessControl": {
+      "singular": "defaultobjectaccesscontrol",
+      "plural": "defaultobjectaccesscontrols"
+    },
+    "storage.gcp.upbound.io/HMACKey": {
+      "singular": "hmackey",
+      "plural": "hmackeys"
+    },
+    "storage.gcp.upbound.io/ManagedFolder": {
+      "singular": "managedfolder",
+      "plural": "managedfolders"
+    },
+    "storage.gcp.upbound.io/ManagedFolderIAMMember": {
+      "singular": "managedfolderiammember",
+      "plural": "managedfolderiammembers"
+    },
+    "storage.gcp.upbound.io/Notification": {
+      "singular": "notification",
+      "plural": "notifications"
+    },
+    "storage.gcp.upbound.io/ObjectACL": {
+      "singular": "objectacl",
+      "plural": "objectacls"
+    },
+    "storage.gcp.upbound.io/ObjectAccessControl": {
+      "singular": "objectaccesscontrol",
+      "plural": "objectaccesscontrols"
+    },
+    "storagetransfer.gcp.m.upbound.io/AgentPool": {
+      "singular": "agentpool",
+      "plural": "agentpools"
+    },
+    "storagetransfer.gcp.m.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "storagetransfer.gcp.upbound.io/AgentPool": {
+      "singular": "agentpool",
+      "plural": "agentpools"
+    },
+    "storagetransfer.gcp.upbound.io/Job": {
+      "singular": "job",
+      "plural": "jobs"
+    },
+    "tags.gcp.m.upbound.io/LocationTagBinding": {
+      "singular": "locationtagbinding",
+      "plural": "locationtagbindings"
+    },
+    "tags.gcp.m.upbound.io/TagBinding": {
+      "singular": "tagbinding",
+      "plural": "tagbindings"
+    },
+    "tags.gcp.m.upbound.io/TagKey": {
+      "singular": "tagkey",
+      "plural": "tagkeys"
+    },
+    "tags.gcp.m.upbound.io/TagValue": {
+      "singular": "tagvalue",
+      "plural": "tagvalues"
+    },
+    "tags.gcp.upbound.io/LocationTagBinding": {
+      "singular": "locationtagbinding",
+      "plural": "locationtagbindings"
+    },
+    "tags.gcp.upbound.io/TagBinding": {
+      "singular": "tagbinding",
+      "plural": "tagbindings"
+    },
+    "tags.gcp.upbound.io/TagKey": {
+      "singular": "tagkey",
+      "plural": "tagkeys"
+    },
+    "tags.gcp.upbound.io/TagValue": {
+      "singular": "tagvalue",
+      "plural": "tagvalues"
+    },
+    "tpu.gcp.m.upbound.io/Node": {
+      "singular": "node",
+      "plural": "nodes"
+    },
+    "tpu.gcp.upbound.io/Node": {
+      "singular": "node",
+      "plural": "nodes"
+    },
+    "vertexai.gcp.m.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "vertexai.gcp.m.upbound.io/Featurestore": {
+      "singular": "featurestore",
+      "plural": "featurestores"
+    },
+    "vertexai.gcp.m.upbound.io/FeaturestoreEntitytype": {
+      "singular": "featurestoreentitytype",
+      "plural": "featurestoreentitytypes"
+    },
+    "vertexai.gcp.m.upbound.io/Tensorboard": {
+      "singular": "tensorboard",
+      "plural": "tensorboards"
+    },
+    "vertexai.gcp.upbound.io/Dataset": {
+      "singular": "dataset",
+      "plural": "datasets"
+    },
+    "vertexai.gcp.upbound.io/Featurestore": {
+      "singular": "featurestore",
+      "plural": "featurestores"
+    },
+    "vertexai.gcp.upbound.io/FeaturestoreEntitytype": {
+      "singular": "featurestoreentitytype",
+      "plural": "featurestoreentitytypes"
+    },
+    "vertexai.gcp.upbound.io/Tensorboard": {
+      "singular": "tensorboard",
+      "plural": "tensorboards"
+    },
+    "vpcaccess.gcp.m.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "vpcaccess.gcp.upbound.io/Connector": {
+      "singular": "connector",
+      "plural": "connectors"
+    },
+    "workflows.gcp.m.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    },
+    "workflows.gcp.upbound.io/Workflow": {
+      "singular": "workflow",
+      "plural": "workflows"
+    }
+  },
   "files": [
     "catalog/accesscontextmanager.gcp.m.upbound.io/accesslevel_v1beta1.fields.txt",
     "catalog/accesscontextmanager.gcp.m.upbound.io/accesslevel_v1beta1.json",

--- a/build/history/rabbitmq-cluster-operator.json
+++ b/build/history/rabbitmq-cluster-operator.json
@@ -2,11 +2,20 @@
   "name": "rabbitmq-cluster-operator",
   "repo": "rabbitmq/cluster-operator",
   "version": "v2.22.1",
-  "builtAt": "2026-07-07T07:24:45.253Z",
+  "builtAt": "2026-07-07T19:14:03.375Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "rabbitmq.com/RabbitmqCluster"
   ],
+  "resources": {
+    "rabbitmq.com/RabbitmqCluster": {
+      "singular": "rabbitmqcluster",
+      "plural": "rabbitmqclusters",
+      "shortNames": [
+        "rmq"
+      ]
+    }
+  },
   "files": [
     "catalog/rabbitmq.com/rabbitmqcluster_v1beta1.fields.txt",
     "catalog/rabbitmq.com/rabbitmqcluster_v1beta1.json"

--- a/build/history/redis-operator.json
+++ b/build/history/redis-operator.json
@@ -2,7 +2,7 @@
   "name": "redis-operator",
   "repo": "OT-CONTAINER-KIT/redis-operator",
   "version": "v0.25.0",
-  "builtAt": "2026-07-05T18:37:14.148Z",
+  "builtAt": "2026-07-07T19:14:20.734Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "redis.redis.opstreelabs.in/Redis",
@@ -10,6 +10,24 @@
     "redis.redis.opstreelabs.in/RedisReplication",
     "redis.redis.opstreelabs.in/RedisSentinel"
   ],
+  "resources": {
+    "redis.redis.opstreelabs.in/Redis": {
+      "singular": "redis",
+      "plural": "redis"
+    },
+    "redis.redis.opstreelabs.in/RedisCluster": {
+      "singular": "rediscluster",
+      "plural": "redisclusters"
+    },
+    "redis.redis.opstreelabs.in/RedisReplication": {
+      "singular": "redisreplication",
+      "plural": "redisreplications"
+    },
+    "redis.redis.opstreelabs.in/RedisSentinel": {
+      "singular": "redissentinel",
+      "plural": "redissentinels"
+    }
+  },
   "files": [
     "catalog/redis.redis.opstreelabs.in/redis_v1beta2.fields.txt",
     "catalog/redis.redis.opstreelabs.in/redis_v1beta2.json",

--- a/build/history/rook.json
+++ b/build/history/rook.json
@@ -2,8 +2,8 @@
   "name": "rook",
   "repo": "rook/rook",
   "version": "v1.20.1",
-  "builtAt": "2026-07-05T11:26:26.124Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:06:58.259Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "ceph.rook.io/CephBlockPool",
     "ceph.rook.io/CephBlockPoolRadosNamespace",
@@ -27,6 +27,158 @@
     "objectbucket.io/ObjectBucket",
     "objectbucket.io/ObjectBucketClaim"
   ],
+  "resources": {
+    "ceph.rook.io/CephBlockPool": {
+      "singular": "cephblockpool",
+      "plural": "cephblockpools",
+      "shortNames": [
+        "cephbp"
+      ]
+    },
+    "ceph.rook.io/CephBlockPoolRadosNamespace": {
+      "singular": "cephblockpoolradosnamespace",
+      "plural": "cephblockpoolradosnamespaces",
+      "shortNames": [
+        "cephbprns",
+        "cephrns"
+      ]
+    },
+    "ceph.rook.io/CephBucketNotification": {
+      "singular": "cephbucketnotification",
+      "plural": "cephbucketnotifications",
+      "shortNames": [
+        "cephbn"
+      ]
+    },
+    "ceph.rook.io/CephBucketTopic": {
+      "singular": "cephbuckettopic",
+      "plural": "cephbuckettopics",
+      "shortNames": [
+        "cephbt"
+      ]
+    },
+    "ceph.rook.io/CephCOSIDriver": {
+      "singular": "cephcosidriver",
+      "plural": "cephcosidrivers",
+      "shortNames": [
+        "cephcosi"
+      ]
+    },
+    "ceph.rook.io/CephClient": {
+      "singular": "cephclient",
+      "plural": "cephclients",
+      "shortNames": [
+        "cephcl"
+      ]
+    },
+    "ceph.rook.io/CephCluster": {
+      "singular": "cephcluster",
+      "plural": "cephclusters",
+      "shortNames": [
+        "ceph"
+      ]
+    },
+    "ceph.rook.io/CephFilesystem": {
+      "singular": "cephfilesystem",
+      "plural": "cephfilesystems",
+      "shortNames": [
+        "cephfs"
+      ]
+    },
+    "ceph.rook.io/CephFilesystemMirror": {
+      "singular": "cephfilesystemmirror",
+      "plural": "cephfilesystemmirrors",
+      "shortNames": [
+        "cephfsm"
+      ]
+    },
+    "ceph.rook.io/CephFilesystemSubVolumeGroup": {
+      "singular": "cephfilesystemsubvolumegroup",
+      "plural": "cephfilesystemsubvolumegroups",
+      "shortNames": [
+        "cephfssvg",
+        "cephsvg"
+      ]
+    },
+    "ceph.rook.io/CephNFS": {
+      "singular": "cephnfs",
+      "plural": "cephnfses",
+      "shortNames": [
+        "nfs"
+      ]
+    },
+    "ceph.rook.io/CephNVMeOFGateway": {
+      "singular": "cephnvmeofgateway",
+      "plural": "cephnvmeofgateways",
+      "shortNames": [
+        "nvmeof"
+      ]
+    },
+    "ceph.rook.io/CephObjectRealm": {
+      "singular": "cephobjectrealm",
+      "plural": "cephobjectrealms",
+      "shortNames": [
+        "cephor"
+      ]
+    },
+    "ceph.rook.io/CephObjectStore": {
+      "singular": "cephobjectstore",
+      "plural": "cephobjectstores",
+      "shortNames": [
+        "cephos"
+      ]
+    },
+    "ceph.rook.io/CephObjectStoreAccount": {
+      "singular": "cephobjectstoreaccount",
+      "plural": "cephobjectstoreaccounts"
+    },
+    "ceph.rook.io/CephObjectStoreUser": {
+      "singular": "cephobjectstoreuser",
+      "plural": "cephobjectstoreusers",
+      "shortNames": [
+        "rcou",
+        "objectuser",
+        "cephosu"
+      ]
+    },
+    "ceph.rook.io/CephObjectZone": {
+      "singular": "cephobjectzone",
+      "plural": "cephobjectzones",
+      "shortNames": [
+        "cephoz"
+      ]
+    },
+    "ceph.rook.io/CephObjectZoneGroup": {
+      "singular": "cephobjectzonegroup",
+      "plural": "cephobjectzonegroups",
+      "shortNames": [
+        "cephozg"
+      ]
+    },
+    "ceph.rook.io/CephRBDMirror": {
+      "singular": "cephrbdmirror",
+      "plural": "cephrbdmirrors",
+      "shortNames": [
+        "cephrbdm"
+      ]
+    },
+    "objectbucket.io/ObjectBucket": {
+      "singular": "objectbucket",
+      "plural": "objectbuckets",
+      "shortNames": [
+        "ob",
+        "obs"
+      ]
+    },
+    "objectbucket.io/ObjectBucketClaim": {
+      "singular": "objectbucketclaim",
+      "plural": "objectbucketclaims",
+      "shortNames": [
+        "obc",
+        "obcs"
+      ]
+    }
+  },
   "files": [
     "catalog/ceph.rook.io/cephblockpool_v1.fields.txt",
     "catalog/ceph.rook.io/cephblockpool_v1.json",

--- a/build/history/scylla-operator.json
+++ b/build/history/scylla-operator.json
@@ -2,7 +2,7 @@
   "name": "scylla-operator",
   "repo": "scylladb/scylla-operator",
   "version": "v1.21.0",
-  "builtAt": "2026-07-05T18:39:40.030Z",
+  "builtAt": "2026-07-07T19:14:38.461Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "scylla.scylladb.com/NodeConfig",
@@ -17,6 +17,52 @@
     "scylla.scylladb.com/ScyllaDBMonitoring",
     "scylla.scylladb.com/ScyllaOperatorConfig"
   ],
+  "resources": {
+    "scylla.scylladb.com/NodeConfig": {
+      "singular": "nodeconfig",
+      "plural": "nodeconfigs"
+    },
+    "scylla.scylladb.com/RemoteKubernetesCluster": {
+      "singular": "remotekubernetescluster",
+      "plural": "remotekubernetesclusters"
+    },
+    "scylla.scylladb.com/RemoteOwner": {
+      "singular": "remoteowner",
+      "plural": "remoteowners"
+    },
+    "scylla.scylladb.com/ScyllaCluster": {
+      "singular": "scyllacluster",
+      "plural": "scyllaclusters"
+    },
+    "scylla.scylladb.com/ScyllaDBCluster": {
+      "singular": "scylladbcluster",
+      "plural": "scylladbclusters"
+    },
+    "scylla.scylladb.com/ScyllaDBDatacenter": {
+      "singular": "scylladbdatacenter",
+      "plural": "scylladbdatacenters"
+    },
+    "scylla.scylladb.com/ScyllaDBDatacenterNodesStatusReport": {
+      "singular": "scylladbdatacenternodesstatusreport",
+      "plural": "scylladbdatacenternodesstatusreports"
+    },
+    "scylla.scylladb.com/ScyllaDBManagerClusterRegistration": {
+      "singular": "scylladbmanagerclusterregistration",
+      "plural": "scylladbmanagerclusterregistrations"
+    },
+    "scylla.scylladb.com/ScyllaDBManagerTask": {
+      "singular": "scylladbmanagertask",
+      "plural": "scylladbmanagertasks"
+    },
+    "scylla.scylladb.com/ScyllaDBMonitoring": {
+      "singular": "scylladbmonitoring",
+      "plural": "scylladbmonitorings"
+    },
+    "scylla.scylladb.com/ScyllaOperatorConfig": {
+      "singular": "scyllaoperatorconfig",
+      "plural": "scyllaoperatorconfigs"
+    }
+  },
   "files": [
     "catalog/scylla.scylladb.com/nodeconfig_v1alpha1.fields.txt",
     "catalog/scylla.scylladb.com/nodeconfig_v1alpha1.json",

--- a/build/history/secrets-store-csi-driver.json
+++ b/build/history/secrets-store-csi-driver.json
@@ -2,12 +2,22 @@
   "name": "secrets-store-csi-driver",
   "repo": "kubernetes-sigs/secrets-store-csi-driver",
   "version": "v1.6.0",
-  "builtAt": "2026-07-05T13:14:43.746Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:24.967Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "secrets-store.csi.x-k8s.io/SecretProviderClass",
     "secrets-store.csi.x-k8s.io/SecretProviderClassPodStatus"
   ],
+  "resources": {
+    "secrets-store.csi.x-k8s.io/SecretProviderClass": {
+      "singular": "secretproviderclass",
+      "plural": "secretproviderclasses"
+    },
+    "secrets-store.csi.x-k8s.io/SecretProviderClassPodStatus": {
+      "singular": "secretproviderclasspodstatus",
+      "plural": "secretproviderclasspodstatuses"
+    }
+  },
   "files": [
     "catalog/secrets-store.csi.x-k8s.io/secretproviderclass_v1.fields.txt",
     "catalog/secrets-store.csi.x-k8s.io/secretproviderclass_v1.json",

--- a/build/history/sigstore-policy-controller.json
+++ b/build/history/sigstore-policy-controller.json
@@ -2,12 +2,25 @@
   "name": "sigstore-policy-controller",
   "repo": "sigstore/policy-controller",
   "version": "v0.15.1",
-  "builtAt": "2026-07-06T22:09:38.739Z",
+  "builtAt": "2026-07-07T19:06:56.772Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "policy.sigstore.dev/ClusterImagePolicy",
     "policy.sigstore.dev/TrustRoot"
   ],
+  "resources": {
+    "policy.sigstore.dev/ClusterImagePolicy": {
+      "singular": "clusterimagepolicy",
+      "plural": "clusterimagepolicies",
+      "shortNames": [
+        "cip"
+      ]
+    },
+    "policy.sigstore.dev/TrustRoot": {
+      "singular": "trustroot",
+      "plural": "trustroots"
+    }
+  },
   "files": [
     "catalog/policy.sigstore.dev/clusterimagepolicy_v1alpha1.fields.txt",
     "catalog/policy.sigstore.dev/clusterimagepolicy_v1alpha1.json",

--- a/build/history/spire-controller-manager.json
+++ b/build/history/spire-controller-manager.json
@@ -2,7 +2,7 @@
   "name": "spire-controller-manager",
   "repo": "spiffe/spire-controller-manager",
   "version": "v0.6.6",
-  "builtAt": "2026-07-05T16:31:22.407Z",
+  "builtAt": "2026-07-07T19:10:12.213Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "spire.spiffe.io/ClusterFederatedTrustDomain",
@@ -10,6 +10,24 @@
     "spire.spiffe.io/ClusterStaticEntry",
     "spire.spiffe.io/ControllerManagerConfig"
   ],
+  "resources": {
+    "spire.spiffe.io/ClusterFederatedTrustDomain": {
+      "singular": "clusterfederatedtrustdomain",
+      "plural": "clusterfederatedtrustdomains"
+    },
+    "spire.spiffe.io/ClusterSPIFFEID": {
+      "singular": "clusterspiffeid",
+      "plural": "clusterspiffeids"
+    },
+    "spire.spiffe.io/ClusterStaticEntry": {
+      "singular": "clusterstaticentry",
+      "plural": "clusterstaticentries"
+    },
+    "spire.spiffe.io/ControllerManagerConfig": {
+      "singular": "controllermanagerconfig",
+      "plural": "controllermanagerconfigs"
+    }
+  },
   "files": [
     "catalog/spire.spiffe.io/clusterfederatedtrustdomain_v1alpha1.fields.txt",
     "catalog/spire.spiffe.io/clusterfederatedtrustdomain_v1alpha1.json",

--- a/build/history/strimzi.json
+++ b/build/history/strimzi.json
@@ -2,8 +2,8 @@
   "name": "strimzi",
   "repo": "strimzi/strimzi-kafka-operator",
   "version": "0.51.0",
-  "builtAt": "2026-07-05T11:33:50.977Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:00.603Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "core.strimzi.io/StrimziPodSet",
     "kafka.strimzi.io/Kafka",
@@ -16,6 +16,78 @@
     "kafka.strimzi.io/KafkaTopic",
     "kafka.strimzi.io/KafkaUser"
   ],
+  "resources": {
+    "core.strimzi.io/StrimziPodSet": {
+      "singular": "strimzipodset",
+      "plural": "strimzipodsets",
+      "shortNames": [
+        "sps"
+      ]
+    },
+    "kafka.strimzi.io/Kafka": {
+      "singular": "kafka",
+      "plural": "kafkas",
+      "shortNames": [
+        "k"
+      ]
+    },
+    "kafka.strimzi.io/KafkaBridge": {
+      "singular": "kafkabridge",
+      "plural": "kafkabridges",
+      "shortNames": [
+        "kb"
+      ]
+    },
+    "kafka.strimzi.io/KafkaConnect": {
+      "singular": "kafkaconnect",
+      "plural": "kafkaconnects",
+      "shortNames": [
+        "kc"
+      ]
+    },
+    "kafka.strimzi.io/KafkaConnector": {
+      "singular": "kafkaconnector",
+      "plural": "kafkaconnectors",
+      "shortNames": [
+        "kctr"
+      ]
+    },
+    "kafka.strimzi.io/KafkaMirrorMaker2": {
+      "singular": "kafkamirrormaker2",
+      "plural": "kafkamirrormaker2s",
+      "shortNames": [
+        "kmm2"
+      ]
+    },
+    "kafka.strimzi.io/KafkaNodePool": {
+      "singular": "kafkanodepool",
+      "plural": "kafkanodepools",
+      "shortNames": [
+        "knp"
+      ]
+    },
+    "kafka.strimzi.io/KafkaRebalance": {
+      "singular": "kafkarebalance",
+      "plural": "kafkarebalances",
+      "shortNames": [
+        "kr"
+      ]
+    },
+    "kafka.strimzi.io/KafkaTopic": {
+      "singular": "kafkatopic",
+      "plural": "kafkatopics",
+      "shortNames": [
+        "kt"
+      ]
+    },
+    "kafka.strimzi.io/KafkaUser": {
+      "singular": "kafkauser",
+      "plural": "kafkausers",
+      "shortNames": [
+        "ku"
+      ]
+    }
+  },
   "files": [
     "catalog/core.strimzi.io/strimzipodset_v1.fields.txt",
     "catalog/core.strimzi.io/strimzipodset_v1.json",

--- a/build/history/submariner-operator.json
+++ b/build/history/submariner-operator.json
@@ -2,13 +2,27 @@
   "name": "submariner-operator",
   "repo": "submariner-io/submariner-operator",
   "version": "v0.24.0",
-  "builtAt": "2026-07-05T19:01:35.819Z",
+  "builtAt": "2026-07-07T19:14:59.017Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "submariner.io/Broker",
     "submariner.io/ServiceDiscovery",
     "submariner.io/Submariner"
   ],
+  "resources": {
+    "submariner.io/Broker": {
+      "singular": "broker",
+      "plural": "brokers"
+    },
+    "submariner.io/ServiceDiscovery": {
+      "singular": "servicediscovery",
+      "plural": "servicediscoveries"
+    },
+    "submariner.io/Submariner": {
+      "singular": "submariner",
+      "plural": "submariners"
+    }
+  },
   "files": [
     "catalog/submariner.io/broker_v1alpha1.fields.txt",
     "catalog/submariner.io/broker_v1alpha1.json",

--- a/build/history/submariner.json
+++ b/build/history/submariner.json
@@ -2,7 +2,7 @@
   "name": "submariner",
   "repo": "submariner-io/submariner",
   "version": "v0.24.0",
-  "builtAt": "2026-07-05T19:01:37.247Z",
+  "builtAt": "2026-07-07T19:15:00.023Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "submariner.io/Cluster",
@@ -15,6 +15,59 @@
     "submariner.io/NonGatewayRoute",
     "submariner.io/RouteAgent"
   ],
+  "resources": {
+    "submariner.io/Cluster": {
+      "singular": "cluster",
+      "plural": "clusters"
+    },
+    "submariner.io/ClusterGlobalEgressIP": {
+      "singular": "clusterglobalegressip",
+      "plural": "clusterglobalegressips",
+      "shortNames": [
+        "cgeip"
+      ]
+    },
+    "submariner.io/Endpoint": {
+      "singular": "endpoint",
+      "plural": "endpoints"
+    },
+    "submariner.io/Gateway": {
+      "singular": "gateway",
+      "plural": "gateways"
+    },
+    "submariner.io/GatewayRoute": {
+      "singular": "gatewayroute",
+      "plural": "gatewayroutes",
+      "shortNames": [
+        "gwrt"
+      ]
+    },
+    "submariner.io/GlobalEgressIP": {
+      "singular": "globalegressip",
+      "plural": "globalegressips",
+      "shortNames": [
+        "geip"
+      ]
+    },
+    "submariner.io/GlobalIngressIP": {
+      "singular": "globalingressip",
+      "plural": "globalingressips",
+      "shortNames": [
+        "giip"
+      ]
+    },
+    "submariner.io/NonGatewayRoute": {
+      "singular": "nongatewayroute",
+      "plural": "nongatewayroutes",
+      "shortNames": [
+        "ngwrt"
+      ]
+    },
+    "submariner.io/RouteAgent": {
+      "singular": "routeagent",
+      "plural": "routeagents"
+    }
+  },
   "files": [
     "catalog/submariner.io/cluster_v1.fields.txt",
     "catalog/submariner.io/cluster_v1.json",

--- a/build/history/tailscale.json
+++ b/build/history/tailscale.json
@@ -2,7 +2,7 @@
   "name": "tailscale",
   "repo": "tailscale/tailscale",
   "version": "v1.98.8",
-  "builtAt": "2026-07-06T22:03:59.578Z",
+  "builtAt": "2026-07-07T19:05:37.368Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "tailscale.com/Connector",
@@ -13,6 +13,54 @@
     "tailscale.com/Recorder",
     "tailscale.com/Tailnet"
   ],
+  "resources": {
+    "tailscale.com/Connector": {
+      "singular": "connector",
+      "plural": "connectors",
+      "shortNames": [
+        "cn"
+      ]
+    },
+    "tailscale.com/DNSConfig": {
+      "singular": "dnsconfig",
+      "plural": "dnsconfigs",
+      "shortNames": [
+        "dc"
+      ]
+    },
+    "tailscale.com/ProxyClass": {
+      "singular": "proxyclass",
+      "plural": "proxyclasses"
+    },
+    "tailscale.com/ProxyGroup": {
+      "singular": "proxygroup",
+      "plural": "proxygroups",
+      "shortNames": [
+        "pg"
+      ]
+    },
+    "tailscale.com/ProxyGroupPolicy": {
+      "singular": "proxygrouppolicy",
+      "plural": "proxygrouppolicies",
+      "shortNames": [
+        "pgp"
+      ]
+    },
+    "tailscale.com/Recorder": {
+      "singular": "recorder",
+      "plural": "recorders",
+      "shortNames": [
+        "rec"
+      ]
+    },
+    "tailscale.com/Tailnet": {
+      "singular": "tailnet",
+      "plural": "tailnets",
+      "shortNames": [
+        "tn"
+      ]
+    }
+  },
   "files": [
     "catalog/tailscale.com/connector_v1alpha1.fields.txt",
     "catalog/tailscale.com/connector_v1alpha1.json",

--- a/build/history/tekton-pipeline.json
+++ b/build/history/tekton-pipeline.json
@@ -2,8 +2,8 @@
   "name": "tekton-pipeline",
   "repo": "tektoncd/pipeline",
   "version": "v1.14.0",
-  "builtAt": "2026-07-05T11:03:00.214Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:06:50.074Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "resolution.tekton.dev/ResolutionRequest",
     "tekton.dev/CustomRun",
@@ -14,6 +14,48 @@
     "tekton.dev/TaskRun",
     "tekton.dev/VerificationPolicy"
   ],
+  "resources": {
+    "resolution.tekton.dev/ResolutionRequest": {
+      "singular": "resolutionrequest",
+      "plural": "resolutionrequests"
+    },
+    "tekton.dev/CustomRun": {
+      "singular": "customrun",
+      "plural": "customruns"
+    },
+    "tekton.dev/Pipeline": {
+      "singular": "pipeline",
+      "plural": "pipelines"
+    },
+    "tekton.dev/PipelineRun": {
+      "singular": "pipelinerun",
+      "plural": "pipelineruns",
+      "shortNames": [
+        "pr",
+        "prs"
+      ]
+    },
+    "tekton.dev/StepAction": {
+      "singular": "stepaction",
+      "plural": "stepactions"
+    },
+    "tekton.dev/Task": {
+      "singular": "task",
+      "plural": "tasks"
+    },
+    "tekton.dev/TaskRun": {
+      "singular": "taskrun",
+      "plural": "taskruns",
+      "shortNames": [
+        "tr",
+        "trs"
+      ]
+    },
+    "tekton.dev/VerificationPolicy": {
+      "singular": "verificationpolicy",
+      "plural": "verificationpolicies"
+    }
+  },
   "files": [
     "catalog/resolution.tekton.dev/resolutionrequest_v1alpha1.fields.txt",
     "catalog/resolution.tekton.dev/resolutionrequest_v1alpha1.json",

--- a/build/history/tigera-operator.json
+++ b/build/history/tigera-operator.json
@@ -2,7 +2,7 @@
   "name": "tigera-operator",
   "repo": "projectcalico/calico",
   "version": "v3.32.1",
-  "builtAt": "2026-07-05T18:40:26.119Z",
+  "builtAt": "2026-07-07T19:14:54.244Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "operator.tigera.io/APIServer",
@@ -15,6 +15,44 @@
     "operator.tigera.io/TigeraStatus",
     "operator.tigera.io/Whisker"
   ],
+  "resources": {
+    "operator.tigera.io/APIServer": {
+      "singular": "apiserver",
+      "plural": "apiservers"
+    },
+    "operator.tigera.io/GatewayAPI": {
+      "singular": "gatewayapi",
+      "plural": "gatewayapis"
+    },
+    "operator.tigera.io/Goldmane": {
+      "singular": "goldmane",
+      "plural": "goldmanes"
+    },
+    "operator.tigera.io/ImageSet": {
+      "singular": "imageset",
+      "plural": "imagesets"
+    },
+    "operator.tigera.io/Installation": {
+      "singular": "installation",
+      "plural": "installations"
+    },
+    "operator.tigera.io/Istio": {
+      "singular": "istio",
+      "plural": "istios"
+    },
+    "operator.tigera.io/ManagementClusterConnection": {
+      "singular": "managementclusterconnection",
+      "plural": "managementclusterconnections"
+    },
+    "operator.tigera.io/TigeraStatus": {
+      "singular": "tigerastatus",
+      "plural": "tigerastatuses"
+    },
+    "operator.tigera.io/Whisker": {
+      "singular": "whisker",
+      "plural": "whiskers"
+    }
+  },
   "files": [
     "catalog/operator.tigera.io/apiserver_v1.fields.txt",
     "catalog/operator.tigera.io/apiserver_v1.json",

--- a/build/history/trust-manager.json
+++ b/build/history/trust-manager.json
@@ -2,12 +2,22 @@
   "name": "trust-manager",
   "repo": "cert-manager/trust-manager",
   "version": "v0.24.0",
-  "builtAt": "2026-07-05T16:34:24.108Z",
+  "builtAt": "2026-07-07T19:05:09.958Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "trust-manager.io/ClusterBundle",
     "trust.cert-manager.io/Bundle"
   ],
+  "resources": {
+    "trust-manager.io/ClusterBundle": {
+      "singular": "clusterbundle",
+      "plural": "clusterbundles"
+    },
+    "trust.cert-manager.io/Bundle": {
+      "singular": "bundle",
+      "plural": "bundles"
+    }
+  },
   "files": [
     "catalog/trust-manager.io/clusterbundle_v1alpha2.fields.txt",
     "catalog/trust-manager.io/clusterbundle_v1alpha2.json",

--- a/build/history/velero.json
+++ b/build/history/velero.json
@@ -2,8 +2,8 @@
   "name": "velero",
   "repo": "vmware-tanzu/velero",
   "version": "v1.18.2",
-  "builtAt": "2026-07-05T13:14:45.783Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:07:49.770Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "velero.io/Backup",
     "velero.io/BackupRepository",
@@ -17,6 +17,61 @@
     "velero.io/ServerStatusRequest",
     "velero.io/VolumeSnapshotLocation"
   ],
+  "resources": {
+    "velero.io/Backup": {
+      "singular": "backup",
+      "plural": "backups"
+    },
+    "velero.io/BackupRepository": {
+      "singular": "backuprepository",
+      "plural": "backuprepositories"
+    },
+    "velero.io/BackupStorageLocation": {
+      "singular": "backupstoragelocation",
+      "plural": "backupstoragelocations",
+      "shortNames": [
+        "bsl"
+      ]
+    },
+    "velero.io/DeleteBackupRequest": {
+      "singular": "deletebackuprequest",
+      "plural": "deletebackuprequests"
+    },
+    "velero.io/DownloadRequest": {
+      "singular": "downloadrequest",
+      "plural": "downloadrequests"
+    },
+    "velero.io/PodVolumeBackup": {
+      "singular": "podvolumebackup",
+      "plural": "podvolumebackups"
+    },
+    "velero.io/PodVolumeRestore": {
+      "singular": "podvolumerestore",
+      "plural": "podvolumerestores"
+    },
+    "velero.io/Restore": {
+      "singular": "restore",
+      "plural": "restores"
+    },
+    "velero.io/Schedule": {
+      "singular": "schedule",
+      "plural": "schedules"
+    },
+    "velero.io/ServerStatusRequest": {
+      "singular": "serverstatusrequest",
+      "plural": "serverstatusrequests",
+      "shortNames": [
+        "ssr"
+      ]
+    },
+    "velero.io/VolumeSnapshotLocation": {
+      "singular": "volumesnapshotlocation",
+      "plural": "volumesnapshotlocations",
+      "shortNames": [
+        "vsl"
+      ]
+    }
+  },
   "files": [
     "catalog/velero.io/backup_v1.fields.txt",
     "catalog/velero.io/backup_v1.json",

--- a/build/history/vertical-pod-autoscaler.json
+++ b/build/history/vertical-pod-autoscaler.json
@@ -2,12 +2,28 @@
   "name": "vertical-pod-autoscaler",
   "repo": "kubernetes/autoscaler",
   "version": "vertical-pod-autoscaler-1.7.0",
-  "builtAt": "2026-07-06T23:14:28.204Z",
+  "builtAt": "2026-07-07T19:07:16.606Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "autoscaling.k8s.io/VerticalPodAutoscaler",
     "autoscaling.k8s.io/VerticalPodAutoscalerCheckpoint"
   ],
+  "resources": {
+    "autoscaling.k8s.io/VerticalPodAutoscaler": {
+      "singular": "verticalpodautoscaler",
+      "plural": "verticalpodautoscalers",
+      "shortNames": [
+        "vpa"
+      ]
+    },
+    "autoscaling.k8s.io/VerticalPodAutoscalerCheckpoint": {
+      "singular": "verticalpodautoscalercheckpoint",
+      "plural": "verticalpodautoscalercheckpoints",
+      "shortNames": [
+        "vpacheckpoint"
+      ]
+    }
+  },
   "files": [
     "catalog/autoscaling.k8s.io/verticalpodautoscaler_v1.fields.txt",
     "catalog/autoscaling.k8s.io/verticalpodautoscaler_v1.json",

--- a/build/history/victoriametrics-operator.json
+++ b/build/history/victoriametrics-operator.json
@@ -2,8 +2,8 @@
   "name": "victoriametrics-operator",
   "repo": "VictoriaMetrics/operator",
   "version": "v0.72.0",
-  "builtAt": "2026-07-05T10:52:55.283Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:05:41.200Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "operator.victoriametrics.com/VLAgent",
     "operator.victoriametrics.com/VLCluster",
@@ -30,6 +30,107 @@
     "operator.victoriametrics.com/VTCluster",
     "operator.victoriametrics.com/VTSingle"
   ],
+  "resources": {
+    "operator.victoriametrics.com/VLAgent": {
+      "singular": "vlagent",
+      "plural": "vlagents"
+    },
+    "operator.victoriametrics.com/VLCluster": {
+      "singular": "vlcluster",
+      "plural": "vlclusters"
+    },
+    "operator.victoriametrics.com/VLSingle": {
+      "singular": "vlsingle",
+      "plural": "vlsingles"
+    },
+    "operator.victoriametrics.com/VLogs": {
+      "singular": "vlogs",
+      "plural": "vlogs"
+    },
+    "operator.victoriametrics.com/VMAgent": {
+      "singular": "vmagent",
+      "plural": "vmagents"
+    },
+    "operator.victoriametrics.com/VMAlert": {
+      "singular": "vmalert",
+      "plural": "vmalerts"
+    },
+    "operator.victoriametrics.com/VMAlertmanager": {
+      "singular": "vmalertmanager",
+      "plural": "vmalertmanagers",
+      "shortNames": [
+        "vma"
+      ]
+    },
+    "operator.victoriametrics.com/VMAlertmanagerConfig": {
+      "singular": "vmalertmanagerconfig",
+      "plural": "vmalertmanagerconfigs"
+    },
+    "operator.victoriametrics.com/VMAnomaly": {
+      "singular": "vmanomaly",
+      "plural": "vmanomalies"
+    },
+    "operator.victoriametrics.com/VMAnomalyConfig": {
+      "singular": "vmanomalyconfig",
+      "plural": "vmanomalyconfigs"
+    },
+    "operator.victoriametrics.com/VMAuth": {
+      "singular": "vmauth",
+      "plural": "vmauths"
+    },
+    "operator.victoriametrics.com/VMCluster": {
+      "singular": "vmcluster",
+      "plural": "vmclusters"
+    },
+    "operator.victoriametrics.com/VMDistributed": {
+      "singular": "vmdistributed",
+      "plural": "vmdistributed"
+    },
+    "operator.victoriametrics.com/VMNodeScrape": {
+      "singular": "vmnodescrape",
+      "plural": "vmnodescrapes"
+    },
+    "operator.victoriametrics.com/VMPodScrape": {
+      "singular": "vmpodscrape",
+      "plural": "vmpodscrapes"
+    },
+    "operator.victoriametrics.com/VMProbe": {
+      "singular": "vmprobe",
+      "plural": "vmprobes"
+    },
+    "operator.victoriametrics.com/VMRule": {
+      "singular": "vmrule",
+      "plural": "vmrules"
+    },
+    "operator.victoriametrics.com/VMScrapeConfig": {
+      "singular": "vmscrapeconfig",
+      "plural": "vmscrapeconfigs"
+    },
+    "operator.victoriametrics.com/VMServiceScrape": {
+      "singular": "vmservicescrape",
+      "plural": "vmservicescrapes"
+    },
+    "operator.victoriametrics.com/VMSingle": {
+      "singular": "vmsingle",
+      "plural": "vmsingles"
+    },
+    "operator.victoriametrics.com/VMStaticScrape": {
+      "singular": "vmstaticscrape",
+      "plural": "vmstaticscrapes"
+    },
+    "operator.victoriametrics.com/VMUser": {
+      "singular": "vmuser",
+      "plural": "vmusers"
+    },
+    "operator.victoriametrics.com/VTCluster": {
+      "singular": "vtcluster",
+      "plural": "vtclusters"
+    },
+    "operator.victoriametrics.com/VTSingle": {
+      "singular": "vtsingle",
+      "plural": "vtsingles"
+    }
+  },
   "files": [
     "catalog/operator.victoriametrics.com/vlagent_v1.fields.txt",
     "catalog/operator.victoriametrics.com/vlagent_v1.json",

--- a/build/history/vitess-operator.json
+++ b/build/history/vitess-operator.json
@@ -2,8 +2,8 @@
   "name": "vitess-operator",
   "repo": "planetscale/vitess-operator",
   "version": "v2.17.0",
-  "builtAt": "2026-07-05T11:26:27.162Z",
-  "fluxSchemaVersion": "0.7.1",
+  "builtAt": "2026-07-07T19:06:59.102Z",
+  "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "planetscale.com/EtcdLockserver",
     "planetscale.com/VitessBackup",
@@ -14,6 +14,61 @@
     "planetscale.com/VitessKeyspace",
     "planetscale.com/VitessShard"
   ],
+  "resources": {
+    "planetscale.com/EtcdLockserver": {
+      "singular": "etcdlockserver",
+      "plural": "etcdlockservers",
+      "shortNames": [
+        "etcdls"
+      ]
+    },
+    "planetscale.com/VitessBackup": {
+      "singular": "vitessbackup",
+      "plural": "vitessbackups",
+      "shortNames": [
+        "vtb"
+      ]
+    },
+    "planetscale.com/VitessBackupSchedule": {
+      "singular": "vitessbackupschedule",
+      "plural": "vitessbackupschedules"
+    },
+    "planetscale.com/VitessBackupStorage": {
+      "singular": "vitessbackupstorage",
+      "plural": "vitessbackupstorages",
+      "shortNames": [
+        "vtbs"
+      ]
+    },
+    "planetscale.com/VitessCell": {
+      "singular": "vitesscell",
+      "plural": "vitesscells",
+      "shortNames": [
+        "vtc"
+      ]
+    },
+    "planetscale.com/VitessCluster": {
+      "singular": "vitesscluster",
+      "plural": "vitessclusters",
+      "shortNames": [
+        "vt"
+      ]
+    },
+    "planetscale.com/VitessKeyspace": {
+      "singular": "vitesskeyspace",
+      "plural": "vitesskeyspaces",
+      "shortNames": [
+        "vtk"
+      ]
+    },
+    "planetscale.com/VitessShard": {
+      "singular": "vitessshard",
+      "plural": "vitessshards",
+      "shortNames": [
+        "vts"
+      ]
+    }
+  },
   "files": [
     "catalog/planetscale.com/etcdlockserver_v2.fields.txt",
     "catalog/planetscale.com/etcdlockserver_v2.json",

--- a/build/history/volcano-jobflow.json
+++ b/build/history/volcano-jobflow.json
@@ -2,12 +2,28 @@
   "name": "volcano-jobflow",
   "repo": "volcano-sh/volcano",
   "version": "v1.15.0",
-  "builtAt": "2026-07-05T17:12:11.001Z",
+  "builtAt": "2026-07-07T19:12:14.102Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "flow.volcano.sh/JobFlow",
     "flow.volcano.sh/JobTemplate"
   ],
+  "resources": {
+    "flow.volcano.sh/JobFlow": {
+      "singular": "jobflow",
+      "plural": "jobflows",
+      "shortNames": [
+        "jf"
+      ]
+    },
+    "flow.volcano.sh/JobTemplate": {
+      "singular": "jobtemplate",
+      "plural": "jobtemplates",
+      "shortNames": [
+        "jt"
+      ]
+    }
+  },
   "files": [
     "catalog/flow.volcano.sh/jobflow_v1alpha1.fields.txt",
     "catalog/flow.volcano.sh/jobflow_v1alpha1.json",

--- a/build/history/volcano.json
+++ b/build/history/volcano.json
@@ -2,7 +2,7 @@
   "name": "volcano",
   "repo": "volcano-sh/volcano",
   "version": "v1.15.0",
-  "builtAt": "2026-07-05T17:12:07.253Z",
+  "builtAt": "2026-07-07T19:11:58.291Z",
   "fluxSchemaVersion": "0.7.2",
   "kinds": [
     "batch.volcano.sh/CronJob",
@@ -15,6 +15,69 @@
     "shard.volcano.sh/NodeShard",
     "topology.volcano.sh/HyperNode"
   ],
+  "resources": {
+    "batch.volcano.sh/CronJob": {
+      "singular": "cronjob",
+      "plural": "cronjobs",
+      "shortNames": [
+        "cronvcjob",
+        "cronvj"
+      ]
+    },
+    "batch.volcano.sh/Job": {
+      "singular": "job",
+      "plural": "jobs",
+      "shortNames": [
+        "vcjob",
+        "vj"
+      ]
+    },
+    "bus.volcano.sh/Command": {
+      "singular": "command",
+      "plural": "commands"
+    },
+    "config.volcano.sh/ColocationConfiguration": {
+      "singular": "colocationconfiguration",
+      "plural": "colocationconfigurations"
+    },
+    "nodeinfo.volcano.sh/Numatopology": {
+      "singular": "numatopology",
+      "plural": "numatopologies",
+      "shortNames": [
+        "numatopo"
+      ]
+    },
+    "scheduling.volcano.sh/PodGroup": {
+      "singular": "podgroup",
+      "plural": "podgroups",
+      "shortNames": [
+        "pg",
+        "podgroup-v1beta1"
+      ]
+    },
+    "scheduling.volcano.sh/Queue": {
+      "singular": "queue",
+      "plural": "queues",
+      "shortNames": [
+        "q",
+        "queue-v1beta1"
+      ]
+    },
+    "shard.volcano.sh/NodeShard": {
+      "singular": "nodeshard",
+      "plural": "nodeshards",
+      "shortNames": [
+        "nsh"
+      ]
+    },
+    "topology.volcano.sh/HyperNode": {
+      "singular": "hypernode",
+      "plural": "hypernodes",
+      "shortNames": [
+        "hn"
+      ]
+    }
+  },
   "files": [
     "catalog/batch.volcano.sh/cronjob_v1alpha1.fields.txt",
     "catalog/batch.volcano.sh/cronjob_v1alpha1.json",

--- a/build/src/build.test.ts
+++ b/build/src/build.test.ts
@@ -3,9 +3,9 @@
 
 import { describe, expect, test } from "bun:test";
 import { CATEGORIES } from "./config.ts";
-import { dropEmptyDocs, fluxInstanceManifest } from "./extract.ts";
+import { crdResourceNames, dropEmptyDocs, fluxInstanceManifest } from "./extract.ts";
 import { excludeByBasename, extractTarFiles, matchAsset } from "./github.ts";
-import { kindCasing, parseKindName, pruneKindsWithoutFields, removedFiles } from "./history.ts";
+import { kindCasing, parseKindName, pruneKindsWithoutFields, removedFiles, resourceNamesForKinds } from "./history.ts";
 import { renderCatalogStats, renderVersionsTable, spliceVersionsTable } from "./readme.ts";
 import { renderBuildSummary } from "./summary.ts";
 import {
@@ -368,6 +368,25 @@ describe("kindCasing", () => {
   });
 });
 
+
+describe("resourceNamesForKinds", () => {
+  test("keeps only resources for indexed kinds", () => {
+    expect(
+      resourceNamesForKinds(
+        {
+          "example.io/Widget": { plural: "widgets", shortNames: ["wdg"] },
+          "example.io/WidgetList": { plural: "widgetlists" },
+        },
+        ["example.io/Widget"],
+      ),
+    ).toEqual({ "example.io/Widget": { plural: "widgets", shortNames: ["wdg"] } });
+  });
+
+  test("returns undefined when no resources match", () => {
+    expect(resourceNamesForKinds({ "example.io/Widget": { plural: "widgets" } }, ["example.io/Gadget"])).toBeUndefined();
+  });
+});
+
 describe("versions table", () => {
   const readme = "# Title\n\n<!-- versions:start -->\nstale\n<!-- versions:end -->\n";
   const versionRow = (
@@ -555,6 +574,71 @@ describe("fluxInstanceManifest", () => {
     expect(doc.kind).toBe("FluxInstance");
     expect(doc.spec.distribution).toEqual({ version: "v2.9.0", registry: "ghcr.io/fluxcd" });
     expect(doc.spec.components).toEqual(["source-controller"]);
+  });
+});
+
+
+describe("crdResourceNames", () => {
+  test("extracts plural, singular and short names from CRD streams", () => {
+    const yaml = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  group: source.extensions.fluxcd.io
+  names:
+    kind: ArtifactGenerator
+    plural: artifactgenerators
+    singular: artifactgenerator
+    shortNames:
+      - ag
+---
+apiVersion: v1
+kind: ConfigMap
+`;
+
+    expect(crdResourceNames(yaml)).toEqual({
+      "source.extensions.fluxcd.io/ArtifactGenerator": {
+        singular: "artifactgenerator",
+        plural: "artifactgenerators",
+        shortNames: ["ag"],
+      },
+    });
+  });
+
+  test("deduplicates short names and accepts repeated identical CRDs", () => {
+    const crd = `
+kind: CustomResourceDefinition
+spec:
+  group: example.io
+  names:
+    kind: Widget
+    plural: widgets
+    shortNames: [wdg, wdg]
+`;
+
+    expect(crdResourceNames(`${crd}---\n${crd}`)).toEqual({
+      "example.io/Widget": { plural: "widgets", shortNames: ["wdg"] },
+    });
+  });
+
+  test("fails on conflicting names for the same group and kind", () => {
+    const yaml = `
+kind: CustomResourceDefinition
+spec:
+  group: example.io
+  names:
+    kind: Widget
+    plural: widgets
+---
+kind: CustomResourceDefinition
+spec:
+  group: example.io
+  names:
+    kind: Widget
+    plural: widgets2
+`;
+
+    expect(() => crdResourceNames(yaml)).toThrow("conflicting CRD resource names for example.io/Widget");
   });
 });
 

--- a/build/src/build.test.ts
+++ b/build/src/build.test.ts
@@ -368,7 +368,6 @@ describe("kindCasing", () => {
   });
 });
 
-
 describe("resourceNamesForKinds", () => {
   test("keeps only resources for indexed kinds", () => {
     expect(
@@ -576,7 +575,6 @@ describe("fluxInstanceManifest", () => {
     expect(doc.spec.components).toEqual(["source-controller"]);
   });
 });
-
 
 describe("crdResourceNames", () => {
   test("extracts plural, singular and short names from CRD streams", () => {

--- a/build/src/build.test.ts
+++ b/build/src/build.test.ts
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, expect, test } from "bun:test";
+import { parsePositiveIntegerFlag } from "./cli.ts";
 import { CATEGORIES } from "./config.ts";
 import { crdResourceNames, dropEmptyDocs, fluxInstanceManifest } from "./extract.ts";
 import { excludeByBasename, extractTarFiles, matchAsset } from "./github.ts";
 import { kindCasing, parseKindName, pruneKindsWithoutFields, removedFiles, resourceNamesForKinds } from "./history.ts";
+import { runBoundedPool } from "./pool.ts";
 import { renderCatalogStats, renderVersionsTable, spliceVersionsTable } from "./readme.ts";
 import { renderBuildSummary } from "./summary.ts";
 import {
@@ -17,6 +19,53 @@ import {
   pickLatestRelease,
 } from "./resolve.ts";
 import type { HistoryEntry, SourceCategory } from "./types.ts";
+
+describe("parsePositiveIntegerFlag", () => {
+  test("uses the default when the flag is absent", () => {
+    expect(parsePositiveIntegerFlag("--concurrent", undefined, 2)).toBe(2);
+  });
+
+  test("accepts positive integers", () => {
+    expect(parsePositiveIntegerFlag("--concurrent", "4", 2)).toBe(4);
+  });
+
+  test("rejects invalid values", () => {
+    for (const value of ["", "0", "-1", "1.5", "two"]) {
+      expect(() => parsePositiveIntegerFlag("--concurrent", value, 2)).toThrow(
+        "--concurrent must be a positive integer",
+      );
+    }
+  });
+});
+
+describe("runBoundedPool", () => {
+  test("limits concurrent tasks and preserves input order in results", async () => {
+    let active = 0;
+    let peak = 0;
+    const results = await runBoundedPool([1, 2, 3, 4], 2, async (item) => {
+      active++;
+      peak = Math.max(peak, active);
+      await Bun.sleep(1);
+      active--;
+      return item * 10;
+    });
+
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(results.map((result) => ("value" in result ? result.value : null))).toEqual([10, 20, 30, 40]);
+  });
+
+  test("continues scheduling after failures", async () => {
+    const results = await runBoundedPool([1, 2, 3], 2, async (item) => {
+      if (item === 1) {
+        throw new Error("boom");
+      }
+      return item;
+    });
+
+    expect(results.map((result) => result.item)).toEqual([1, 2, 3]);
+    expect(results.some((result) => "error" in result && result.item === 1)).toBe(true);
+  });
+});
 
 describe("matchAsset", () => {
   test("matches exact names", () => {

--- a/build/src/cli.ts
+++ b/build/src/cli.ts
@@ -1,0 +1,14 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+export function parsePositiveIntegerFlag(flag: string, value: string | undefined, defaultValue: number): number {
+  const raw = value ?? String(defaultValue);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${flag} must be a positive integer, got '${raw}'`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${flag} must be a safe positive integer, got '${raw}'`);
+  }
+  return parsed;
+}

--- a/build/src/extract.ts
+++ b/build/src/extract.ts
@@ -4,7 +4,7 @@
 import { $, YAML } from "bun";
 import { repoOf } from "./config.ts";
 import { downloadAsset, fetchCrdDir, fetchCrdFile, findReleaseAsset } from "./github.ts";
-import { FLUX_SCHEMA_BIN } from "./paths.ts";
+import { FLUX_SCHEMA_BIN, ROOT_DIR } from "./paths.ts";
 import { bareVersion, displayVersion, openshiftRef } from "./resolve.ts";
 import type { CrdSource, FluxInstance, ResourceNames, Source } from "./types.ts";
 
@@ -175,7 +175,13 @@ async function crdYaml(source: CrdSource, version: string): Promise<string> {
     return fetchCrdFile(repoOf(source), version, input.crdFile);
   }
   const manifest = fluxInstanceManifest(input.fluxInstance, version);
-  return await $`flux-operator build instance -f - < ${new Response(manifest)}`.quiet().text();
+  // The distribution artifact is public; point DOCKER_CONFIG at a dir with no
+  // config.json so the pull stays anonymous instead of invoking the user's
+  // docker credential helpers (which can prompt or time out).
+  return await $`flux-operator build instance -f - < ${new Response(manifest)}`
+    .env({ ...process.env, DOCKER_CONFIG: ROOT_DIR })
+    .quiet()
+    .text();
 }
 
 /** The FluxInstance manifest piped through `flux-operator build instance`. */

--- a/build/src/extract.ts
+++ b/build/src/extract.ts
@@ -6,7 +6,7 @@ import { repoOf } from "./config.ts";
 import { downloadAsset, fetchCrdDir, fetchCrdFile, findReleaseAsset } from "./github.ts";
 import { FLUX_SCHEMA_BIN } from "./paths.ts";
 import { bareVersion, displayVersion, openshiftRef } from "./resolve.ts";
-import type { CrdSource, FluxInstance, Source } from "./types.ts";
+import type { CrdSource, FluxInstance, ResourceNames, Source } from "./types.ts";
 
 /** Reports the version of the flux-schema binary in use. */
 export async function fluxSchemaVersion(): Promise<string> {
@@ -14,11 +14,15 @@ export async function fluxSchemaVersion(): Promise<string> {
   return out.trim().replace(/^flux-schema version /, "");
 }
 
+export interface ExtractionResult {
+  resources: Record<string, ResourceNames>;
+}
+
 /**
  * Extracts the source's JSON Schemas and field indexes at the given version
  * into the staging directory.
  */
-export async function extractSource(source: Source, version: string, dir: string): Promise<void> {
+export async function extractSource(source: Source, version: string, dir: string): Promise<ExtractionResult> {
   const flags = [
     "--strip-description=false",
     "--with-field-index",
@@ -30,12 +34,12 @@ export async function extractSource(source: Source, version: string, dir: string
   switch (source.extract) {
     case "k8s":
       await $`${FLUX_SCHEMA_BIN} extract k8s --version ${bareVersion(version)} ${flags}`.quiet();
-      return;
+      return emptyExtractionResult();
     case "openshift":
       await $`${FLUX_SCHEMA_BIN} extract openshift --ref ${openshiftRef(version)} ${flags}`.quiet();
-      return;
+      return emptyExtractionResult();
     case "crd":
-      await extractCrd(source, version, flags);
+      return extractCrd(source, version, flags);
   }
 }
 
@@ -44,9 +48,15 @@ export async function extractSource(source: Source, version: string, dir: string
  * a Bun shell pipeline, like bash without pipefail, only reports the last
  * command's status, letting an upstream failure pass as an empty extraction.
  */
-async function extractCrd(source: CrdSource, version: string, flags: string[]): Promise<void> {
+async function extractCrd(source: CrdSource, version: string, flags: string[]): Promise<ExtractionResult> {
   const yaml = dropEmptyDocs(await crdYaml(source, version));
+  const resources = crdResourceNames(yaml);
   await $`${FLUX_SCHEMA_BIN} extract crd /dev/stdin ${flags} < ${new Response(yaml)}`.quiet();
+  return { resources };
+}
+
+function emptyExtractionResult(): ExtractionResult {
+  return { resources: {} };
 }
 
 /**
@@ -67,6 +77,85 @@ export function dropEmptyDocs(yaml: string): string {
     }),
   );
   return kept.join("---\n");
+}
+
+/** Extracts CRD discovery names from a YAML stream, keyed by `<group>/<Kind>`. */
+export function crdResourceNames(yaml: string): Record<string, ResourceNames> {
+  const resources: Record<string, ResourceNames> = {};
+  for (const raw of yaml.split(/^---[ \t]*(?:#[^\n]*)?\r?\n/m)) {
+    const doc = raw.trim();
+    if (doc === "") {
+      continue;
+    }
+    const parsed = YAML.parse(doc);
+    const root = record(parsed);
+    if (root?.kind !== "CustomResourceDefinition") {
+      continue;
+    }
+    const spec = record(root.spec);
+    const names = record(spec?.names);
+    const group = stringValue(spec?.group);
+    const kind = stringValue(names?.kind);
+    if (group === undefined || kind === undefined) {
+      continue;
+    }
+
+    const next = compactResourceNames({
+      singular: stringValue(names?.singular),
+      plural: stringValue(names?.plural),
+      shortNames: stringArray(names?.shortNames),
+    });
+    const key = `${group}/${kind}`;
+    const existing = resources[key];
+    if (existing !== undefined && !sameResourceNames(existing, next)) {
+      throw new Error(`conflicting CRD resource names for ${key}`);
+    }
+    resources[key] = next;
+  }
+
+  return Object.fromEntries(Object.entries(resources).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function compactResourceNames(names: ResourceNames): ResourceNames {
+  return {
+    ...(names.singular === undefined ? {} : { singular: names.singular }),
+    ...(names.plural === undefined ? {} : { plural: names.plural }),
+    ...(names.shortNames === undefined || names.shortNames.length === 0 ? {} : { shortNames: names.shortNames }),
+  };
+}
+
+function sameResourceNames(a: ResourceNames, b: ResourceNames): boolean {
+  return (
+    a.singular === b.singular &&
+    a.plural === b.plural &&
+    (a.shortNames ?? []).join("\0") === (b.shortNames ?? []).join("\0")
+  );
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item === "" || seen.has(item)) {
+      continue;
+    }
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
 }
 
 async function crdYaml(source: CrdSource, version: string): Promise<string> {

--- a/build/src/history.ts
+++ b/build/src/history.ts
@@ -4,7 +4,7 @@
 import { mkdir, readdir, rename, rm, rmdir } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { CATALOG_DIR, HISTORY_DIR, ROOT_DIR } from "./paths.ts";
-import type { HistoryEntry } from "./types.ts";
+import type { HistoryEntry, ResourceNames } from "./types.ts";
 
 export async function readHistory(name: string): Promise<HistoryEntry | null> {
   const file = Bun.file(join(HISTORY_DIR, `${name}.json`));
@@ -102,6 +102,22 @@ export function parseKindName(fieldsText: string): string | null {
  * `readText`. One entry per kind (casing is version-invariant); a fields index
  * missing its `kind` enum row fails the build loudly rather than losing casing.
  */
+
+/** Filters discovery names down to the indexed kinds recorded in history. */
+export function resourceNamesForKinds(
+  resources: Record<string, ResourceNames>,
+  kinds: string[],
+): Record<string, ResourceNames> | undefined {
+  const out: Record<string, ResourceNames> = {};
+  for (const id of kinds) {
+    const resource = resources[id];
+    if (resource !== undefined) {
+      out[id] = resource;
+    }
+  }
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
 export async function kindCasing(
   files: string[],
   readText: (file: string) => Promise<string>,

--- a/build/src/main.ts
+++ b/build/src/main.ts
@@ -16,6 +16,7 @@ import {
   listStagedFiles,
   pruneKindsWithoutFields,
   readHistory,
+  resourceNamesForKinds,
   removedFiles,
   syncCatalog,
   writeHistory,
@@ -88,7 +89,7 @@ async function processSource(
   const foreign = foreignFiles(history, source.name);
   const staging = await mkdtemp(join(tmpdir(), `schema-catalog-${source.name}-`));
   try {
-    await extractSource(source, version, staging);
+    const extraction = await extractSource(source, version, staging);
     const staged = await listStagedFiles(staging);
     if (staged.length === 0) {
       throw new Error(`extraction at ${version} produced no files`);
@@ -109,6 +110,7 @@ async function processSource(
     }
     const files = await syncCatalog(staging, kept);
     const kinds = await kindCasing(kept, (rel) => Bun.file(join(staging, rel)).text());
+    const resources = resourceNamesForKinds(extraction.resources, kinds);
     const removed = removedFiles(prev, files, foreign);
     await gcCatalog(removed);
     const entry: HistoryEntry = {
@@ -118,6 +120,7 @@ async function processSource(
       builtAt: new Date().toISOString(),
       fluxSchemaVersion: opts.toolVersion,
       kinds,
+      ...(resources === undefined ? {} : { resources }),
       files,
     };
     await writeHistory(entry);

--- a/build/src/main.ts
+++ b/build/src/main.ts
@@ -5,6 +5,7 @@ import { appendFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { parsePositiveIntegerFlag } from "./cli.ts";
 import { loadSources, repoOf } from "./config.ts";
 import { extractSource, fluxSchemaVersion } from "./extract.ts";
 import {
@@ -22,6 +23,7 @@ import {
   writeHistory,
 } from "./history.ts";
 import { README_PATH, ROOT_DIR, SOURCES_PATH } from "./paths.ts";
+import { runBoundedPool } from "./pool.ts";
 import { updateReadme } from "./readme.ts";
 import { displayVersion, resolveVersion } from "./resolve.ts";
 import { renderBuildSummary } from "./summary.ts";
@@ -38,6 +40,7 @@ Options:
   --source <name>   Process a single source from build/config/sources.yaml
   --force           Rebuild even when the resolved version is unchanged
   --summary <path>  Write a markdown summary of the changes (for PR bodies)
+  --concurrent <n>  Process up to n sources at once (default: 2)
   --run-to-completion  Don't abort on a source failure; report failures instead
                        (exit 0 and, with --summary, list them in the PR body)
   -h, --help        Show this help message
@@ -174,17 +177,26 @@ function errorMessage(err: unknown): string {
 }
 
 async function main(): Promise<number> {
-  const { values, positionals } = parseArgs({
-    args: Bun.argv.slice(2),
-    options: {
-      source: { type: "string" },
-      force: { type: "boolean", default: false },
-      summary: { type: "string" },
-      "run-to-completion": { type: "boolean", default: false },
-      help: { type: "boolean", short: "h", default: false },
-    },
-    allowPositionals: true,
-  });
+  const parseOptions = {
+    source: { type: "string" },
+    force: { type: "boolean", default: false },
+    summary: { type: "string" },
+    concurrent: { type: "string" },
+    "run-to-completion": { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  } as const;
+  let parsed: ReturnType<typeof parseArgs<{ options: typeof parseOptions; allowPositionals: true }>>;
+  try {
+    parsed = parseArgs({
+      args: Bun.argv.slice(2),
+      options: parseOptions,
+      allowPositionals: true,
+    });
+  } catch (err) {
+    console.error(`error: ${errorMessage(err)}\n\n${USAGE}`);
+    return 1;
+  }
+  const { values, positionals } = parsed;
 
   const command = positionals[0];
   if (values.help) {
@@ -193,6 +205,13 @@ async function main(): Promise<number> {
   }
   if (command !== "build" && command !== "regen") {
     console.error(command === undefined ? USAGE : `error: unknown command '${command}'\n\n${USAGE}`);
+    return 1;
+  }
+  let concurrent: number;
+  try {
+    concurrent = parsePositiveIntegerFlag("--concurrent", values.concurrent, 2);
+  } catch (err) {
+    console.error(`error: ${errorMessage(err)}`);
     return 1;
   }
 
@@ -225,14 +244,15 @@ async function main(): Promise<number> {
   const failures: SourceFailure[] = [];
   const changes: BuildChange[] = [];
   let upToDate = 0;
-  for (const source of sources) {
-    try {
-      const change = await processSource(source, opts, history);
+  const results = await runBoundedPool(sources, concurrent, (source) => processSource(source, opts, history));
+  for (const result of results) {
+    if ("error" in result) {
+      const message = errorMessage(result.error);
+      failures.push({ name: result.item.name, message });
+      console.error(`  ${result.item.name}: error: ${message}`);
+    } else {
+      const change = result.value;
       change !== null ? changes.push(change) : upToDate++;
-    } catch (err) {
-      const message = errorMessage(err);
-      failures.push({ name: source.name, message });
-      console.error(`  ${source.name}: error: ${message}`);
     }
   }
 

--- a/build/src/pool.ts
+++ b/build/src/pool.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+export type PoolResult<T, R> =
+  | { index: number; item: T; value: R }
+  | { index: number; item: T; error: unknown };
+
+/**
+ * Runs `task` over `items` with at most `concurrency` tasks in flight.
+ * Failures never stop the pool: every item is processed and reported, matching
+ * the sequential loop this replaces. Results keep the input order.
+ */
+export async function runBoundedPool<T, R>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<PoolResult<T, R>[]> {
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+    throw new Error(`concurrency must be a positive integer, got ${concurrency}`);
+  }
+
+  const results: PoolResult<T, R>[] = new Array(items.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next++;
+      const item = items[index]!;
+      try {
+        results[index] = { index, item, value: await task(item, index) };
+      } catch (error) {
+        results[index] = { index, item, error };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}

--- a/build/src/types.ts
+++ b/build/src/types.ts
@@ -73,6 +73,16 @@ export interface CrdSource extends SourceBase {
 
 export type Source = K8sSource | OpenShiftSource | CrdSource;
 
+/** Kubernetes discovery names for kubectl-style resource references. */
+export interface ResourceNames {
+  /** Singular resource name reported by discovery. */
+  singular?: string;
+  /** Plural resource name reported by discovery. */
+  plural?: string;
+  /** Short names reported by discovery, in discovery order. */
+  shortNames?: string[];
+}
+
 /** Last successful build result, stored at build/history/<name>.json. */
 export interface HistoryEntry {
   name: string;
@@ -91,6 +101,8 @@ export interface HistoryEntry {
    * index uses for display; the slug is recovered by lowercasing.
    */
   kinds: string[];
+  /** Discovery names keyed by original-cased `<group>/<Kind>`. */
+  resources?: Record<string, ResourceNames>;
   /** Catalog files owned by this source, repo-root relative, sorted. */
   files: string[];
 }

--- a/web/README.md
+++ b/web/README.md
@@ -64,7 +64,7 @@ committed.
 
 ```json
 {
-  "v": 1,
+  "v": 3,
   "generatedAt": "2026-07-06T00:00:00.000Z",
   "categories": ["Provisioning", "Runtime"],
   "projects": [
@@ -78,7 +78,7 @@ committed.
       "groups": [
         {
           "g": "kustomize.toolkit.fluxcd.io",
-          "kinds": [["kustomization", ["v1", "v1beta2"], 1]]
+          "kinds": [["kustomization", ["v1", "v1beta2"], 1, "Kustomization", { "n": ["ks"] }]]
         }
       ]
     }
@@ -86,11 +86,17 @@ committed.
 }
 ```
 
-`projects[].groups[].kinds[]` is `[kind, versions, fieldsBits]`. `versions` is
-sorted by Kubernetes API priority, newest/preferred first: stable versions before
-beta, beta before alpha, higher major/sequence before lower. Bit `i` in
-`fieldsBits` corresponds to `versions[i]`; set means
-`<kind>_<version>.fields.txt` exists, unset means schema-only.
+`projects[].groups[].kinds[]` is
+`[kind, versions, fieldsBits, display?, resource?]`. `versions` is sorted by
+Kubernetes API priority: stable versions before beta, beta before alpha, higher
+major/sequence before lower. Bit `i` in `fieldsBits` corresponds to
+`versions[i]`; set means `<kind>_<version>.fields.txt` exists, unset means
+schema-only.
+
+`resource` stores only discovery-name exceptions for kubectl-style resource
+references: `s` for singular when it differs from `kind`, `p` for plural when it
+cannot be derived from `kind`, and `n` for short names. The API group is stored
+once in `g`, never repeated per kind.
 
 ## MCP
 

--- a/web/scripts/gen-index.ts
+++ b/web/scripts/gen-index.ts
@@ -6,9 +6,9 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CATEGORIES, loadSources, repoOf } from "../../build/src/config.ts";
 import { displayVersion } from "../../build/src/resolve.ts";
-import type { HistoryEntry, Source } from "../../build/src/types.ts";
+import type { HistoryEntry, ResourceNames, Source } from "../../build/src/types.ts";
 import { compareApiVersion } from "../src/shared/index-query.ts";
-import type { CatalogIndex, GroupEntry, KindEntry, ProjectEntry } from "../src/shared/types.ts";
+import type { CatalogIndex, GroupEntry, KindEntry, ProjectEntry, ResourceEntry } from "../src/shared/types.ts";
 
 /**
  * Catalog path contract recorded in build history manifests. Non-conforming
@@ -72,7 +72,7 @@ export function generateIndex(sources: Source[], entries: HistoryEntry[]): Catal
   }
 
   return {
-    v: 2,
+    v: 3,
     generatedAt: new Date().toISOString(),
     categories: CATEGORIES,
     projects: projects.sort((a, b) => a.alias.localeCompare(b.alias)),
@@ -96,6 +96,57 @@ if (import.meta.main) {
   console.log(`${index.projects.length} projects, ${groups} groups, ${kinds} kinds, ${bytes} bytes`);
 }
 
+function compactResource(kind: string, names: ResourceNames | undefined): ResourceEntry | undefined {
+  if (names === undefined) {
+    return undefined;
+  }
+  const out: ResourceEntry = {};
+  const singular = normalizedName(names.singular);
+  const plural = normalizedName(names.plural);
+  if (singular !== undefined && singular !== kind) {
+    out.s = singular;
+  }
+  if (plural !== undefined && plural !== pluralResourceName(kind)) {
+    out.p = plural;
+  }
+
+  const redundant = new Set([kind, singular, plural].filter((value): value is string => value !== undefined));
+  const shortNames: string[] = [];
+  const seen = new Set<string>();
+  for (const name of names.shortNames ?? []) {
+    const normalized = normalizedName(name);
+    if (normalized === undefined || redundant.has(normalized) || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    shortNames.push(normalized);
+  }
+  if (shortNames.length > 0) {
+    out.n = shortNames;
+  }
+
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
+function normalizedName(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === undefined || normalized === "" ? undefined : normalized;
+}
+
+function pluralResourceName(kind: string): string {
+  if (kind.endsWith("y") && kind.length > 1 && !isVowel(kind[kind.length - 2]!)) {
+    return `${kind.slice(0, -1)}ies`;
+  }
+  if (["ch", "sh", "s", "x", "z"].some((suffix) => kind.endsWith(suffix))) {
+    return `${kind}es`;
+  }
+  return `${kind}s`;
+}
+
+function isVowel(value: string): boolean {
+  return value === "a" || value === "e" || value === "i" || value === "o" || value === "u";
+}
+
 async function loadHistory(dir: string): Promise<HistoryEntry[]> {
   const files = (await readdir(dir)).filter((file) => file.endsWith(".json")).sort();
   return Promise.all(
@@ -111,6 +162,10 @@ function collectGroups(entry: HistoryEntry): GroupEntry[] {
   const casing = new Map<string, string>();
   for (const id of entry.kinds ?? []) {
     casing.set(id.toLowerCase(), id.slice(id.indexOf("/") + 1));
+  }
+  const resources = new Map<string, ResourceNames>();
+  for (const [id, names] of Object.entries(entry.resources ?? {})) {
+    resources.set(id.toLowerCase(), names);
   }
 
   for (const file of entry.files) {
@@ -160,6 +215,10 @@ function collectGroups(entry: HistoryEntry): GroupEntry[] {
             }
           });
           const display = casing.get(`${g}/${kind}`);
+          const resource = compactResource(kind, resources.get(`${g}/${display ?? kind}`.toLowerCase()));
+          if (resource !== undefined) {
+            return [kind, versions, fieldsBits, display ?? kind, resource];
+          }
           return display === undefined || display === kind
             ? [kind, versions, fieldsBits]
             : [kind, versions, fieldsBits, display];

--- a/web/scripts/gen-index.ts
+++ b/web/scripts/gen-index.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { CATEGORIES, loadSources, repoOf } from "../../build/src/config.ts";
 import { displayVersion } from "../../build/src/resolve.ts";
 import type { HistoryEntry, ResourceNames, Source } from "../../build/src/types.ts";
-import { compareApiVersion } from "../src/shared/index-query.ts";
+import { compareApiVersion, pluralResourceName } from "../src/shared/index-query.ts";
 import type { CatalogIndex, GroupEntry, KindEntry, ProjectEntry, ResourceEntry } from "../src/shared/types.ts";
 
 /**
@@ -131,20 +131,6 @@ function compactResource(kind: string, names: ResourceNames | undefined): Resour
 function normalizedName(value: string | undefined): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized === undefined || normalized === "" ? undefined : normalized;
-}
-
-function pluralResourceName(kind: string): string {
-  if (kind.endsWith("y") && kind.length > 1 && !isVowel(kind[kind.length - 2]!)) {
-    return `${kind.slice(0, -1)}ies`;
-  }
-  if (["ch", "sh", "s", "x", "z"].some((suffix) => kind.endsWith(suffix))) {
-    return `${kind}es`;
-  }
-  return `${kind}s`;
-}
-
-function isVowel(value: string): boolean {
-  return value === "a" || value === "e" || value === "i" || value === "o" || value === "u";
 }
 
 async function loadHistory(dir: string): Promise<HistoryEntry[]> {

--- a/web/src/shared/index-query.ts
+++ b/web/src/shared/index-query.ts
@@ -186,7 +186,12 @@ function scoreMatch(kind: string, group: string, project: string, needle: string
   return 0;
 }
 
-function pluralResourceName(kind: string): string {
+/**
+ * Derives the default Kubernetes plural resource name. web/scripts/gen-index.ts
+ * uses this to decide whether to omit compact `p` fields, so the deriver and
+ * generator must stay in sync.
+ */
+export function pluralResourceName(kind: string): string {
   if (kind.endsWith("y") && kind.length > 1 && !isVowel(kind[kind.length - 2]!)) {
     return `${kind.slice(0, -1)}ies`;
   }

--- a/web/src/shared/index-query.ts
+++ b/web/src/shared/index-query.ts
@@ -74,6 +74,26 @@ export function kindDisplay(entry: KindEntry): string {
   return entry[3] ?? entry[0];
 }
 
+/** Returns normalized resource-reference aliases carried by the compact index. */
+export function resourceAliases(entry: KindEntry): string[] {
+  const aliases = new Set<string>();
+  const add = (value: string | undefined): void => {
+    const normalized = value?.trim().toLowerCase();
+    if (normalized !== undefined && normalized !== "") {
+      aliases.add(normalized);
+    }
+  };
+  add(entry[0]);
+  add(kindDisplay(entry));
+  add(pluralResourceName(entry[0]));
+  add(entry[4]?.s);
+  add(entry[4]?.p);
+  for (const name of entry[4]?.n ?? []) {
+    add(name);
+  }
+  return [...aliases];
+}
+
 /**
  * Searches kind, group, project alias, and project name with simple deterministic
  * scoring. Empty queries and non-positive limits return no hits; results are
@@ -92,7 +112,7 @@ export function searchIndex(index: CatalogIndex, query: string, limit = 20): Sea
       const groupText = group.g.toLowerCase();
       for (const entry of group.kinds) {
         const kindText = entry[0].toLowerCase();
-        const score = scoreMatch(kindText, groupText, projectText, needle);
+        const score = scoreMatch(kindText, groupText, projectText, needle, resourceAliases(entry));
         if (score === 0) {
           continue;
         }
@@ -150,11 +170,11 @@ export function findKind(
   return undefined;
 }
 
-function scoreMatch(kind: string, group: string, project: string, needle: string): number {
-  if (kind.startsWith(needle)) {
+function scoreMatch(kind: string, group: string, project: string, needle: string, aliases: string[]): number {
+  if (kind.startsWith(needle) || aliases.some((alias) => alias.startsWith(needle))) {
     return 4;
   }
-  if (kind.includes(needle)) {
+  if (kind.includes(needle) || aliases.some((alias) => alias.includes(needle))) {
     return 3;
   }
   if (group.includes(needle)) {
@@ -164,6 +184,20 @@ function scoreMatch(kind: string, group: string, project: string, needle: string
     return 1;
   }
   return 0;
+}
+
+function pluralResourceName(kind: string): string {
+  if (kind.endsWith("y") && kind.length > 1 && !isVowel(kind[kind.length - 2]!)) {
+    return `${kind.slice(0, -1)}ies`;
+  }
+  if (["ch", "sh", "s", "x", "z"].some((suffix) => kind.endsWith(suffix))) {
+    return `${kind}es`;
+  }
+  return `${kind}s`;
+}
+
+function isVowel(value: string): boolean {
+  return value === "a" || value === "e" || value === "i" || value === "o" || value === "u";
 }
 
 function parseApiVersion(version: string): ParsedApiVersion | undefined {

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -9,7 +9,7 @@
  */
 export interface CatalogIndex {
   /** Index contract version. */
-  v: 2;
+  v: 3;
   /** ISO timestamp for when `scripts/gen-index.ts` wrote the asset. */
   generatedAt: string;
   /** CNCF category names; `ProjectEntry.cat` stores an index into this array. */
@@ -48,11 +48,25 @@ export interface GroupEntry {
 }
 
 /**
- * Compact kind tuple: `[kind, versions, fieldsBits, display?]`. `kind` is the
- * lowercase catalog slug used for object paths, routes, and lookups. `versions`
- * is sorted by Kubernetes API priority with the preferred/latest version at
- * index 0; bit `i` in `fieldsBits` is set when `versions[i]` has a sibling
- * `.fields.txt` index. `display` is the original-cased kind name for UI text and
- * is omitted when it equals `kind`; read it through `kindDisplay`.
+ * Compact discovery names for kubectl-style resource references. `s` is only
+ * set when singular differs from `kind`, `p` is only set when plural cannot be
+ * derived from `kind`, and `n` contains short names in discovery order. The API
+ * group is stored once on `GroupEntry.g`, never repeated here.
  */
-export type KindEntry = [kind: string, versions: string[], fieldsBits: number, display?: string];
+export interface ResourceEntry {
+  s?: string;
+  p?: string;
+  n?: string[];
+}
+
+/**
+ * Compact kind tuple: `[kind, versions, fieldsBits, display?, resource?]`.
+ * `kind` is the lowercase catalog slug used for object paths, routes, and
+ * lookups. `versions` is sorted by Kubernetes API priority with the latest
+ * version at index 0; bit `i` in `fieldsBits` is set when `versions[i]` has a
+ * sibling `.fields.txt` index. `display` is the original-cased kind name for UI
+ * text and is omitted when it equals `kind`; read it through `kindDisplay`.
+ * `resource` carries only discovery-name exceptions needed for resource
+ * reference lookup and completion.
+ */
+export type KindEntry = [kind: string, versions: string[], fieldsBits: number, display?: string, resource?: ResourceEntry];

--- a/web/src/worker/mcp-core.ts
+++ b/web/src/worker/mcp-core.ts
@@ -3,7 +3,7 @@
 
 import { filterFieldLines, parseFieldsFile } from "../shared/fields.ts";
 import type { FieldLine } from "../shared/fields.ts";
-import { kindDisplay, latestVersion } from "../shared/index-query.ts";
+import { kindDisplay, latestVersion, resourceAliases } from "../shared/index-query.ts";
 import type { CatalogIndex, KindEntry, ProjectEntry } from "../shared/types.ts";
 import type { Env } from "./index.ts";
 
@@ -129,7 +129,7 @@ export function resolveKind(index: CatalogIndex, group: string, kind: string): R
 
   for (const project of index.projects) {
     const groupEntry = project.groups.find((candidate) => normalize(candidate.g) === normalizedGroup);
-    const kindEntry = groupEntry?.kinds.find((candidate) => normalize(candidate[0]) === normalizedKind);
+    const kindEntry = groupEntry?.kinds.find((candidate) => resourceAliases(candidate).includes(normalizedKind));
     if (groupEntry !== undefined && kindEntry !== undefined) {
       return { project, group: groupEntry.g, entry: kindEntry };
     }
@@ -403,13 +403,14 @@ function closeKindMatches(index: CatalogIndex, group: string, kind: string): Arr
     for (const groupEntry of project.groups) {
       const sameGroup = normalize(groupEntry.g) === normalizedGroup;
       for (const entry of groupEntry.kinds) {
-        const entryKind = normalize(entry[0]);
+        const aliases = resourceAliases(entry);
+        const bestAlias = closestAlias(normalizedKind, aliases) ?? normalize(entry[0]);
         candidates.push({
           apiVersion: formatApiVersion(groupEntry.g, latestVersion(entry)),
           kind: kindDisplay(entry),
-          score: distance(normalizedKind, entryKind),
+          score: distance(normalizedKind, bestAlias),
           sameGroup,
-          includes: entryKind.includes(normalizedKind),
+          includes: aliases.some((alias) => alias.includes(normalizedKind)),
         });
       }
     }
@@ -427,6 +428,19 @@ function closeKindMatches(index: CatalogIndex, group: string, kind: string): Arr
     })
     .slice(0, 5)
     .map(({ apiVersion, kind }) => ({ apiVersion, kind }));
+}
+
+function closestAlias(needle: string, aliases: string[]): string | undefined {
+  let best: string | undefined;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const alias of aliases) {
+    const score = distance(needle, alias);
+    if (score < bestScore) {
+      best = alias;
+      bestScore = score;
+    }
+  }
+  return best;
 }
 
 function distance(a: string, b: string): number {

--- a/web/test/gen-index.test.ts
+++ b/web/test/gen-index.test.ts
@@ -46,6 +46,9 @@ describe("generateIndex", () => {
         ...baseEntry,
         name: "alpha",
         kinds: ["alpha.example.io/Gadget"],
+        resources: {
+          "alpha.example.io/Gadget": { singular: "gadget", plural: "gadgets", shortNames: ["gd"] },
+        },
         files: [
           "catalog/alpha.example.io/gadget_v1beta1.json",
           "catalog/alpha.example.io/gadget_v2.json",
@@ -61,7 +64,7 @@ describe("generateIndex", () => {
       throw new Error("expected alpha and beta projects");
     }
 
-    expect(index.v).toBe(2);
+    expect(index.v).toBe(3);
     expect(index.categories[alpha.cat]).toBe("Runtime");
     expect(index.projects.map((project) => project.alias)).toEqual(["Alpha", "Beta"]);
     expect(alpha.repo).toBe("example/alpha");
@@ -72,9 +75,37 @@ describe("generateIndex", () => {
     expect("pin" in beta).toBe(false);
     expect(alpha.groups[0]?.g).toBe("alpha.example.io");
     // Original casing recorded in `kinds` becomes the 4th tuple element.
-    expect(alpha.groups[0]?.kinds[0]).toEqual(["gadget", ["v2", "v1beta1"], 1, "Gadget"]);
+    expect(alpha.groups[0]?.kinds[0]).toEqual(["gadget", ["v2", "v1beta1"], 1, "Gadget", { n: ["gd"] }]);
     // A kind with no recorded casing keeps the slug and omits the display element.
     expect(beta.groups[0]?.kinds[0]).toEqual(["widget", ["v1"], 0]);
+  });
+
+
+  test("stores only non-derivable discovery names in kind tuples", () => {
+    const entries: HistoryEntry[] = [
+      {
+        ...baseEntry,
+        name: "alpha",
+        kinds: ["alpha.example.io/NetworkPolicy", "alpha.example.io/Person"],
+        resources: {
+          "alpha.example.io/NetworkPolicy": { singular: "networkpolicy", plural: "networkpolicies", shortNames: ["netpol"] },
+          "alpha.example.io/Person": { singular: "human", plural: "people" },
+        },
+        files: [
+          "catalog/alpha.example.io/networkpolicy_v1.json",
+          "catalog/alpha.example.io/networkpolicy_v1.fields.txt",
+          "catalog/alpha.example.io/person_v1.json",
+          "catalog/alpha.example.io/person_v1.fields.txt",
+        ],
+      },
+    ];
+
+    const alpha = generateIndex(sources, entries).projects[0];
+
+    expect(alpha?.groups[0]?.kinds).toEqual([
+      ["networkpolicy", ["v1"], 1, "NetworkPolicy", { n: ["netpol"] }],
+      ["person", ["v1"], 1, "Person", { s: "human", p: "people" }],
+    ]);
   });
 
   test("throws on bad catalog file paths", () => {

--- a/web/test/gen-index.test.ts
+++ b/web/test/gen-index.test.ts
@@ -80,7 +80,6 @@ describe("generateIndex", () => {
     expect(beta.groups[0]?.kinds[0]).toEqual(["widget", ["v1"], 0]);
   });
 
-
   test("stores only non-derivable discovery names in kind tuples", () => {
     const entries: HistoryEntry[] = [
       {

--- a/web/test/index-query.test.ts
+++ b/web/test/index-query.test.ts
@@ -83,13 +83,12 @@ describe("searchIndex", () => {
       ["other", 2],
     ]);
   });
-});
-
 
   test("matches plural and short-name aliases", () => {
     expect(searchIndex(index, "gw", 1).map((hit) => [hit.kind, hit.score])).toEqual([["gateway", 4]]);
     expect(searchIndex(index, "cert", 1).map((hit) => [hit.kind, hit.score])).toEqual([["certificate", 4]]);
   });
+});
 
 describe("findKind", () => {
   test("finds exact group and kind", () => {

--- a/web/test/index-query.test.ts
+++ b/web/test/index-query.test.ts
@@ -6,7 +6,7 @@ import { compareApiVersion, findKind, searchIndex } from "../src/shared/index-qu
 import type { CatalogIndex } from "../src/shared/types.ts";
 
 const index: CatalogIndex = {
-  v: 2,
+  v: 3,
   generatedAt: "2026-07-06T00:00:00.000Z",
   categories: ["Runtime"],
   projects: [
@@ -18,9 +18,9 @@ const index: CatalogIndex = {
       version: "v1.0.0",
       builtAt: "2026-07-06",
       groups: [
-        { g: "certificates.example.io", kinds: [["Other", ["v1"], 0]] },
-        { g: "infra.example.io", kinds: [["EdgeGateway", ["v1"], 1]] },
-        { g: "networking.example.io", kinds: [["Gateway", ["v1"], 1]] },
+        { g: "certificates.example.io", kinds: [["other", ["v1"], 0, "Other"]] },
+        { g: "infra.example.io", kinds: [["edgegateway", ["v1"], 1, "EdgeGateway"]] },
+        { g: "networking.example.io", kinds: [["gateway", ["v1"], 1, "Gateway", { n: ["gw"] }]] },
       ],
     },
     {
@@ -30,7 +30,7 @@ const index: CatalogIndex = {
       repo: "cert-manager/cert-manager",
       version: "v1.0.0",
       builtAt: "2026-07-06",
-      groups: [{ g: "cert-manager.io", kinds: [["Certificate", ["v1"], 1]] }],
+      groups: [{ g: "cert-manager.io", kinds: [["certificate", ["v1"], 1, "Certificate", { p: "certificates", n: ["cert"] }]] }],
     },
   ],
 };
@@ -69,9 +69,9 @@ describe("searchIndex", () => {
     const hits = searchIndex(index, "gate", 3);
 
     expect(hits.map((hit) => [hit.kind, hit.score])).toEqual([
-      ["Gateway", 4],
-      ["EdgeGateway", 3],
-      ["Other", 1],
+      ["gateway", 4],
+      ["edgegateway", 3],
+      ["other", 1],
     ]);
   });
 
@@ -79,18 +79,24 @@ describe("searchIndex", () => {
     const hits = searchIndex(index, "cert", 2);
 
     expect(hits.map((hit) => [hit.kind, hit.score])).toEqual([
-      ["Certificate", 4],
-      ["Other", 2],
+      ["certificate", 4],
+      ["other", 2],
     ]);
   });
 });
 
+
+  test("matches plural and short-name aliases", () => {
+    expect(searchIndex(index, "gw", 1).map((hit) => [hit.kind, hit.score])).toEqual([["gateway", 4]]);
+    expect(searchIndex(index, "cert", 1).map((hit) => [hit.kind, hit.score])).toEqual([["certificate", 4]]);
+  });
+
 describe("findKind", () => {
   test("finds exact group and kind", () => {
-    const hit = findKind(index, "networking.example.io", "Gateway");
+    const hit = findKind(index, "networking.example.io", "gateway");
 
     expect(hit?.project.name).toBe("gateway-api");
-    expect(hit?.entry).toEqual(["Gateway", ["v1"], 1]);
+    expect(hit?.entry).toEqual(["gateway", ["v1"], 1, "Gateway", { n: ["gw"] }]);
   });
 
   test("returns undefined for misses", () => {

--- a/web/test/mcp.test.ts
+++ b/web/test/mcp.test.ts
@@ -157,7 +157,6 @@ describe("MCP catalog helpers", () => {
     expect(resolved?.entry[0]).toBe("kustomization");
   });
 
-
   test("resolveKind matches compact resource aliases", () => {
     const resolved = resolveKind(index, "kustomize.toolkit.fluxcd.io", "ks");
 

--- a/web/test/mcp.test.ts
+++ b/web/test/mcp.test.ts
@@ -20,7 +20,7 @@ import type { CatalogObjectLoader } from "../src/worker/mcp-core.ts";
 import type { Env } from "../src/worker/index.ts";
 
 const index: CatalogIndex = {
-  v: 2,
+  v: 3,
   generatedAt: "2026-07-06T00:00:00.000Z",
   categories: [
     "Provisioning",
@@ -41,7 +41,7 @@ const index: CatalogIndex = {
       groups: [
         {
           g: "kustomize.toolkit.fluxcd.io",
-          kinds: [["kustomization", ["v1", "v1beta2"], 1, "Kustomization"]],
+          kinds: [["kustomization", ["v1", "v1beta2"], 1, "Kustomization", { n: ["ks"] }]],
         },
       ],
     },
@@ -62,7 +62,7 @@ const index: CatalogIndex = {
       version: "v1.34.0",
       builtAt: "2026-07-06",
       groups: [
-        { g: "core", kinds: [["pod", ["v1"], 1, "Pod"]] },
+        { g: "core", kinds: [["pod", ["v1"], 1, "Pod", { p: "pods", n: ["po"] }]] },
         { g: "apps", kinds: [["deployment", ["v1"], 1, "Deployment"]] },
       ],
     },
@@ -153,6 +153,13 @@ describe("MCP catalog helpers", () => {
 
   test("resolveKind is case-insensitive for kind names", () => {
     const resolved = resolveKind(index, "kustomize.toolkit.fluxcd.io", "Kustomization");
+
+    expect(resolved?.entry[0]).toBe("kustomization");
+  });
+
+
+  test("resolveKind matches compact resource aliases", () => {
+    const resolved = resolveKind(index, "kustomize.toolkit.fluxcd.io", "ks");
 
     expect(resolved?.entry[0]).toBe("kustomization");
   });


### PR DESCRIPTION
PoC for the `flux-schema explain -s ecosystem` index data.

- Parses CRD `spec.names` during build and records discovery names in history.
- Emits compact index v3 tuples: `[kind, versions, fieldsBits, display?, resource?]`.
- `resource` only stores exceptions: `s` singular, `p` non-derivable plural, `n` short names; group is not repeated per kind.
- Lets web/MCP lookup match compact plural and short-name aliases.

Benchmark note: current history does not have `resources`, so the real old-vs-new index size comparison needs a full rebuild first. Bun is not installed in my local checkout, so I only ran `git diff --check` locally.