### PR TITLE
Migrate MCP server to stateless SDK v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ run, dev, sync, deploy, archive) are listed in
   validate <manifests> --schema-location ./catalog` against a real example.
 - Web changes: `bun run lint && bun test` inside `web/`, plus the smoke
   matrix in [web/README.md](web/README.md#verification) for serving changes.
+  Verify MCP serving changes end to end with `bun scripts/mcp-e2e-test.ts`
+  from `web/` (or `bun run mcp-e2e`); it runs the full modern-plus-legacy
+  protocol suite against production by default and accepts a base URL for a
+  local Wrangler dev instance.
 
 ## CI
 

--- a/web/README.md
+++ b/web/README.md
@@ -303,6 +303,11 @@ curl -fsS https://schemas.fluxoperator.dev/mcp \
   --data '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"curl","version":"dev"}}}}'
 ```
 
+The smoke matrix has a scripted superset in `scripts/mcp-e2e-test.ts`
+(`bun run mcp-e2e`). This post-deploy helper checks the modern 2026-07-28 lane,
+the legacy lane, error semantics, and the discovery documents against
+production by default. Pass a base URL to target a local Wrangler dev session.
+
 Validation must pass both directions: a valid manifest passes, and the same
 manifest with an intentionally invalid field fails.
 

--- a/web/README.md
+++ b/web/README.md
@@ -165,6 +165,13 @@ The server `instructions` steer agents through a `grep_catalog` ->
 `grep_schema` -> `get_schema` escalation so most field questions never load a
 full schema.
 
+The official MCP SDK v2 `@modelcontextprotocol/server` runs behind the
+Cloudflare `agents/mcp/server` stateless handler. It serves the modern
+2026-07-28 protocol with per-request `_meta`, `Mcp-Method`/`Mcp-Name`, and
+`server/discover`, plus a built-in legacy lane for 2025 stateless clients.
+Legacy responses are SSE-framed, GET returns 405, and an unknown tool returns
+JSON-RPC -32602.
+
 ```shell
 claude mcp add --transport http flux-schema-catalog https://schemas.fluxoperator.dev/mcp
 ```
@@ -288,6 +295,12 @@ curl -fsS https://schemas.fluxoperator.dev/mcp \
   -H 'content-type: application/json' \
   -H 'accept: application/json, text/event-stream' \
   --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"dev"}}}'
