### PR TITLE
Add explain type metadata extraction

### DIFF
--- a/.github/workflows/update-catalog.yaml
+++ b/.github/workflows/update-catalog.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Setup flux-schema
-        uses: fluxcd/flux-schema/actions/setup@311d886d4669269c92dd9ab5f285051a991ec6c6 # v0.7.0
+        uses: fluxcd/flux-schema/actions/setup@a19a8a3a3400b3f937135ea82533f923d211798a # v0.8.0
       - name: Setup flux-operator
         uses: controlplaneio-fluxcd/flux-operator/actions/setup@be9fe84303cf7b8337b74aad1f7e1ccdafa17274 # v0.53.0
       - name: Update catalog
@@ -54,7 +54,7 @@ jobs:
           EOF
       - name: Test validate action
         if: steps.build.outputs.changed == 'true'
-        uses: fluxcd/flux-schema/actions/validate@311d886d4669269c92dd9ab5f285051a991ec6c6 # v0.7.0
+        uses: fluxcd/flux-schema/actions/validate@a19a8a3a3400b3f937135ea82533f923d211798a # v0.8.0
         with:
           path: example
           config: .fluxschema-smoke.yml

--- a/build/README.md
+++ b/build/README.md
@@ -93,8 +93,11 @@ upstream surfaces as an error rather than a silent no-op. `exclude` is only vali
 alongside `crdDir`.
 
 Every extraction runs with `--strip-description=false --with-field-index
---index-source="<alias> <version> <url>"` and the
-`{{ .Group }}/{{ .Kind }}_{{ .Version }}.json` output template. The binary
+--with-explain-type-metadata --index-source="<alias> <version> <url>"` and the
+`{{ .Group }}/{{ .Kind }}_{{ .Version }}.json` output template. Field indexes
+serve the web/MCP/search use cases, while explain type metadata keeps only the
+JSON-local type hints needed after the ecosystem `index.json` has resolved a
+resource. It does not write alias files or a `.explain/` tree. The binary
 lowercases all template variables, so catalog filenames are lowercase.
 
 **Fieldless kinds are pruned.** After staging, `pruneKindsWithoutFields` drops

--- a/build/src/extract.ts
+++ b/build/src/extract.ts
@@ -26,6 +26,7 @@ export async function extractSource(source: Source, version: string, dir: string
   const flags = [
     "--strip-description=false",
     "--with-field-index",
+    "--with-explain-type-metadata",
     // The header shows the stripped version; the git ref below stays the full tag.
     `--index-source=${source.alias} ${displayVersion(version)} ${source.url}`,
     "--output-format={{ .Group }}/{{ .Kind }}_{{ .Version }}.json",


### PR DESCRIPTION
Adds the Flux Schema v0.8.0 explain extraction surface to the catalog build.

- Passes `--with-explain-type-metadata` on every extraction so schema JSON keeps the type hints needed after the ecosystem `index.json` resolves a resource.
- Keeps lookup/completion out of generated schemas: no aliases and no `.explain/` tree.
- Updates Flux Schema setup/validate action pins to v0.8.0.

This PR does not rebuild `catalog/`. After merge, run `update-catalog` with `force=true` to re-extract all sources with v0.8.0.

Tests: `git diff --check`. `make lint`/`make test` not run locally because Bun is not installed in this environment.