+curl -fsS https://schemas.fluxoperator.dev/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H 'mcp-protocol-version: 2026-07-28' \
+  -H 'mcp-method: server/discover' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"curl","version":"dev"}}}}'
 ```
 
 Validation must pass both directions: a valid manifest passes, and the same

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "schema-catalog-web",
       "dependencies": {
-        "agents": "0.17.3",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@modelcontextprotocol/server": "2.0.0",
+        "agents": "0.20.1",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -68,8 +70,6 @@
     "@babel/types": ["@babel/types@8.0.0", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0" } }, "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
-
-    "@cloudflare/codemode": ["@cloudflare/codemode@0.4.2", "", { "dependencies": { "@types/json-schema": "^7.0.15", "acorn": "^8.17.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.0", "@tanstack/ai": ">=0.8.0 <1.0.0", "ai": "^6.0.0", "zod": "^4.0.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@tanstack/ai", "ai", "zod"] }, "sha512-6sLMZDRY2USbXirrI4tjmGSMYAYM+E/PJIaDQLLbMdvQjk1z1TmJNSLomrZwErO1zFPXvGX2kaqkkxvixkfV2w=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -207,7 +207,13 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -265,15 +271,11 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
-
     "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
-
-    "agents": ["agents@0.17.3", "", { "dependencies": { "@babel/plugin-proposal-decorators": "^8.0.2", "@cfworker/json-schema": "^4.1.1", "@cloudflare/codemode": "^0.4.2", "@modelcontextprotocol/sdk": "1.29.0", "@rolldown/plugin-babel": "^0.2.3", "cron-schedule": "^6.0.0", "esbuild": "^0.28.1", "mimetext": "^3.0.28", "nanoid": "^5.1.16", "partyserver": "^0.5.8", "partysocket": "1.3.0", "yaml": "^2.9.0", "yargs": "^18.0.0" }, "peerDependencies": { "@ai-sdk/react": "^3.0.204", "@tanstack/ai": ">=0.10.2 <1.0.0", "@x402/core": "^2.0.0", "@x402/evm": "^2.0.0", "ai": "^6.0.0", "chat": "^4.29.0", "just-bash": "^3.0.0", "react": "^19.0.0", "vite": ">=6.0.0 <9.0.0", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/react", "@tanstack/ai", "@x402/core", "@x402/evm", "ai", "chat", "just-bash", "vite"], "bin": { "agents": "dist/cli/index.js" } }, "sha512-h0rc+dXwe/B6WblHH+Q3625nN/aryZntj6NIJX7tf+VSjmnI1EZyWtVBYMdX4FJZLShpl/vcx/A1AkxytWCPNQ=="],
+    "agents": ["agents@0.20.1", "", { "dependencies": { "@babel/plugin-proposal-decorators": "^8.0.2", "@cfworker/json-schema": "^4.1.1", "@rolldown/plugin-babel": "^0.2.3", "cron-schedule": "^6.0.0", "esbuild": "^0.28.1", "mimetext": "^3.0.28", "nanoid": "^5.1.16", "partyserver": "^0.5.8", "partysocket": "1.3.0", "yaml": "^2.9.0", "yargs": "^18.0.0" }, "peerDependencies": { "@ai-sdk/react": "^3.0.0 || ^4.0.0", "@cloudflare/codemode": ">=0.5.0", "@modelcontextprotocol/client": "2.0.0", "@modelcontextprotocol/sdk": "1.30.0", "@modelcontextprotocol/server": "2.0.0", "@tanstack/ai": ">=0.10.2 <1.0.0", "@x402/core": "^2.0.0", "@x402/evm": "^2.0.0", "ai": "^6.0.0 || ^7.0.0", "chat": "^4.29.0", "just-bash": "^3.0.0", "react": "^19.0.0", "vite": ">=6.0.0 <9.0.0", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/react", "@cloudflare/codemode", "@tanstack/ai", "@x402/core", "@x402/evm", "ai", "chat", "just-bash", "vite"], "bin": { "agents": "dist/cli/index.js" } }, "sha512-HQRYMeZpD3k8djYBH7atRPojZMee3NvmXkzsmMWXfdHZ94vMljmWqSsD1XZd70LovHyQrw6/R81AZZIsRiFM6Q=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -309,7 +311,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -437,9 +439,9 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimetext": ["mimetext@3.0.28", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@babel/runtime-corejs3": "^7.26.0", "js-base64": "^3.7.7", "mime-types": "^2.1.35" } }, "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g=="],
 
@@ -583,28 +585,16 @@
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
-    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mimetext/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
-    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mimetext/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "build": "bun scripts/gen-index.ts && bun scripts/build-ui.ts",
     "dev": "bun scripts/dev.ts",
     "serve": "bun scripts/serve.ts",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "mcp-e2e": "bun scripts/mcp-e2e-test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.30.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "agents": "0.17.3",
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "@modelcontextprotocol/server": "2.0.0",
+    "agents": "0.20.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/web/scripts/mcp-e2e-test.ts
+++ b/web/scripts/mcp-e2e-test.ts
@@ -1,0 +1,342 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+/**
+ * Runs read-only end-to-end checks against the deployed MCP server, including
+ * the modern and legacy protocol lanes, error semantics, and discovery
+ * documents. Run it after deployment against production, or pass the base URL
+ * of a local Wrangler dev session.
+ *
+ * Usage (from web/):
+ *   bun scripts/mcp-e2e-test.ts [base-url]
+ */
+
+const DEFAULT_BASE_URL = "https://schemas.fluxoperator.dev";
+const baseUrl = (Bun.argv[2] ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+const endpoint = `${baseUrl}/mcp`;
+const accept = "application/json, text/event-stream";
+const protocolVersion = "2026-07-28";
+const clientInfo = { name: "mcp-e2e-test", version: "1.0" };
+const meta = {
+  "io.modelcontextprotocol/protocolVersion": protocolVersion,
+  "io.modelcontextprotocol/clientCapabilities": {},
+  "io.modelcontextprotocol/clientInfo": clientInfo,
+};
+
+let passed = 0;
+let checks = 0;
+let requestId = 0;
+
+function ok(cond: unknown, label: string, detail: string): void {
+  checks++;
+  if (cond) passed++;
+  console.log(`${cond ? "pass" : "FAIL"} ${label}: ${detail.replace(/\r/g, "\\r").replace(/\n/g, "\\n")}`);
+}
+
+function show(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? String(value);
+}
+
+/** Fetch with a hard timeout so a stalled endpoint cannot hang the script. */
+function timedFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(30_000) });
+}
+
+async function parseRpc(res: Response, id?: number): Promise<any> {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/event-stream")) return res.json();
+  const frames = (await res.text()).split(/\r?\n\r?\n/);
+  const messages = frames.flatMap((frame) => {
+    const data = frame
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("");
+    return data ? [JSON.parse(data)] : [];
+  });
+  // Prefer the message answering this request id; notifications carry none.
+  return messages.find((message) => id !== undefined && message?.id === id) ?? messages.at(-1);
+}
+
+async function modernRpc(
+  method: string,
+  params: Record<string, unknown> = {},
+  tool?: string,
+): Promise<{ res: Response; body: any }> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept,
+    "mcp-protocol-version": protocolVersion,
+    "mcp-method": method,
+  };
+  if (tool !== undefined) headers["mcp-name"] = tool;
+
+  const id = ++requestId;
+  const res = await timedFetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params: { ...params, _meta: meta },
+    }),
+  });
+  return { res, body: await parseRpc(res, id) };
+}
+
+async function legacyRpc(method: string, params: Record<string, unknown> = {}): Promise<{ res: Response; body: any }> {
+  const id = ++requestId;
+  const res = await timedFetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    }),
+  });
+  return { res, body: await parseRpc(res, id) };
+}
+
+function resultText(body: any): string {
+  return (
+    body?.result?.content
+      ?.filter((item: any) => item.type === "text")
+      .map((item: any) => item.text)
+      .join("\n") ?? ""
+  );
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+console.log(`MCP end-to-end checks: ${baseUrl}`);
+
+console.log("\nmodern protocol (2026-07-28)");
+
+const discover = await modernRpc("server/discover");
+const discoverContentType = discover.res.headers.get("content-type") ?? "";
+ok(
+  discoverContentType.includes("application/json") && !discoverContentType.includes("text/event-stream"),
+  "server/discover uses JSON",
+  discoverContentType,
+);
+ok(
+  discover.body?.result?.supportedVersions?.includes(protocolVersion),
+  "server/discover advertises modern protocol",
+  show(discover.body?.result?.supportedVersions),
+);
+ok(
+  discover.body?.result?.capabilities?.tools !== undefined,
+  "server/discover advertises tools",
+  show(discover.body?.result?.capabilities),
+);
+ok(
+  discover.body?.result?.instructions?.includes("kubectl explain"),
+  "server/discover includes instructions",
+  show(discover.body?.result?.instructions),
+);
+ok(
+  discover.body?.result?._meta?.["io.modelcontextprotocol/serverInfo"]?.name === "flux-schema-catalog",
+  "server/discover identifies the server",
+  show(discover.body?.result?._meta?.["io.modelcontextprotocol/serverInfo"]),
+);
+ok(
+  discover.body?.result?.ttlMs === 3_600_000 && discover.body?.result?.cacheScope === "public",
+  "server/discover includes cache hints",
+  `ttlMs=${show(discover.body?.result?.ttlMs)}, cacheScope=${show(discover.body?.result?.cacheScope)}`,
+);
+
+const toolsList = await modernRpc("tools/list");
+const expectedTools = ["get_project", "get_schema", "grep_catalog", "grep_schema", "list_projects"];
+const actualTools = (toolsList.body?.result?.tools ?? []).map((tool: any) => tool.name).sort();
+ok(
+  actualTools.length === expectedTools.length && actualTools.every((name: string, index: number) => name === expectedTools[index]),
+  "tools/list returns the exact tool set",
+  show(actualTools),
+);
+ok(
+  toolsList.body?.result?.ttlMs === 3_600_000 && toolsList.body?.result?.cacheScope === "public",
+  "tools/list includes cache hints",
+  `ttlMs=${show(toolsList.body?.result?.ttlMs)}, cacheScope=${show(toolsList.body?.result?.cacheScope)}`,
+);
+
+const grepCatalog = await modernRpc(
+  "tools/call",
+  { name: "grep_catalog", arguments: { query: "Kustomization" } },
+  "grep_catalog",
+);
+const grepCatalogText = resultText(grepCatalog.body);
+ok(
+  grepCatalogText.includes("kustomize.toolkit.fluxcd.io/v1 Kustomization") &&
+    grepCatalogText.includes("# matched "),
+  "grep_catalog returns matches and footer",
+  show(grepCatalogText),
+);
+
+const grepSchema = await modernRpc(
+  "tools/call",
+  {
+    name: "grep_schema",
+    arguments: {
+      apiVersion: "kustomize.toolkit.fluxcd.io/v1",
+      kind: "Kustomization",
+      query: "spec.prune",
+    },
+  },
+  "grep_schema",
+);
+const grepSchemaText = resultText(grepSchema.body);
+ok(
+  grepSchemaText.startsWith("# kustomize.toolkit.fluxcd.io/v1 Kustomization from ") &&
+    grepSchemaText.includes("spec.prune"),
+  "grep_schema returns the requested field",
+  show(grepSchemaText),
+);
+
+const listProjects = await modernRpc(
+  "tools/call",
+  { name: "list_projects", arguments: {} },
+  "list_projects",
+);
+const listProjectsFooter = resultText(listProjects.body).split("\n").at(-1) ?? "";
+ok(/^# \d+ projects$/.test(listProjectsFooter), "list_projects returns a project count", listProjectsFooter);
+
+const getSchema = await modernRpc(
+  "tools/call",
+  {
+    name: "get_schema",
+    arguments: { apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization" },
+  },
+  "get_schema",
+);
+const getSchemaText = resultText(getSchema.body);
+const parsedSchema = tryParseJson(getSchemaText);
+const schemaIsObject =
+  typeof parsedSchema === "object" && parsedSchema !== null && "properties" in parsedSchema;
+const schemaHitSizeGuard = getSchemaText.includes("inline response limit");
+const getSchemaLabel = schemaIsObject
+  ? "get_schema returns a JSON Schema object"
+  : schemaHitSizeGuard
+    ? "get_schema reports the inline response limit"
+    : "get_schema returns a JSON Schema or the inline response limit";
+ok(
+  schemaIsObject || schemaHitSizeGuard,
+  getSchemaLabel,
+  schemaIsObject ? "schema object with properties" : show(getSchemaText),
+);
+
+const missingMethodRes = await timedFetch(endpoint, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    accept,
+    "mcp-protocol-version": protocolVersion,
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: ++requestId,
+    method: "tools/list",
+    params: { _meta: meta },
+  }),
+});
+const missingMethodBody = await parseRpc(missingMethodRes, requestId);
+ok(
+  missingMethodBody?.error !== undefined &&
+    (missingMethodBody.error.code === -32020 ||
+      String(missingMethodBody.error.message ?? "").includes("Mcp-Method")),
+  "modern request without mcp-method is rejected",
+  show(missingMethodBody),
+);
+
+console.log("\nlegacy lane");
+
+const legacyTools = await legacyRpc("tools/list");
+const legacyContentType = legacyTools.res.headers.get("content-type") ?? "";
+ok(
+  legacyContentType.includes("text/event-stream") && legacyTools.body?.result?.tools?.length === 5,
+  "tools/list works without initialize",
+  `content-type=${legacyContentType}, tools=${show(legacyTools.body?.result?.tools?.length)}`,
+);
+
+const initialize = await legacyRpc("initialize", {
+  protocolVersion: "2025-06-18",
+  capabilities: {},
+  clientInfo,
+});
+ok(
+  initialize.res.status === 200 &&
+    typeof initialize.body?.result?.protocolVersion === "string" &&
+    initialize.body.result.protocolVersion.length > 0,
+  "initialize negotiates a protocol",
+  `status=${initialize.res.status}, protocolVersion=${show(initialize.body?.result?.protocolVersion)}`,
+);
+
+console.log("\nerror semantics");
+
+const getResponse = await timedFetch(endpoint, { headers: { accept: "application/json" } });
+ok(getResponse.status === 405, "GET is method not allowed", `status=${getResponse.status}`);
+
+const unknownMethod = await legacyRpc("no/such");
+ok(
+  unknownMethod.body?.error?.code === -32601,
+  "unknown method returns -32601",
+  show(unknownMethod.body),
+);
+
+const unknownTool = await legacyRpc("tools/call", { name: "no_such_tool", arguments: {} });
+ok(unknownTool.body?.error?.code === -32602, "unknown tool returns -32602", show(unknownTool.body));
+
+const invalidArguments = await legacyRpc("tools/call", { name: "grep_catalog", arguments: {} });
+ok(
+  invalidArguments.body?.result?.isError === true,
+  "invalid arguments return a tool-result error",
+  show(invalidArguments.body),
+);
+
+console.log("\ndiscovery");
+
+const serverCardRes = await timedFetch(`${baseUrl}/mcp/server-card`);
+const serverCard: any = await serverCardRes.json();
+ok(
+  serverCard?.remotes?.[0]?.supportedProtocolVersions?.[0] === protocolVersion,
+  "server card advertises modern protocol first",
+  show(serverCard?.remotes?.[0]?.supportedProtocolVersions),
+);
+ok(
+  serverCard?.serverInfo?.name === "flux-schema-catalog" &&
+    typeof serverCard?.serverInfo?.version === "string" &&
+    serverCard?.serverInfo?.version === serverCard?.version,
+  "server card identity and version agree",
+  `serverInfo=${show(serverCard?.serverInfo)}, version=${show(serverCard?.version)}`,
+);
+
+const wellKnownCardRes = await timedFetch(`${baseUrl}/.well-known/mcp/server-card.json`);
+const wellKnownCard: any = await wellKnownCardRes.json();
+ok(
+  wellKnownCard?.remotes?.[0]?.supportedProtocolVersions?.[0] === protocolVersion,
+  "well-known server card advertises modern protocol first",
+  show(wellKnownCard?.remotes?.[0]?.supportedProtocolVersions),
+);
+
+const catalogRes = await timedFetch(`${baseUrl}/.well-known/mcp/catalog.json`);
+const catalog: any = await catalogRes.json();
+ok(
+  Array.isArray(catalog?.entries) && catalog.entries.length > 0,
+  "MCP catalog contains entries",
+  show(catalog?.entries),
+);
+
+console.log(`\n${passed}/${checks} checks passed`);
+if (passed !== checks) process.exit(1);

--- a/web/src/worker/mcp.ts
+++ b/web/src/worker/mcp.ts
@@ -1,8 +1,16 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createMcpHandler, WorkerTransport } from "agents/mcp";
+/**
+ * Stateless MCP endpoint for the modern 2026-07-28 protocol, including the
+ * per-request `_meta` envelope, `Mcp-Method`/`Mcp-Name` headers, and
+ * `server/discover`. The SDK also provides built-in compatibility for
+ * 2025-era stateless clients. Legacy responses are SSE-framed because the
+ * fallback has no JSON mode, legacy GET returns 405, and an unknown tool is a
+ * -32602 protocol error.
+ */
+import { McpServer } from "@modelcontextprotocol/server";
+import { createMcpHandler } from "agents/mcp/server";
 import { z } from "zod";
 import { SERVER_INFO } from "./server-card.ts";
 import {
@@ -17,6 +25,10 @@ import {
 import { getCatalogObject } from "./catalog.ts";
 import type { Env } from "./index.ts";
 import { loadIndex } from "./index-data.ts";
+
+// Catalog content changes only at deploy and is public, so 2026-era clients
+// can cache list results and the discover probe for one hour in shared caches.
+const CACHE_HINT = { ttlMs: 3_600_000, cacheScope: "public" } as const;
 
 /**
  * System instructions sent to MCP clients. They position the catalog as the
@@ -58,21 +70,38 @@ const GrepSchemaInput = z.object({
   limit: z.number().int().min(1).max(500).default(200),
 });
 
+let handler: ReturnType<typeof createMcpHandler> | undefined;
+
+// Read by the server factory on every request instead of closing over the
+// first request's env, so a surviving isolate picks up binding changes.
+let currentEnv: Env;
+
 /**
- * Handles the stateless streamable HTTP MCP endpoint at `/mcp`. The transport
- * uses no session IDs, so every request builds a server instance whose tools
- * load the current memoized index and catalog objects through Worker bindings.
+ * Handles modern 2026-07-28 stateless requests and the SDK's built-in legacy
+ * compatibility lane at `/mcp`. Every request gets a fresh server instance.
  */
 export function handleMcp(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-  const server = createCatalogMcpServer(env);
-  const transport = new WorkerTransport({ sessionIdGenerator: undefined });
-  const handler = createMcpHandler(server, { route: "/mcp", transport });
+  currentEnv = env;
+  handler ??= createMcpHandler(() => createCatalogMcpServer(currentEnv), {
+    // The route is an EXACT pathname match, and src/worker/index.ts dispatches
+    // only the exact `/mcp` path.
+    route: "/mcp",
+    // The v2 wrapper validates browser Origin headers against a
+    // localhost/workers.dev allowlist by default, which would lock hosted MCP
+    // clients out of the custom domain. The content is public, read-only, and
+    // unauthenticated with no session to steal, so origins are unrestricted.
+    allowedOriginHostnames: "*",
+  });
   return handler(req, env, ctx);
 }
 
 function createCatalogMcpServer(env: Env): McpServer {
   const server = new McpServer(SERVER_INFO, {
     instructions,
+    cacheHints: {
+      "server/discover": CACHE_HINT,
+      "tools/list": CACHE_HINT,
+    },
   });
 
   server.registerTool(

--- a/web/src/worker/server-card.ts
+++ b/web/src/worker/server-card.ts
@@ -1,10 +1,18 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/server";
+
+/**
+ * First revision of the stateless (modern) protocol era, served by the SDK v2
+ * handler. The SDK exports no named constant for it: its
+ * SUPPORTED_PROTOCOL_VERSIONS lists the legacy era, which the handler's
+ * compatibility lane also still serves.
+ */
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
 
 /** Runtime identity, shared verbatim between the MCP server and its Server Card. */
-export const SERVER_INFO = { name: "flux-schema-catalog", title: "Flux Schema Catalog", version: "0.1.0" };
+export const SERVER_INFO = { name: "flux-schema-catalog", title: "Flux Schema Catalog", version: "0.2.0" };
 
 const SERVER_DESCRIPTION =
   "Authoritative JSON Schemas and greppable field indexes for core Kubernetes, OpenShift, the Flux ecosystem, " +
@@ -49,7 +57,11 @@ export function serveServerCard(req: Request): Response {
     websiteUrl: "https://schemas.fluxoperator.dev",
     repository: { url: "https://github.com/controlplaneio-fluxcd/schema-catalog", source: "github" },
     remotes: [
-      { type: "streamable-http", url: endpoint, supportedProtocolVersions: SUPPORTED_PROTOCOL_VERSIONS },
+      {
+        type: "streamable-http",
+        url: endpoint,
+        supportedProtocolVersions: [MODERN_PROTOCOL_VERSION, ...SUPPORTED_PROTOCOL_VERSIONS],
+      },
     ],
     serverInfo: SERVER_INFO,
     transport: { type: "streamable-http", endpoint },


### PR DESCRIPTION
Serve the modern [2026-07-28](https://blog.modelcontextprotocol.io/posts/2026-07-28/) stateless protocol via `@modelcontextprotocol/server` 2.0.0 behind the `agents/mcp/server` handler, keeping the built-in legacy lane for 2025-era clients. Bump the server version to 0.2.0 and advertise the new protocol revision in the discovery documents.

Add post-deploy helper (`bun run mcp-e2e`) covering the modern 2026-07-28 lane, the legacy lane, error semantics, and the discovery documents. Targets production by default; accepts a base URL for a local Wrangler dev session.